### PR TITLE
Improve folder tree selection highlight visibility

### DIFF
--- a/src/components/panel/FolderTree.tsx
+++ b/src/components/panel/FolderTree.tsx
@@ -152,7 +152,7 @@ function TreeNode({
     <div className="text-sm">
       <div
         className={clsx('flex items-center gap-2 p-1.5 rounded-md transition-colors', {
-          'bg-surface': isSelected,
+          'bg-accent/20': isSelected,
           'hover:bg-card-active': !isSelected,
         })}
         onClick={handleNameClick}


### PR DESCRIPTION
The selected folder row used bg-surface as its background, which is a subtle elevation step barely distinguishable from the panel background. The hover state on unselected rows used bg-card-active, meaning hovering over a non-selected item was visually more prominent than the actual selection — making it very difficult to see which folder is active.

Change the selected row background to bg-accent/20 so it uses the theme accent colour at 20% opacity, giving a clear and consistent visual indicator that works across all themes.