### PR TITLE
Fix crop handle clipping

### DIFF
--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -790,7 +790,7 @@ export default function Editor({
       </div>
 
       <div
-        className={clsx('flex-1 relative overflow-hidden', isFullScreen ? 'rounded-none' : 'rounded-lg')}
+        className={clsx('flex-1 relative', isFullScreen ? 'rounded-none' : 'rounded-lg')}
         onContextMenu={onContextMenu}
         ref={imageContainerRef}
       >


### PR DESCRIPTION
## Description
The inner image canvas container had overflow-hidden applied alongside rounded-lg, which caused the browser to clip content at the rounded corners. This made ReactCrop's corner handles inaccessible when the crop selection reached the edges of the image. The outer editor container already applies overflow-hidden, so removing it from the inner container has no effect on pan/zoom clipping behavior.

## Type of Change
- [x ] Bug fix (depending on your point of view?)
- [x ] UI/UX improvement

## Changes Made
As above; couldn't see the corner of the image when trying a crop.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->

## Testing
- [x ] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Linux Mint
- **Hardware:** i7-7700k and rx6600

## Checklist
- [x ] My code follows the project's code style
- [x ] I haven't added unnecessary AI-generated code comments
- [x ] My changes generate no new warnings or errors

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [x ] This PR is AI-generated but guided by a human