### PR TITLE
feat(macos): green titlebar button fullscreens window

### DIFF
--- a/src/window/TitleBar.jsx
+++ b/src/window/TitleBar.jsx
@@ -21,16 +21,18 @@ export default function TitleBar() {
 
   const appWindow = getCurrentWindow();
   const handleMinimize = () => appWindow.minimize();
-  const handleMaximize = useCallback(() => {
+  const handleMaximize = useCallback(async () => {
     switch (osPlatform) {
-      case 'macos':
-        appWindow.setFullscreen(true);
+      case 'macos': {
+        const isFullscreen = await appWindow.isFullscreen();
+        appWindow.setFullscreen(!isFullscreen);
         break;
+      }
       default:
         appWindow.toggleMaximize();
         break;
     }
-  }, [osPlatform]);
+  }, [osPlatform, appWindow]);
   const handleClose = () => appWindow.close();
 
   const isMac = osPlatform === 'macos';

--- a/src/window/TitleBar.jsx
+++ b/src/window/TitleBar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { platform } from '@tauri-apps/plugin-os';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { Minus, Square, X } from 'lucide-react';
@@ -21,7 +21,7 @@ export default function TitleBar() {
 
   const appWindow = getCurrentWindow();
   const handleMinimize = () => appWindow.minimize();
-  const handleMaximize = React.useCallback(() => {
+  const handleMaximize = useCallback(() => {
     switch (osPlatform) {
       case 'macos':
         appWindow.setFullscreen(true);

--- a/src/window/TitleBar.jsx
+++ b/src/window/TitleBar.jsx
@@ -21,7 +21,16 @@ export default function TitleBar() {
 
   const appWindow = getCurrentWindow();
   const handleMinimize = () => appWindow.minimize();
-  const handleMaximize = () => appWindow.toggleMaximize();
+  const handleMaximize = React.useCallback(() => {
+    switch (osPlatform) {
+      case 'macos':
+        appWindow.setFullscreen(true);
+        break;
+      default:
+        appWindow.toggleMaximize();
+        break;
+    }
+  }, [osPlatform]);
   const handleClose = () => appWindow.close();
 
   const isMac = osPlatform === 'macos';


### PR DESCRIPTION
Fixes #156

Not sure how to bind this Mac "globe key", or if it's even possible to do so with Tauri. I'm looking at https://v2.tauri.app/plugin/global-shortcut/ but I don't see any modifier like "globe" as an option and I don't know what else it might be aliased as, if anything.