### PR TITLE
docs(README): Expand the installation section and add AUR package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,12 @@ You have two options to run RapidRAW:
 
 **1. Download the Latest Release (Recommended)**
 
-Grab the pre-built installer or application bundle for your operating system from the [**Releases**](https://github.com/CyberTimon/RapidRAW/releases) page.
+**Windows & macOS:**
+- Grab the pre-built installer or application bundle for your operating system from the [**Releases**](https://github.com/CyberTimon/RapidRAW/releases) page.
+
+**Linux:**
+- On Debian-based distributions, install the `.deb` package.
+- On Arch-based distributions, use the [`rapidraw-bin`](https://aur.archlinux.org/packages/rapidraw-bin) package from the AUR.
 
 **2. Build from Source**
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ You have two options to run RapidRAW:
 - Grab the pre-built installer or application bundle for your operating system from the [**Releases**](https://github.com/CyberTimon/RapidRAW/releases) page.
 
 **Linux:**
-- On Debian-based distributions, install the `.deb` package.
+- On Debian-based distributions, install the `.deb` package from the [**Releases**](https://github.com/CyberTimon/RapidRAW/releases) page.
 - On Arch-based distributions, use the [`rapidraw-bin`](https://aur.archlinux.org/packages/rapidraw-bin) package from the AUR.
 
 **2. Build from Source**


### PR DESCRIPTION
This PR adds AUR package link to the _Getting Started_ section and expands the section slightly, as the download method varies depending on the operating system.