### PR TITLE
Removed dashed line for Brush Mask

### DIFF
--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -263,16 +263,13 @@ const MaskOverlay = memo(
         <Group onClick={handleSelect} onTap={handleSelect}>
           {lines.map((line: DrawnLine, i: number) => (
             <Line
-              dash={[4, 4]}
               hitStrokeWidth={line.brushSize * scale}
               key={i}
               lineCap="round"
               lineJoin="round"
-              opacity={isSelected ? 1 : 0.7}
               points={line.points.flatMap((p: Coord) => [(p.x - cropX) * scale, (p.y - cropY) * scale])}
-              stroke={isSelected ? '#0ea5e9' : subMask.mode === SubMaskMode.Subtractive ? '#f43f5e' : 'white'}
+              stroke="transparent"
               strokeScaleEnabled={false}
-              strokeWidth={isSelected ? 3 : 2}
               tension={0.5}
             />
           ))}


### PR DESCRIPTION
This commit removes the dash for the brush mask and its eraser.

Due to the new eraser the dashed lines get confusing very fast, so I removed them. I hope that is fine.

before: 

<img width="635" height="638" alt="image" src="https://github.com/user-attachments/assets/ded1e1f0-8054-4638-be4e-1701c9f637a8" />

After:

<img width="635" height="638" alt="image" src="https://github.com/user-attachments/assets/9f08df34-4ef8-49ab-8b00-53717e346bae" />