### PR TITLE
Add extra issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for RapidRAW
+title: "FEATURE: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to suggest a new feature! Please fill out the information below to help us understand your idea.
+        
+        > **Note:** This template is for feature requests only. For bug reports, please use the [Bug Report template](../../issues/new/choose) instead.
+
+  - type: input
+    id: title
+    attributes:
+      label: Feature Title
+      description: Provide a brief, descriptive title for this feature
+      placeholder: Describe the feature briefly...
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: Feature Description
+      description: Describe the feature you'd like to see added
+      placeholder: A clear and detailed description of what you want to happen...
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, mockups, or examples
+      placeholder: Any additional information, images, or examples that would help illustrate your request...
+
+  - type: checkboxes
+    id: similar-requests
+    attributes:
+      label: Similar feature requests
+      description: Have you checked for similar feature requests?
+      options:
+        - label: I have searched existing issues and discussions and didn't find a duplicate
+          required: true

--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -1,5 +1,6 @@
 name: Issue Report
 description: Report a bug or issue with RapidRAW (not for feature requests)
+title: "BUG: "
 labels: ["bug"]
 body:
   - type: markdown
@@ -8,6 +9,15 @@ body:
         Thanks for taking the time to report a bug! Please fill out the information below to help us understand and fix the issue.
         
         > **Note:** This template is for reporting bugs and issues only. For feature requests, please use the [Discussions page](../../discussions) instead.
+
+  - type: input
+    id: title
+    attributes:
+      label: Issue Title
+      description: Provide a brief, descriptive title for this bug
+      placeholder: Describe the issue briefly...
+    validations:
+      required: true
 
   - type: textarea
     id: what-happened


### PR DESCRIPTION
Hey Timon, 

Noticed a lot of FR in the issue list, it would be great if they get a auto title and a auto label
so we can filter on the issue list and be more productive :) 