### PR TITLE
Fix TIFF export compatibility with cwebp and other TIFF readers

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1594,7 +1594,7 @@ fn encode_image_to_bytes(
                 .map_err(|e| e.to_string())?;
         }
         "tiff" => {
-            image
+            DynamicImage::ImageRgb16(image.to_rgb16())
                 .write_to(&mut cursor, image::ImageFormat::Tiff)
                 .map_err(|e| e.to_string())?;
         }


### PR DESCRIPTION
The GPU processing pipeline produces 32-bit floating-point images internally. When written to TIFF via the image crate, these were encoded with a floating-point predictor (TIFF tag 317) and without a proper ExtraSamples declaration. Many TIFF readers — including cwebp and older versions of libtiff — reject files written this way, producing errors such as "Unknown field with tag 317" and "Cannot retrieve TIFF ExtraSamples info".

Fix by explicitly converting to 16-bit RGB before encoding, mirroring what the PNG arm already does for float images. This produces a standard, universally compatible 16-bit/channel TIFF that all tools can read. The trade-off is that file sizes may be somewhat larger than 8-bit exports from other software, but 16-bit depth is appropriate for a lossless format.