### PR TITLE
feat: add categories for desktop file

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,12 +21,15 @@
     ],
     "security": {
       "csp": null,
-      "capabilities": ["default"]
+      "capabilities": [
+        "default"
+      ]
     },
     "macOSPrivateApi": true
   },
   "bundle": {
     "active": true,
+    "category": "Photography",
     "targets": "all",
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -15,7 +15,9 @@
   "bundle": {
     "linux": {
       "rpm": {
-        "provides": ["rapid-raw"],
+        "provides": [
+          "rapid-raw"
+        ],
         "recommends": [
           "webkit2gtk4.1",
           "webkit2gtk4",


### PR DESCRIPTION
hi! i'm currently packaging rapidraw for nix via nixpkgs and I noticed that the tauri generated desktop file doesn't have proper categories on linux so I thought I'd add them :)