### PR TITLE
Fix Metainfo Typo

### DIFF
--- a/data/io.github.cybertimon.rapidraw.metainfo.xml
+++ b/data/io.github.cybertimon.rapidraw.metainfo.xml
@@ -4,7 +4,7 @@
   
   <name>RapidRAW</name>
   <summary>A non-destructive, and GPU-accelerated RAW image editor built with performance in mind</summary>
-  <developer id="com.github.cybertimon">
+  <developer id="io.github.cybertimon">
     <name>Timon Käch</name>
   </developer>
   


### PR DESCRIPTION
This fixes the minor typo. As per the previous PR, you can try this build by copying both the manifest and the metainfo file to the same location and then running `flatpak run org.flatpak.Builder --user --install --install-deps-from=flathub --force-clean build-dir io.github.cybertimon.rapidraw.yml`.

Also, from what I've gathered, I'll go ahead with the submission to Flathub and ping you in the PR, so the team knows that you officially approve. Worst case, I'll help to resubmit with the proper domain once you get around to creating a website. Does that sound right @CyberTimon?