### PR TITLE
Fix eraser tool to use circular strokes instead of removing whole lines

### DIFF
--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -861,23 +861,12 @@ const ImageCanvas = memo(
 
         const existingLines = activeSubMask.parameters.lines || [];
 
-        if (brushSettings?.tool === ToolType.Eraser) {
-          const remainingLines = existingLines.filter(
-            (drawnLine: DrawnLine) => !linesIntersect(imageSpaceLine, drawnLine),
-          );
-          if (remainingLines.length !== existingLines.length) {
-            updateSubMask(activeId, {
-              parameters: { ...activeSubMask.parameters, lines: remainingLines },
-            });
-          }
-        } else {
-          updateSubMask(activeId, {
-            parameters: {
-              ...activeSubMask.parameters,
-              lines: [...existingLines, imageSpaceLine],
-            },
-          });
-        }
+        updateSubMask(activeId, {
+          parameters: {
+            ...activeSubMask.parameters,
+            lines: [...existingLines, imageSpaceLine],
+          },
+        });
       }
     }, [
       activeAiSubMaskId,


### PR DESCRIPTION
- Changed eraser behavior to add eraser strokes as lines with circular intersections
- Eraser now works like brush with circular feathered strokes but subtracts from mask
- Provides much more accurate and precise erasing control
- Brush feather setting already works with both brush and eraser

This is the first time I try to contribute to a Project on Github, I hope this is what I'm supposed to do.

The brush before was very annoying to use due to its inaccuracy, thats why the eraser works the same way a brush does now (but in reverse)


Video example:

Before:
https://github.com/user-attachments/assets/94578032-7917-4021-ac44-35b0e0d016f4

After:
https://github.com/user-attachments/assets/e79605d8-495a-4524-ae5f-8f2c0ce047e1



