### PR TITLE
ci(cache): add rust-cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         if: startsWith(inputs.platform, 'macos')
 
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Fixes https://github.com/CyberTimon/RapidRAW/issues/17

See https://github.com/andrewazores/RapidRAW/actions/runs/16034816728 for a CI run before the cache was enabled. This takes ~13 minutes to complete currently - each OS is done in parallel, so the slowest (Windows) defines the overall time.

See https://github.com/andrewazores/RapidRAW/actions/runs/16035873648/job/45247392134 for a CI run with cache primed. The build time is reduced to 7 minutes. This one also includes #16 which is still a WIP and failed for Windows in this case, but for reasons unrelated to the cache.