### PR TITLE
fix: estimate batch export size with original image size

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1945,7 +1945,7 @@ async fn estimate_batch_export_size(
     const ESTIMATE_DIM: u32 = 1280;
 
     let original_image = match read_file_mapped(Path::new(&source_path_str)) {
-        Ok(mmap) => load_base_image_from_bytes(&mmap, &source_path_str, true, highlight_compression, None)
+        Ok(mmap) => load_base_image_from_bytes(&mmap, &source_path_str, false, highlight_compression, None)
             .map_err(|e| e.to_string())?,
         Err(e) => {
             log::warn!(
@@ -1954,7 +1954,7 @@ async fn estimate_batch_export_size(
                 e
             );
             let bytes = fs::read(&source_path_str).map_err(|io_err| io_err.to_string())?;
-            load_base_image_from_bytes(&bytes, &source_path_str, true, highlight_compression, None)
+            load_base_image_from_bytes(&bytes, &source_path_str, false, highlight_compression, None)
                 .map_err(|e| e.to_string())?
         }
     };


### PR DESCRIPTION
In the batch export window for the same image I had some wildly different values than in the single image export mode

Batch Mode: ~230KB
Single Mode: ~5.8MB

Turns out, the boolean flag for fast de-mosaic generates a lower resolution image and this throws off the size calculations. I couldn't find out how to load the fast de-mosaic version in the preview size but still get the values for original size. Is there something exposed in rawler?

Before:

```
2026-02-13 20:47:10 [INFO] crop: Rect{6:5, 1548x1032, LTRB=[6, 5, 1554, 1037]}, intermediate dim: Dim2 { w: 1561, h: 1042 }, rawimage: Dim2 { w: 6656, h: 4608 }
```


After:

```
2026-02-13 20:43:55 [INFO] crop: Rect{26:20, 6192x4128, LTRB=[26, 20, 6218, 4148]}, intermediate dim: Dim2 { w: 6244, h: 4168 }, rawimage: Dim2 { w: 6656, h: 4608 }
```

The values are still not exactly the same but close enough

Batch Mode: ~6.1MB
Single Mode: ~5.8MB

