### PR TITLE
build(linux): replace custom patch with merged tauri config

### DIFF
--- a/patches/linux/0001-window-transparency.sh
+++ b/patches/linux/0001-window-transparency.sh
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-yq -iP '.app.windows[0].transparent=false' src-tauri/tauri.conf.json

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,9 @@
+{
+    "app": {
+        "windows": [
+            {
+                "transparent": false
+            }
+        ]
+    }
+}


### PR DESCRIPTION
See 0a83244ffbace72bfcc6b6d5fa5528446e036a2e

It turns out that tauri has some logic to automatically merge `tauri.conf.json` with other files named `tauri.$platform.conf.json`, where `$platform` can be `linux`, `windows`, `macos`, etc.:

```
$ npx tauri build --help
Build your app in release mode and generate bundles and installers. It makes use of the `build.frontendDist` property from your `tauri.conf.json` file. It also runs your `build.beforeBuildCommand` which usually builds your frontend into `build.frontendDist`. This will also run `build.beforeBundleCommand` before generating the bundles and installers of your app.

Usage: npm run npx build [OPTIONS] [ARGS]...

...

  -c, --config <CONFIG>
          JSON strings or paths to JSON, JSON5 or TOML files to merge with the default configuration file
          
          Configurations are merged in the order they are provided, which means a particular value overwrites previous values when a config key-value pair conflicts.
          
          Note that a platform-specific file is looked up and merged with the default file by default (tauri.macos.conf.json, tauri.linux.conf.json, tauri.windows.conf.json, tauri.android.conf.json and tauri.ios.conf.json) but you can use this for more specific use cases such as different build flavors.
```

So the Linux window transparency patch can be replaced with this mechanism instead, which is cleaner.
