### PR TITLE
fix: prevent overscrolling on html element

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="overscroll-none">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />


### PR DESCRIPTION
This PR fixes the bouncing overscroll behaviour present on macOS

Previous behaviour:

https://github.com/user-attachments/assets/64bc892a-3667-4e21-9d3e-f4fa19e01b9f

I also changed the <title> tag, not that it's displayed anywhere I could find.