### PR TITLE
Ensure Identical Rust Version For All Builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           rustflags: ''
-        if: startsWith(inputs.platform, 'macos') || startsWith(inputs.platform, 'windows')
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.93.1"


### PR DESCRIPTION
## Description
By using the `rust-toolchain.toml` config file, we can make sure that all builds follow the same Rust version. Both the CI and local Cargo understand and respect that setting out of the box. This avoids situations where the app is being tested with a different Rust version than it is being built for on Windows, which again differs from the macOS build all at the grace of the cache on the runners.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [X] Build/CI or Dependency update

## Changes Made
- Explicitly specify the Rust version used for the build
- Also install that version on Linux hosts, not just macOS and Windows in the CI

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, AMD graphics

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [X] This PR contains only blood, sweat, and coffee (AI-free)