### PR TITLE
Fix denoised RAW TIFF saved as 32-bit float instead of 16-bit

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3259,7 +3259,7 @@ async fn save_denoised_image(
 
     let (output_filename, image_to_save): (String, DynamicImage) = if is_raw {
         let filename = format!("{}_Denoised.tiff", stem);
-        (filename, denoised_image)
+        (filename, DynamicImage::ImageRgb16(denoised_image.to_rgb16()))
     } else {
         let filename = format!("{}_Denoised.png", stem);
         (filename, DynamicImage::ImageRgb8(denoised_image.to_rgb8()))


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
- [ x] Bug fix

## Changes Made
The denoiser works internally with 32-bit float precision, but save_denoised_image() was writing that DynamicImage directly to disk. The image crate then produced a 32-bit float TIFF (~286 MB) which most viewers (Eye of GNOME, Shotwell, etc.) cannot open.

Convert to 16-bit integer before saving, matching the behaviour of the regular TIFF export path and halving the file size to ~144 MB.

## Screenshots/Videos
At present, RapidRAW produces 286MB TIF files. These cannot be read. I believe a single line of code can fix this.

## Testing
- [x ] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Linux Mint
- i7-770K GPU RX6600

## Checklist
- [x ] My code follows the project's code style
- [ x] I haven't added unnecessary AI-generated code comments
- [ x] My changes generate no new warnings or errors

## Additional Notes
None. This bug must have appeared in the past few days.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [x ] This PR is AI-generated but guided by a human