### PR TITLE
Fix batch adjustments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -282,6 +282,7 @@ function App() {
   });
   const [isSliderDragging, setIsSliderDragging] = useState(false);
   const dragIdleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevAdjustmentsRef = useRef<{ path: string; adjustments: Adjustments } | null>(null);
   const [isFullScreen, setIsFullScreen] = useState(false);
   const [isAnimatingTheme, setIsAnimatingTheme] = useState(false);
   const isInitialThemeMount = useRef(true);
@@ -2411,6 +2412,25 @@ function App() {
         currentResRef.current = targetRes;
         applyAdjustments(adjustments, false, targetRes);
         debouncedSave(selectedImage.path, adjustments);
+
+        const otherPaths = multiSelectedPaths.filter((p) => p !== selectedImage.path);
+        if (otherPaths.length > 0) {
+          const prev = prevAdjustmentsRef.current;
+          if (prev && prev.path === selectedImage.path) {
+            const delta: Partial<Adjustments> = {};
+            for (const key of Object.keys(adjustments) as Array<keyof Adjustments>) {
+              if (JSON.stringify(adjustments[key]) !== JSON.stringify(prev.adjustments[key])) {
+                (delta as any)[key] = adjustments[key];
+              }
+            }
+            if (Object.keys(delta).length > 0) {
+              invoke(Invokes.ApplyAdjustmentsToPaths, { paths: otherPaths, adjustments: delta }).catch((err) => {
+                console.error('Failed to apply adjustments to multi-selection:', err);
+              });
+            }
+          }
+        }
+        prevAdjustmentsRef.current = { path: selectedImage.path, adjustments };
       }, 50);
     }
 
@@ -2423,6 +2443,7 @@ function App() {
     selectedImage?.path,
     selectedImage?.isReady,
     isSliderDragging,
+    multiSelectedPaths,
     applyAdjustments,
     debouncedSave,
     appSettings?.enableLivePreviews,


### PR DESCRIPTION
## Description
When multiple images were selected (Ctrl/Shift+click) and a slider was adjusted, the change was only persisted for the primary selectedImage. The other selected paths were never updated. I assume this was in error as the hooks to multiple image adjustments were present in the code.

The adjustment save path (useEffect watching adjustments) now calls apply_adjustments_to_paths for any selected paths beyond the primary image after each  non-dragging change. The backend merges adjustments key-by-key into each image's existing sidecar, so per-image settings that weren't touched in this session (e.g. individual white balance corrections) are preserved.

## Type of Change
- [x ] Bug fix (I suspect)
- [x ] UI/UX improvement


## Changes Made
As above.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->

## Testing
- [x ] I have tested these changes locally and confirmed that they work as expected without issues. It is glorious and undo works as well.

**Test Configuration:**
- **OS:** Linux Mint
- **Hardware:** i7-7700k and rx6600

## Checklist
- [x ] My code follows the project's code style
- [x ] I haven't added unnecessary AI-generated code comments
- [x ] My changes generate no new warnings or errors

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [x ] This PR is AI-generated but guided by a human