### PR TITLE
Fix export hang on dialog

### DIFF
--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -361,8 +361,6 @@ export default function ExportPanel({
       return;
     }
 
-    setExportState({ status: Status.Exporting, progress: { current: 0, total: numImages }, errorMessage: '' });
-
     let finalFilenameTemplate = filenameTemplate;
     if (isBatchMode && !filenameTemplate.includes('{sequence}') && !filenameTemplate.includes('{original_filename}')) {
       finalFilenameTemplate = `${filenameTemplate}_{sequence}`;
@@ -392,14 +390,13 @@ export default function ExportPanel({
       if (isBatchMode || !isEditorContext) {
         const outputFolder = await open({ title: `Select Folder to Export ${numImages} Image(s)`, directory: true });
         if (outputFolder) {
+          setExportState({ status: Status.Exporting, progress: { current: 0, total: numImages }, errorMessage: '' });
           await invoke(Invokes.BatchExportImages, {
             exportSettings,
             outputFolder,
             outputFormat: FILE_FORMATS.find((f: FileFormat) => f.id === fileFormat)?.extensions[0],
             paths: pathsToExport,
           });
-        } else {
-          setExportState((prev: ExportState) => ({ ...prev, status: Status.Idle }));
         }
       } else {
         const selectedFormat: any = FILE_FORMATS.find((f) => f.id === fileFormat);
@@ -413,14 +410,13 @@ export default function ExportPanel({
           filters: FILE_FORMATS.map((f: FileFormat) => ({ name: f.name, extensions: f.extensions })),
         });
         if (filePath) {
+          setExportState({ status: Status.Exporting, progress: { current: 0, total: numImages }, errorMessage: '' });
           await invoke(Invokes.ExportImage, {
             exportSettings,
             jsAdjustments: adjustments,
             originalPath: selectedImage.path,
             outputPath: filePath,
           });
-        } else {
-          setExportState((prev: ExportState) => ({ ...prev, status: Status.Idle }));
         }
       }
     } catch (error) {

--- a/src/components/panel/right/LibraryExportPanel.tsx
+++ b/src/components/panel/right/LibraryExportPanel.tsx
@@ -377,8 +377,6 @@ export default function LibraryExportPanel({
       return;
     }
 
-    setExportState({ status: Status.Exporting, progress: { current: 0, total: numImages }, errorMessage: '' });
-
     let finalFilenameTemplate = filenameTemplate;
     if (numImages > 1 && !filenameTemplate.includes('{sequence}') && !filenameTemplate.includes('{original_filename}')) {
       finalFilenameTemplate = `${filenameTemplate}_{sequence}`;
@@ -411,14 +409,13 @@ export default function LibraryExportPanel({
       });
 
       if (outputFolder) {
+        setExportState({ status: Status.Exporting, progress: { current: 0, total: numImages }, errorMessage: '' });
         await invoke(Invokes.BatchExportImages, {
           exportSettings,
           outputFolder,
           outputFormat: FILE_FORMATS.find((f: FileFormat) => f.id === fileFormat)?.extensions[0],
           paths: multiSelectedPaths,
         });
-      } else {
-        setExportState((prev: ExportState) => ({ ...prev, status: Status.Idle }));
       }
     } catch (error) {
       console.error('Error exporting images:', error);


### PR DESCRIPTION
## Problem
                                                                                                                                           
The export status was set to `Exporting` before awaiting the file dialog. If the dialog hung (e.g. due to a Wayland window z-order issue) or failed silently, the UI was permanently stuck showing "Exporting (0/1)" with a spinner and no way to recover other than restarting the application.

## Fix

Move `setExportState(Exporting)` to after the dialog resolves and only when a valid path has been returned by the user. The UI now only enters the Exporting state once the export is genuinely underway. Applies to both `ExportPanel` and `LibraryExportPanel`.

Note this PR depends on the "export improvements" PR I submitted earlier.