### PR TITLE
Add ability to dock waveform into adjustments panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -275,7 +275,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [histogram, setHistogram] = useState<ChannelConfig | null>(null);
   const [waveform, setWaveform] = useState<WaveformData | null>(null);
-  const [isWaveformVisible, setIsWaveformVisible] = useState(false);
+  const [isWaveformVisible, setIsWaveformVisible] = useState(true);
   const [uiVisibility, setUiVisibility] = useState<UiVisibility>({
     folderTree: true,
     filmstrip: true,
@@ -1482,9 +1482,9 @@ function App() {
     }
   }, [uiVisibility, appSettings, handleSettingsChange]);
 
-  const handleToggleWaveform = useCallback(() => {
-    setIsWaveformVisible((prev: boolean) => !prev);
-  }, []);
+  //const handleToggleWaveform = useCallback(() => {
+//    setIsWaveformVisible((prev: boolean) => !prev);
+ // }, []);
 
   useEffect(() => {
     if (isInitialMount.current || !appSettings) {
@@ -4540,10 +4540,7 @@ function App() {
               isSliderDragging={isSliderDragging}
               isMaskControlHovered={isMaskControlHovered}
               isStraightenActive={isStraightenActive}
-              isWaveformDocked={appSettings?.dockWaveformInAdjustments ?? true}
-              isWaveformVisible={isWaveformVisible}
               onBackToLibrary={handleBackToLibrary}
-              onCloseWaveform={() => setIsWaveformVisible(false)}
               onContextMenu={handleEditorContextMenu}
               onGenerateAiMask={handleGenerateAiMask}
               onQuickErase={handleQuickErase}
@@ -4552,7 +4549,6 @@ function App() {
               onSelectMask={setActiveMaskId}
               onStraighten={handleStraighten}
               onToggleFullScreen={handleToggleFullScreen}
-              onToggleWaveform={handleToggleWaveform}
               onUndo={undo}
               onZoomed={handleUserTransform}
               renderedRightPanel={renderedRightPanel}
@@ -4568,7 +4564,6 @@ function App() {
               transformedOriginalUrl={transformedOriginalUrl}
               uncroppedAdjustedPreviewUrl={uncroppedAdjustedPreviewUrl}
               updateSubMask={updateSubMask}
-              waveform={waveform}
               onDisplaySizeChange={handleDisplaySizeChange}
               onInitialFitScale={setInitialFitScale}
               onZoomChange={handleZoomChange}
@@ -4672,9 +4667,6 @@ function App() {
                           copiedSectionAdjustments={copiedSectionAdjustments}
                           handleAutoAdjustments={handleAutoAdjustments}
                           histogram={histogram}
-                          isWaveformDocked={appSettings?.dockWaveformInAdjustments ?? true}
-                          isWaveformVisible={isWaveformVisible}
-                          onCloseWaveform={() => setIsWaveformVisible(false)}
                           selectedImage={selectedImage}
                           setAdjustments={setAdjustments}
                           setCollapsibleState={setCollapsibleSectionsState}
@@ -4684,26 +4676,9 @@ function App() {
                           handleLutSelect={handleLutSelect}
                           appSettings={appSettings}
                           isWbPickerActive={isWbPickerActive}
-                            toggleWbPicker={toggleWbPicker}
-                            onDragStateChange={setIsSliderDragging}
+                          toggleWbPicker={toggleWbPicker}
+                          onDragStateChange={setIsSliderDragging}
                           />
-                          //<Controls
-                           // adjustments={adjustments}
-                           // collapsibleState={collapsibleSectionsState}
-                           // copiedSectionAdjustments={copiedSectionAdjustments}
-                           // handleAutoAdjustments={handleAutoAdjustments}
-                           // histogram={histogram}
-                           // selectedImage={selectedImage}
-                           // setAdjustments={setAdjustments}
-                           // setCollapsibleState={setCollapsibleSectionsState}
-                            //setCopiedSectionAdjustments={setCopiedSectionAdjustments}
-                          //  theme={theme}
-                          //  handleLutSelect={handleLutSelect}
-                          //  appSettings={appSettings}
-                          //  isWbPickerActive={isWbPickerActive}
-                          //  toggleWbPicker={toggleWbPicker}
-                          //  onDragStateChange={setIsSliderDragging}
-                          ///>
                         )}
                         {renderedRightPanel === Panel.Metadata && (
                           <MetadataPanel

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -10,9 +10,8 @@ import { ImageDimensions, useImageRenderSize } from '../../hooks/useImageRenderS
 import { Adjustments, AiPatch, Coord, MaskContainer } from '../../utils/adjustments';
 import EditorToolbar from './editor/EditorToolbar';
 import ImageCanvas from './editor/ImageCanvas';
-import Waveform from './editor/Waveform';
 import { Mask, SubMask } from './right/Masks';
-import { BrushSettings, Invokes, Panel, SelectedImage, TransformState, WaveformData } from '../ui/AppProperties';
+import { BrushSettings, Invokes, Panel, SelectedImage, TransformState } from '../ui/AppProperties';
 import type { OverlayMode } from './right/CropPanel';
 
 interface EditorProps {
@@ -32,10 +31,7 @@ interface EditorProps {
   isMaskControlHovered: boolean;
   isStraightenActive: boolean;
   isRotationActive?: boolean;
-  isWaveformDocked: boolean;
-  isWaveformVisible: boolean;
   onBackToLibrary(): void;
-  onCloseWaveform(): void;
   onContextMenu(event: any): void;
   onGenerateAiMask(subMaskId: string, startPoint: Coord, endPoint: Coord): void;
   onQuickErase(subMaskId: string | null, startPoint: Coord, endpoint: Coord): void;
@@ -44,7 +40,6 @@ interface EditorProps {
   onSelectMask(id: string | null): void;
   onStraighten(val: number): void;
   onToggleFullScreen(): void;
-  onToggleWaveform(): void;
   onUndo(): void;
   onZoomed(state: TransformState): void;
   renderedRightPanel: Panel | null;
@@ -58,7 +53,6 @@ interface EditorProps {
   transformedOriginalUrl: string | null;
   uncroppedAdjustedPreviewUrl: string | null;
   updateSubMask(id: string | null, subMask: Partial<SubMask>): void;
-  waveform: WaveformData | null;
   onDisplaySizeChange?(size: any): void;
   onInitialFitScale?(scale: number): void;
   originalSize?: ImageDimensions;
@@ -89,10 +83,7 @@ export default function Editor({
   isMaskControlHovered,
   isStraightenActive,
   isRotationActive,
-  isWaveformDocked,
-  isWaveformVisible,
   onBackToLibrary,
-  onCloseWaveform,
   onContextMenu,
   onGenerateAiMask,
   onQuickErase,
@@ -101,7 +92,6 @@ export default function Editor({
   onSelectMask,
   onStraighten,
   onToggleFullScreen,
-  onToggleWaveform,
   onUndo,
   onZoomed,
   selectedImage,
@@ -114,7 +104,6 @@ export default function Editor({
   transformedOriginalUrl,
   uncroppedAdjustedPreviewUrl,
   updateSubMask,
-  waveform,
   onDisplaySizeChange,
   onInitialFitScale,
   originalSize,
@@ -677,7 +666,6 @@ export default function Editor({
         activeSubMask?.type === Mask.QuickEraser ||
         activeSubMask?.parameters?.isInitialDraw));
 
-  const waveFormData: WaveformData = waveform || { blue: [], green: [], height: 0, luma: [], red: [], width: 0 };
   const isZoomActionActive = !isCropping && !isMasking && !isAiEditing && !isWbPickerActive;
   const isMaxZoom = transformState.scale >= transformConfig.maxScale - 0.5;
 
@@ -699,12 +687,6 @@ export default function Editor({
         isFullScreen ? 'bg-black rounded-none p-0 gap-0' : 'bg-bg-secondary rounded-lg p-2 gap-2',
       )}
     >
-      <AnimatePresence>
-        {isWaveformVisible && !isFullScreen && !isWaveformDocked && (
-          <Waveform waveformData={waveFormData} onClose={onCloseWaveform} docked={false} />
-        )}
-      </AnimatePresence>
-
       <div
         className={clsx(
           'flex-shrink-0 transition-all duration-300 ease-in-out',
@@ -716,12 +698,10 @@ export default function Editor({
           canRedo={canRedo}
           canUndo={canUndo}
           isLoading={isLoading}
-          isWaveformVisible={isWaveformVisible}
           onBackToLibrary={onBackToLibrary}
           onRedo={onRedo}
           onToggleFullScreen={onToggleFullScreen}
           onToggleShowOriginal={toggleShowOriginal}
-          onToggleWaveform={onToggleWaveform}
           onUndo={onUndo}
           selectedImage={selectedImage}
           showOriginal={showOriginal}

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -775,18 +775,6 @@ export default function SettingsPanel({
                     </SettingItem>
 
                     <SettingItem
-                      label="Waveform Docking"
-                      description="Dock the waveform inside the Adjustments panel instead of floating over the image."
-                    >
-                      <Switch
-                        checked={appSettings?.dockWaveformInAdjustments ?? true}
-                        id="dock-waveform-toggle"
-                        label="Dock Waveform"
-                        onChange={(checked) => onSettingsChange({ ...appSettings, dockWaveformInAdjustments: checked })}
-                      />
-                    </SettingItem>
-
-                    <SettingItem
                       label="EXIF Library Sorting"
                       description="Read EXIF data (ISO, aperture, etc.) on folder load at the cost of slower folder loading when using EXIF sorting."
                     >
@@ -1704,7 +1692,6 @@ export default function SettingsPanel({
                         <KeybindItem keys={['K']} description="Toggle AI panel" />
                         <KeybindItem keys={['P']} description="Toggle Presets panel" />
                         <KeybindItem keys={['I']} description="Toggle Metadata panel" />
-                        <KeybindItem keys={['W']} description="Toggle Waveform display" />
                         <KeybindItem keys={['E']} description="Toggle Export panel" />
                       </div>
                     </div>

--- a/src/components/panel/editor/EditorToolbar.tsx
+++ b/src/components/panel/editor/EditorToolbar.tsx
@@ -1,5 +1,5 @@
 import { memo, useState, useEffect, useRef, useMemo } from 'react';
-import { Eye, EyeOff, ArrowLeft, Maximize, Loader2, Undo, Redo, Waves } from 'lucide-react';
+import { Eye, EyeOff, ArrowLeft, Maximize, Loader2, Undo, Redo } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
 import { SelectedImage } from '../../ui/AppProperties';
@@ -10,13 +10,11 @@ import { TextColors, TextVariants, TextWeights } from '../../../types/typography
 interface EditorToolbarProps {
   canRedo: boolean;
   canUndo: boolean;
-  isWaveformVisible: boolean;
   isLoading: boolean;
   onBackToLibrary(): void;
   onRedo(): void;
   onToggleFullScreen(): void;
   onToggleShowOriginal(): void;
-  onToggleWaveform(): void;
   onUndo(): void;
   selectedImage: SelectedImage;
   showOriginal: boolean;
@@ -32,12 +30,10 @@ const EditorToolbar = memo(
     canRedo,
     canUndo,
     isLoading,
-    isWaveformVisible,
     onBackToLibrary,
     onRedo,
     onToggleFullScreen,
     onToggleShowOriginal,
-    onToggleWaveform,
     onUndo,
     selectedImage,
     showOriginal,
@@ -601,19 +597,6 @@ const EditorToolbar = memo(
               )}
             </AnimatePresence>
           </div>
-
-          <button
-            className={clsx(
-              'p-2 rounded-full transition-colors',
-              isWaveformVisible
-                ? 'bg-accent text-button-text hover:bg-accent/90 hover:text-button-text'
-                : 'bg-surface hover:bg-card-active text-text-primary',
-            )}
-            onClick={onToggleWaveform}
-            data-tooltip="Toggle Waveform (W)"
-          >
-            <Waves size={20} />
-          </button>
 
           <button
             className={clsx(

--- a/src/components/panel/editor/Waveform.tsx
+++ b/src/components/panel/editor/Waveform.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from 'react';
-import Draggable from 'react-draggable';
 import { X, Waves } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { WaveformData } from '../../ui/AppProperties';
@@ -34,8 +33,6 @@ interface RgbWaveformProps {
 }
 
 interface WaveformProps {
- docked?: boolean;
-  onClose(): void;
   waveformData: WaveformData;
 }
 
@@ -115,9 +112,8 @@ const RgbWaveformDisplay = ({ redData, greenData, blueData, width, height, maxVa
   return <canvas ref={canvasRef} width={width} height={height} className="absolute inset-0" />;
 };
 
-export default function Waveform({ waveformData, onClose, docked = true }: WaveformProps) {
+export default function Waveform({ waveformData }: WaveformProps) {
   const [displayMode, setDisplayMode] = useState<DisplayMode>(DisplayMode.Rgb);
-  const nodeRef = useRef<any>(null);
 
   const { red, green, blue, luma, width, height } = waveformData || {};
 
@@ -135,8 +131,7 @@ export default function Waveform({ waveformData, onClose, docked = true }: Wavef
   const inactiveButtonClass = 'text-text-primary hover:bg-bg-tertiary';
 
   return (
-    <Draggable nodeRef={nodeRef} handle=".handle" bounds="parent" disabled={docked}>
-      <div ref={nodeRef} className={docked ? 'relative' : 'absolute top-20 left-20 z-50'}>
+    <div className="relative">
         <motion.div
           animate={{ opacity: 1, scale: 1 }}
           className="bg-surface/90 backdrop-blur-md border border-text-secondary/10 shadow-xl rounded-lg overflow-hidden"
@@ -146,18 +141,6 @@ export default function Waveform({ waveformData, onClose, docked = true }: Wavef
           style={{ transformOrigin: 'top left' }}
           transition={{ duration: 0.2, ease: 'easeOut' }}
         >
-          <div className={`handle flex items-center justify-between p-3${docked ? '' : ' cursor-move'}`}>
-            <div className="flex items-center gap-2">
-              <Waves size={16} />
-              <Text variant={TextVariants.heading}>Waveform</Text>
-            </div>
-            <button
-              className="p-1 rounded-lg text-text-secondary hover:bg-bg-primary hover:text-text-primary transition-colors"
-              onClick={onClose}
-            >
-              <X size={16} />
-            </button>
-          </div>
           {waveformData && (
             <div className="p-2 pt-0">
               <div className="relative w-[256px] h-[256px] bg-black/50 rounded">
@@ -254,6 +237,5 @@ export default function Waveform({ waveformData, onClose, docked = true }: Wavef
           )}
         </motion.div>
       </div>
-    </Draggable>
   );
 }

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -26,7 +26,6 @@ interface ControlsProps {
   handleAutoAdjustments(): void;
   handleLutSelect(path: string): void;
   histogram: ChannelConfig | null;
-  isWaveformDocked: boolean;
   isWaveformVisible: boolean;
   onCloseWaveform(): void;
   selectedImage: SelectedImage;
@@ -48,7 +47,6 @@ export default function Controls({
   handleAutoAdjustments,
   handleLutSelect,
   histogram,
-  isWaveformDocked,
   isWaveformVisible,
   onCloseWaveform,
   selectedImage,
@@ -192,11 +190,9 @@ export default function Controls({
         </div>
       </div>
       <div className="flex-grow overflow-y-auto p-4 flex flex-col gap-2">
-        {isWaveformVisible && isWaveformDocked && (
           <div className="flex-shrink-0">
-            <Waveform waveformData={waveFormData} onClose={onCloseWaveform} docked />
+            <Waveform waveformData={waveFormData} onClose={() => {}} docked />
           </div>
-        )}
         {Object.keys(ADJUSTMENT_SECTIONS).map((sectionName: string) => {
           const SectionComponent: any = {
             basic: BasicAdjustments,

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -2,7 +2,7 @@ import { ExportPreset } from './ExportImportProperties';
 import { Adjustments } from '../../utils/adjustments';
 import { ToolType } from '../panel/right/Masks';
 
-export const GLOBAL_KEYS = [' ', 'ArrowUp', 'ArrowDown', 'f', 'b', 'w'];
+export const GLOBAL_KEYS = [' ', 'ArrowUp', 'ArrowDown', 'f', 'b'];
 export const OPTION_SEPARATOR = 'separator';
 
 export enum Invokes {
@@ -153,7 +153,6 @@ export interface AppSettings {
   linearRawMode?: string;
   enableXmpSync?: boolean;
   createXmpIfMissing?: boolean;
-  dockWaveformInAdjustments?: boolean;
 }
 
 export interface BrushSettings {

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -38,7 +38,6 @@ interface KeyboardShortcutsProps {
   setActiveMaskId(id: string | null): void;
   setCopiedFilePaths(paths: Array<string>): void;
   setIsStraightenActive(active: any): void;
-  setIsWaveformVisible(visible: any): void;
   setLibraryActivePath(path: string): void;
   setMultiSelectedPaths(paths: Array<string>): void;
   setShowOriginal(show: any): void;
@@ -87,7 +86,6 @@ export const useKeyboardShortcuts = ({
   setActiveMaskId,
   setCopiedFilePaths,
   setIsStraightenActive,
-  setIsWaveformVisible,
   setLibraryActivePath,
   setMultiSelectedPaths,
   setShowOriginal,
@@ -217,10 +215,6 @@ export const useKeyboardShortcuts = ({
         if (key === 'e' && !isCtrl) {
           event.preventDefault();
           handleRightPanelSelect(Panel.Export);
-        }
-        if (key === 'w' && !isCtrl) {
-          event.preventDefault();
-          setIsWaveformVisible((prev: boolean) => !prev);
         }
       } else {
         if ((key === 'enter' || key === ' ') && !isCtrl) {
@@ -435,7 +429,6 @@ export const useKeyboardShortcuts = ({
     setActiveMaskId,
     setCopiedFilePaths,
     setIsStraightenActive,
-    setIsWaveformVisible,
     setLibraryActivePath,
     setMultiSelectedPaths,
     setShowOriginal,


### PR DESCRIPTION
## Description
Added the ability to dock the waveform as it overlays on the image and gets in the way, so having it dock is a good way to have a clear space to make your edits as see the whole image and also view the waveform at the same time. I added it as a setting option, so that existing behavior remains and only if the users wants it docked then it will be a user defined setting.

## Type of Change
- [ x] New feature

## Changes Made
- Added a Option in the General Settings section to allow the use to toggle the waveform to dock in the adjustment section of the image editor
- If this toggle is off, the normal behavior is to overlay the waveform on the image canvas
- if this toggle is on, the behavior is to dock the waveform at the top of the Adjustments section, so its not overlayed on the image canvas 

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->
<img width="918" height="1027" alt="Screenshot 2026-03-10 at 22 17 08" src="https://github.com/user-attachments/assets/653d35a7-8c3e-432c-bf32-d67cbe1df2fc" />
<img width="1622" height="1054" alt="Screenshot 2026-03-10 at 22 17 30" src="https://github.com/user-attachments/assets/fdd8b0d2-3903-4ba0-a912-e1d60783be0b" />

## Testing
- [ x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** macOS Tahoe
- **Hardware:** Apple M2

## Checklist
- [ x] My code follows the project's code style
- [ x] I haven't added unnecessary AI-generated code comments
- [ x] My changes generate no new warnings or errors

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)

