### PR TITLE
build(macos): lower minimum version to 13.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
             builds-args: '--bundles nsis'
             target: ''
             asset-prefix: '01'
-          - platform: 'macos-latest'
+          - platform: 'macos-13'
             target: aarch64-apple-darwin
             asset-prefix: '02'
-          - platform: 'macos-latest'
+          - platform: 'macos-13'
             target: x86_64-apple-darwin
             asset-prefix: '02'
           - platform: 'ubuntu-22.04'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
             builds-args: '--bundles nsis'
             target: ''
             asset-prefix: '01'
-          - platform: 'macos-latest'
+          - platform: 'macos-13'
             target: aarch64-apple-darwin
             asset-prefix: '02'
-          - platform: 'macos-latest'
+          - platform: 'macos-13'
             target: x86_64-apple-darwin
             asset-prefix: '02'
           - platform: 'ubuntu-22.04'

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ npx tauri dev --release
 RapidRAW is built to be lightweight and cross-platform. The minimum (tested) requirements are:
 
 *   **Windows:** Windows 10 or newer
-*   **macOS:** macOS 15 (Sequoia) or newer
+*   **macOS:** macOS 13 (Ventura) or newer
 *   **Linux:** Ubuntu 22.04+ or a compatible modern distribution
 
 ## Contributing

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,7 +1,7 @@
 {
   "bundle": {
     "macOS": {
-      "minimumSystemVersion": "15.0"
+      "minimumSystemVersion": "13.0"
     }
   }
 }


### PR DESCRIPTION
Depends on #102 

Sets the minimum version in the application bundle, and the GitHub Actions runner used to build macOS distributions, to 13 (Ventura).