### PR TITLE
Add user-configurable font setting

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -304,6 +304,8 @@ pub struct AppSettings {
     pub sort_criteria: Option<SortCriteria>,
     pub filter_criteria: Option<FilterCriteria>,
     pub theme: Option<String>,
+    #[serde(default)]
+    pub font_family: Option<String>,
     pub transparent: Option<bool>,
     pub decorations: Option<bool>,
     #[serde(alias = "comfyuiAddress")]
@@ -375,6 +377,7 @@ impl Default for AppSettings {
             sort_criteria: None,
             filter_criteria: None,
             theme: Some("dark".to_string()),
+            font_family: None,
             transparent: Some(true),
             #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
             decorations: Some(true),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1572,9 +1572,15 @@ function App() {
       root.style.setProperty(key, value as string);
     });
 
+    const fontFamily = appSettings?.fontFamily || 'poppins';
+    const fontStack = fontFamily === 'system'
+      ? '-apple-system, BlinkMacSystemFont, system-ui, sans-serif'
+      : "'Poppins', system-ui, sans-serif";
+    root.style.setProperty('--font-family', fontStack);
+
     const isLight = [Theme.Light, Theme.Snow, Theme.Arctic].includes(effectThemeForWindow);
     invoke(Invokes.UpdateWindowEffect, { theme: isLight ? Theme.Light : Theme.Dark });
-  }, [theme, adaptivePalette]);
+  }, [theme, adaptivePalette, appSettings?.fontFamily]);
 
   useEffect(() => {
     if (isInitialThemeMount.current) {

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -703,6 +703,17 @@ export default function SettingsPanel({
                       />
                     </SettingItem>
 
+                    <SettingItem label="Font" description="Change the application font.">
+                      <Dropdown
+                        onChange={(value: any) => onSettingsChange({ ...appSettings, fontFamily: value })}
+                        options={[
+                          { value: 'poppins', label: 'Poppins' },
+                          { value: 'system', label: 'System Default' },
+                        ]}
+                        value={appSettings?.fontFamily || 'poppins'}
+                      />
+                    </SettingItem>
+
                     <SettingItem
                       description="Dynamically changes editor colors based on the current image."
                       label="Editor Theme"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,7 +19,7 @@ export default {
         'hover-color': 'rgb(var(--color-hover-color) / <alpha-value>)',
       },
       fontFamily: {
-        sans: ['Poppins', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-family)'],
       },
       boxShadow: {
         'shiny': '0 0 24px rgba(255, 255, 255, 0.12)',


### PR DESCRIPTION
## Summary
- Adds a **Font** dropdown in General Settings with two options: **Poppins** (default) and **System Default**
- Poppins remains the default — this just gives users the option to switch
- Setting persists across sessions via `AppSettings`

## Motivation
Some users with accessibility needs or high-DPI/low-DPI displays may prefer their system font for better readability at small UI sizes. System fonts are also hinted and optimized per-platform (SF Pro on macOS, Segoe UI on Windows), so this can improve legibility for users who find that matters to them.

## Implementation
- Font is controlled via a `--font-family` CSS custom property referenced by Tailwind's `font-sans`
- Applied in the same `useEffect` that handles theme CSS variables
- Added `font_family: Option<String>` to the Rust `AppSettings` struct with `#[serde(default)]` for backwards compatibility

