### PR TITLE
Persist main window size and position between launches

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
         "label": "main",
         "create": false,
         "title": "RapidRAW",
-        "width": 1200,
-        "height": 800,
+        "width": 1280,
+        "height": 720,
         "transparent": true,
         "decorations": false
       }


### PR DESCRIPTION
This change adds the ability to persist windows size and position between RapidRAW app launches 