### PR TITLE
fix show edited/original label

### DIFF
--- a/src/components/panel/editor/EditorToolbar.tsx
+++ b/src/components/panel/editor/EditorToolbar.tsx
@@ -545,7 +545,7 @@ const EditorToolbar = memo(
                 : 'bg-surface hover:bg-card-active text-text-primary',
             )}
             onClick={onToggleShowOriginal}
-            data-tooltip={showOriginal ? 'Show Edited (.)' : 'Show Original (.)'}
+            data-tooltip={showOriginal ? 'Show Edited (B)' : 'Show Original (B)'}
           >
             {showOriginal ? <EyeOff size={20} /> : <Eye size={20} />}
           </button>


### PR DESCRIPTION
Does what the title says :)

<img width="144" height="71" alt="image" src="https://github.com/user-attachments/assets/ee196f51-ecfe-4e84-86e2-7d0f6fa44771" />

Just started using rapidraw so not sure if the keybind used to be a `.` and this was left over from back then.