### PR TITLE
Fix Warnings on Linux

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2532,7 +2532,7 @@ async fn load_and_parse_lut(
     Ok(LutParseResult { size: lut_size })
 }
 
-fn apply_window_effect(_theme: String, _window: impl raw_window_handle::HasWindowHandle) {
+fn apply_window_effect(theme: String, window: impl raw_window_handle::HasWindowHandle) {
     #[cfg(target_os = "windows")]
     {
         let color = match theme.as_str() {
@@ -2568,7 +2568,10 @@ fn apply_window_effect(_theme: String, _window: impl raw_window_handle::HasWindo
     }
 
     #[cfg(target_os = "linux")]
-    {}
+    {
+        // Explicitly ignore these variables on Linux to silence warnings
+        let _ = (theme, window);
+    }
 }
 
 fn setup_logging(app_handle: &tauri::AppHandle) {


### PR DESCRIPTION
This makes the theme and window variables that are exclusive to Windows and macOS as intentionally unused to get rid of the build warnings on Linux.