### PR TITLE
ci(asset): set asset name pattern to include platform and arch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ on:
       release-id:
         required: false
         type: string
+      asset-name-pattern:
+        required: false
+        type: string
       upload-artifacts:
         required: false
         type: boolean
@@ -49,7 +52,7 @@ jobs:
           cache: 'npm'
 
       - name: Install additional system dependencies (Linux)
-        if: startsWith(inputs.platform, 'ubuntu-22')
+        if: ${{ startsWith(inputs.platform, 'ubuntu-22') }}
         run: |-
           sudo apt-get update
           sudo apt-get install -y \
@@ -63,7 +66,7 @@ jobs:
             librsvg2-dev
 
       - name: Install additional system dependencies (Linux)
-        if: startsWith(inputs.platform, 'ubuntu-24')
+        if: ${{ startsWith(inputs.platform, 'ubuntu-24') }}
         run: |-
           sudo apt-get update
           sudo apt-get install -y \
@@ -84,14 +87,26 @@ jobs:
         if: ${{ inputs.target != '' }}
         run: rustup target add ${{ inputs.target }}
 
+      - id: patch-release-name
+        shell: bash
+        if: ${{ inputs.release-id != '' }}
+        run: |
+          platform="${{ inputs.platform }}"
+          replacement="${platform%-*}"
+          replacement="$(echo ${replacement} | sed -E 's/\.//g')"
+          patched_platform=$(echo '${{ inputs.asset-name-pattern }}' | sed -E "s/\[platform\]/${replacement}/")
+          echo "platform=${patched_platform}" >> $GITHUB_OUTPUT
+
       - id: tauri-build
         name: Build with tauri-action
-        uses: tauri-apps/tauri-action@v0
+        # FIXME set this back to a release major version, ex. v0
+        uses: tauri-apps/tauri-action@cf3eb9b18add8548a40584695215c80ab7274f31
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NO_STRIP: ${{ startsWith(inputs.platform, 'ubuntu') }}
         with:
           args: ${{ inputs.build-args }} ${{ inputs.target != '' && '--target' || ''  }} ${{ inputs.target }}
+          assetNamePattern: ${{ steps.patch-release-name.outputs.platform }}
           releaseId: ${{ inputs.release-id }}
 
       - name: Setup gh actions artifact client
@@ -99,22 +114,22 @@ jobs:
 
       - name: Upload binaries (Windows)
         shell: bash
-        if: startsWith(inputs.platform, 'windows')
+        if: ${{ startsWith(inputs.platform, 'windows') && inputs.release-id == '' }}
         run: |
           find src-tauri/target/release/bundle -name "*.exe" | while read -r file; do
             name=$(basename "$file")
-            patched_name=$(echo $name | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?/${{ github.sha }}/')
+            patched_name=$(echo $name | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?/${{ github.sha }}_${{ inputs.platform }}_${{ inputs.target }}/')
             echo "Uploading $name, file: $file"
             # TODO zip the file before upload
             gh-actions-artifact-client.js upload "$patched_name" --retentionDays=7 < "$file"
           done
 
       - name: Upload binaries
-        if: ${{ !startsWith(inputs.platform, 'windows') }}
+        if: ${{ !startsWith(inputs.platform, 'windows') && inputs.release-id == '' }}
         run: |
           find src-tauri/target/${{ inputs.target || 'release' }} -type f -name "*.rpm" -o -name "*.deb" -o -name "*.AppImage" -o -name "*.dmg" | while read -r file; do
             name=$(basename "$file")
-            patched_name=$(echo $name | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?/${{ github.sha }}/')
+            patched_name=$(echo $name | sed -E 's/[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+)?/${{ github.sha }}_${{ inputs.platform }}_${{ inputs.target }}/')
             echo "Uploading $name, file: $file"
             zip -j - "$file" | gh-actions-artifact-client.js upload "$patched_name" --retentionDays=7
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
       platform: ${{ matrix.platform }}
       target: ${{ matrix.target }}
       build-args: ${{ matrix.args }}
+      asset-name-pattern: "[name]_v[version]_[platform]_[arch][ext]"
     secrets: inherit
     permissions:
       contents: write


### PR DESCRIPTION
Fixes #48

The CI `build.yml` should be updated at some point to point to a `tauri-action` release version that contains the new feature. For now I have just pointed it directly at the latest commit on the action's dev branch.

Sample runs:
- CI: https://github.com/andrewazores/RapidRAW/actions/runs/16210967639
- Release: https://github.com/andrewazores/RapidRAW/actions/runs/16210974842
