### PR TITLE
Fix switching images quickly from keyboard

### DIFF
--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -158,10 +158,6 @@ export const useKeyboardShortcuts = ({
       }
 
       if (['arrowup', 'arrowdown', 'arrowleft', 'arrowright'].includes(key)) {
-        if (isViewLoading) {
-          event.preventDefault();
-          return;
-        }
         event.preventDefault();
 
         if (selectedImage) {


### PR DESCRIPTION
When you open an image, and the bottom section shows images horizontally, clicking a different image causes the image to be changed immediately. But switching image from <kbd>ArrowLeft</kbd> or <kbd>ArrowRight</kbd> can be only done after the image has been fully loaded. Removing that code section allows switching images more quickly from keyboard as well.

Actually I'm not sure which way is the one you have intended:
1. Image must be fully loaded before it can be switched
2. Image can be switched even if not fully loaded

So please elaborate if this fix is not what you want :)