### PR TITLE
Added 2 clickable links in the issue pop-up

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Click this link to check if your camera's raw files are supported by the dnglab library used by RapidRAW.
   - name: Supported lenses
     url: https://lensfun.github.io/lenslist/
-    about: Click thi link to check if your lenses are supported by the lensfun library used by RapidRAW.
+    about: Click this link to check if your lenses are supported by the lensfun library used by RapidRAW.


### PR DESCRIPTION
This config file adds 2 clickable links when you press "new issue" 
Making sure that users have a earlier encounter with the external libraries we ask them about in the bug template.