### PR TITLE
ci(appimage): separate AppImage build job on newer runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           cache: 'npm'
 
       - name: Install additional system dependencies (Linux)
-        if: startsWith(inputs.platform, 'ubuntu')
+        if: startsWith(inputs.platform, 'ubuntu-22')
         run: |-
           sudo apt-get update
           sudo apt-get install -y \
@@ -61,6 +61,21 @@ jobs:
             libssl-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
+
+      - name: Install additional system dependencies (Linux)
+        if: startsWith(inputs.platform, 'ubuntu-24')
+        run: |-
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-0=2.44.0-2 \
+            libwebkit2gtk-4.1-dev=2.44.0-2 \
+            libjavascriptcoregtk-4.1-0=2.44.0-2 \
+            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+            gir1.2-webkit2-4.1=2.44.0-2 \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf
 
       - name: Apply patches (Linux)
         if: startsWith(inputs.platform, 'ubuntu')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
             args: ''
             target: x86_64-apple-darwin
           - platform: 'ubuntu-22.04'
-            args: ''
+            args: '--bundles deb,rpm'
+            target: ''
+          - platform: 'ubuntu-24.04'
+            args: '--bundles appimage'
             target: ''
           - platform: 'windows-latest'
             args: '--bundles nsis'


### PR DESCRIPTION
Fixes #20
Fixes #28
See https://github.com/andrewazores/RapidRAW/actions/runs/16156822179

Following some hints in the links I shared on #20, this sets up the CI to run the AppImage build on an ubuntu-24.04 runner separately from the rpm and deb builds, which continue to be done on 22.04 since those seem to be working just fine.

I confirmed that the AppImage generated by this run works as expected on my Fedora 41 system:

https://github.com/andrewazores/RapidRAW/actions/runs/16156822179/artifacts/3491223344