### PR TITLE
Improve preview performance and fix stale preview race condition

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -129,6 +129,12 @@ struct PreviewJob {
     is_interactive: bool,
 }
 
+#[derive(serde::Serialize, Clone)]
+struct PreviewUpdatePayload {
+    path: String,
+    data: Vec<u8>,
+}
+
 pub struct AppState {
     window_setup_complete: AtomicBool,
     original_image: Mutex<Option<LoadedImage>>,
@@ -911,7 +917,10 @@ fn process_preview_job(
             .encode_rgb(&rgb_pixels, width as u32, height as u32)
         {
             Ok(bytes) => {
-                let _ = app_handle.emit("preview-update-final", bytes);
+                let _ = app_handle.emit("preview-update-final", PreviewUpdatePayload {
+                    path: loaded_image.path.clone(),
+                    data: bytes,
+                });
             },
             Err(e) => {
                 log::error!("Failed to encode preview with mozjpeg-rs: {}", e);
@@ -1383,7 +1392,10 @@ async fn generate_fullscreen_preview(
             .encode_rgb(&rgb_pixels, width as u32, height as u32)
         {
             Ok(bytes) => {
-                let _ = app_handle_clone.emit("preview-update-final", bytes);
+                let _ = app_handle_clone.emit("preview-update-final", PreviewUpdatePayload {
+                    path: path.clone(),
+                    data: bytes,
+                });
             }
             Err(e) => {
                 log::error!("Failed to encode fullscreen preview with mozjpeg-rs: {}", e);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -320,6 +320,8 @@ function App() {
   });
   const [supportedTypes, setSupportedTypes] = useState<SupportedTypes | null>(null);
   const [selectedImage, setSelectedImage] = useState<SelectedImage | null>(null);
+  const selectedImagePathRef = useRef<string | null>(null);
+  useEffect(() => { selectedImagePathRef.current = selectedImage?.path ?? null; }, [selectedImage?.path]);
   const [multiSelectedPaths, setMultiSelectedPaths] = useState<Array<string>>([]);
   const [libraryActivePath, setLibraryActivePath] = useState<string | null>(null);
   const [libraryActiveAdjustments, setLibraryActiveAdjustments] = useState<Adjustments>(INITIAL_ADJUSTMENTS);
@@ -2626,7 +2628,9 @@ function App() {
     const listeners = [
       listen('preview-update-final', (event: any) => {
         if (isEffectActive) {
-          const imageData = new Uint8Array(event.payload);
+          const { path, data } = event.payload;
+          if (path !== selectedImagePathRef.current) return;
+          const imageData = new Uint8Array(data);
           const blob = new Blob([imageData], { type: 'image/jpeg' });
           const url = URL.createObjectURL(blob);
           setFinalPreviewUrl(url);


### PR DESCRIPTION
This PR addresses two performance issues and one stability/correctness bug found while profiling RapidRAW on a mid-range system  (i7-7700K, RX 6600).                                                                                                                     
                                                            
  1. Parallelize downscale_f32_image (performance)

  downscale_f32_image in image_processing.rs was implemented as a single-threaded nested loop using get_pixel() — a bounds-checked per-pixel accessor — with no parallelism despite rayon being available. For a 24MP image being downscaled to the preview resolution this involves tens of millions of accessor calls on a single thread.

  The implementation has been rewritten to use par_chunks_exact_mut over the output buffer (row-parallel) with direct flat slice access into the source image, eliminating both the per-pixel function call overhead and the single-threaded bottleneck. This is most noticeable during geometry operations (rotation, crop, lens correction) which invalidate the transform cache and trigger a fresh downscale.

  2. Fix stale preview race condition (correctness)

  preview-update-final events emitted by the backend carried no identifier indicating which image they belonged to. The preview worker thread processes jobs to completion before picking up the next one, so when navigating quickly between images a preview computed for the previous image could arrive after navigation and be displayed briefly for the new image — a visible "flicker back" to the previous photo.

The fix tags each preview-update-final event with the source image path. The frontend discards any event whose path does not match the currently selected image. Both emit sites (process_preview_job and generate_fullscreen_preview) have been updated.

Platform note: These issues were observed and the fixes tested on Linux (Ubuntu 24.04, Wayland, AMD RX 6600 with RADV Vulkan). The changes themselves are platform-agnostic — the Rust parallelisation and the event-tagging fix have no OS-specific dependencies — but they have not been tested on macOS or Windows.