### PR TITLE
Fix panasonic g9ii lensfun alias

### DIFF
--- a/src-tauri/lensfun_db/mil-panasonic.xml
+++ b/src-tauri/lensfun_db/mil-panasonic.xml
@@ -137,6 +137,7 @@
     <camera>
         <maker>Panasonic</maker>
         <model>DC-G9M2</model>
+        <model lang="en">DC-G9 II</model>
         <mount>Micro 4/3 System</mount>
         <cropfactor>2</cropfactor>
     </camera>


### PR DESCRIPTION
The Panasonic DC-G9 II reports itself as DC-G9 II in EXIF data (the English marketing name), but the lensfun database only contained the entry DC-G9M2 (the Japanese/internal designation used by Panasonic). With no alias bridging the two, camera body lookup fails entirely and lens correction profiles cannot be applied to images shot with this camera.

This change adds DC-G9 II as an English-language model alias for the existing DC-G9M2 entry, which already has the correct mount (Micro 4/3 System) and crop factor (2). No calibration data has been added or modified.

The fix was verified against a DC-G9 II shooting .rw2 files, rather than just inferred from the EXIF spec.