### PR TITLE
set up Linux builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: build
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: false
+        type: string
+      platform:
+        required: true
+        type: string
+      build-args:
+        required: false
+        type: string
+      release-id:
+        required: false
+        type: string
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ${{ inputs.platform }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        if: startsWith(inputs.platform, 'macos')
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install additional system dependencies
+        if: startsWith(inputs.platform, 'ubuntu')
+        run: |-
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libxdo-dev \
+            libssl-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            librust-pango-dev \
+            libatk1.0-dev \
+            librust-atk-dev \
+            librust-atk-sys-dev \
+            libgtk-3-dev \
+            librust-gtk-sys-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - name: Install frontend dependencies
+        run: npm install
+
+      - name: Build with tauri-action
+        uses: tauri-apps/tauri-action@v0
+        with:
+          args: ${{ inputs.build-args }}
+          releaseId: ${{ inputs.release-id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,53 +12,13 @@ on:
       - main
 
 jobs:
-  pr-ci:
+  ci:
     strategy:
       fail-fast: false
       matrix:
         platform: [macos-latest, windows-latest, 'ubuntu-22.04']
-
-    runs-on: ${{ matrix.platform }}
-    steps:
-
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install additional system dependencies
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
-        run: |-
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            librust-pango-dev \
-            libatk1.0-dev \
-            librust-atk-dev \
-            librust-atk-sys-dev \
-            libgtk-3-dev \
-            librust-gtk-sys-dev \
-            libjavascriptcoregtk-4.1-dev
-
-      - name: Install frontend dependencies
-        run: npm install
-
-      - name: Build with tauri-action
-        uses: tauri-apps/tauri-action@v0
-        with:
-          args: ${{ matrix.platform == 'windows-latest' && '--bundles nsis' || '' }}
+    uses: ./.github/workflows/build.yml
+    with:
+      platform: ${{ matrix.platform }}
+      build-args: ${{ matrix.platform == 'windows-latest' && '--bundles nsis' || '' }}
+    secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,18 @@
-name: 'Release: Build & Package App'
+name: 'CI'
+
+concurrency:
+  group: ci-${{ github.run_id }}
+  cancel-in-progress: true
 
 on:
-  release:
-    types: [created]
+  pull_request_target:
+    types: [opened, edited, synchronize]
+  push:
+    branches:
+      - main
 
 jobs:
-  release:
-    permissions:
-      contents: write
+  pr-ci:
     strategy:
       fail-fast: false
       matrix:
@@ -15,6 +20,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -29,6 +35,7 @@ jobs:
 
       - name: Install additional system dependencies
         if: ${{ matrix.platform == 'ubuntu-22.04' }}
+        run: |-
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
@@ -51,10 +58,7 @@ jobs:
       - name: Install frontend dependencies
         run: npm install
 
-      - name: Build and release with tauri-action
+      - name: Build with tauri-action
         uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          releaseId: ${{ github.event.release.id }}
           args: ${{ matrix.platform == 'windows-latest' && '--bundles nsis' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,49 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         platform: [macos-latest, windows-latest, 'ubuntu-22.04']
-
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
-
-      - name: Install additional system dependencies
-        if: ${{ matrix.platform == 'ubuntu-22.04' }}
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            build-essential \
-            curl \
-            wget \
-            file \
-            libxdo-dev \
-            libssl-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev \
-            librust-pango-dev \
-            libatk1.0-dev \
-            librust-atk-dev \
-            librust-atk-sys-dev \
-            libgtk-3-dev \
-            librust-gtk-sys-dev \
-            libjavascriptcoregtk-4.1-dev
-
-      - name: Install frontend dependencies
-        run: npm install
-
-      - name: Build and release with tauri-action
-        uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          releaseId: ${{ github.event.release.id }}
-          args: ${{ matrix.platform == 'windows-latest' && '--bundles nsis' || '' }}
+    uses: ./.github/workflows/build.yml
+    with:
+      platform: ${{ matrix.platform }}
+      build-args: ${{ matrix.platform == 'windows-latest' && '--bundles nsis' || '' }}
+      release-id: ${{ github.event.release.id }}
+    secrets: inherit


### PR DESCRIPTION
Fixes #1

~~TODO 1: extract shared logic (almost the whole thing) to reusable workflow: https://docs.github.com/en/actions/how-tos/sharing-automations/reusing-workflows . Do PR CI and on-merge CI without release, then do release build when a GH release is created.~~

TODO 2: get this to run on `ubuntu-latest`/`ubuntu-24.04`