### PR TITLE
fix: keep tagging submenu open while editing tags

### DIFF
--- a/src/context/ContextMenuContext.tsx
+++ b/src/context/ContextMenuContext.tsx
@@ -42,6 +42,7 @@ function SubMenu({ cancelCloseSubmenu, closeSubmenu, hideContextMenu, options, p
 
   const customOption = options.length === 1 && options[0].customComponent ? options[0] : null;
   const CustomComponent = customOption?.customComponent;
+  const isInteractiveSubmenu = Boolean(customOption);
 
   useLayoutEffect(() => {
     if (parentRef?.current && menuRef?.current) {
@@ -121,7 +122,11 @@ function SubMenu({ cancelCloseSubmenu, closeSubmenu, hideContextMenu, options, p
         initial={{ opacity: 0, scale: 0.95 }}
         onContextMenu={(e: any) => e.preventDefault()}
         onMouseEnter={cancelCloseSubmenu}
-        onMouseLeave={() => closeSubmenu(parentPath)}
+        onMouseLeave={() => {
+          if (!isInteractiveSubmenu) {
+            closeSubmenu(parentPath);
+          }
+        }}
         ref={menuRef}
         style={style}
         transition={{ duration: 0.1, ease: 'easeOut' }}
@@ -149,6 +154,7 @@ function MenuItem({ option, path, hideContextMenu }: MenuItemProps) {
   const { activeSubmenu, openSubmenu, closeSubmenu, cancelCloseSubmenu } = useContextMenu();
   const itemRef = useRef(null);
   const hoverTimeoutRef = useRef<any>(null);
+  const hasInteractiveSubmenu = Boolean(option.submenu?.length === 1 && option.submenu[0].customComponent);
 
   const isSubmenuOpen =
     option.submenu &&
@@ -178,7 +184,7 @@ function MenuItem({ option, path, hideContextMenu }: MenuItemProps) {
       clearTimeout(hoverTimeoutRef.current);
     }
 
-    if (option.submenu && !option.disabled) {
+    if (option.submenu && !option.disabled && !hasInteractiveSubmenu) {
       closeSubmenu(path);
     }
   };
@@ -201,6 +207,9 @@ function MenuItem({ option, path, hideContextMenu }: MenuItemProps) {
           if (!option.disabled && !option.submenu && option.onClick) {
             option.onClick();
             hideContextMenu();
+          }
+          if (!option.disabled && option.submenu && hasInteractiveSubmenu) {
+            openSubmenu(path);
           }
         }}
         ref={itemRef}

--- a/src/context/TaggingSubMenu.tsx
+++ b/src/context/TaggingSubMenu.tsx
@@ -79,7 +79,11 @@ export default function TaggingSubMenu({
   const shortcuts = appSettings?.taggingShortcuts || [];
 
   return (
-    <div className="bg-surface/90 p-2 w-64 text-text-primary rounded-lg" onClick={(e) => e.stopPropagation()}>
+    <div
+      className="bg-surface/90 p-2 w-64 text-text-primary rounded-lg"
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+    >
       <div className="mb-2">
         <div className="flex flex-wrap gap-1 p-1 bg-surface rounded-md min-h-[32px] items-center">
           <AnimatePresence>


### PR DESCRIPTION
## Description

This fixes the tagging context menu closing while editing custom tags.

The issue appears to come from the custom context menu treating the tagging submenu like a normal hover submenu. That works for simple nested actions, but it is unstable for interactive content like an input field, where focus and pointer movement can cause the submenu to close unexpectedly.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Treat interactive custom submenus differently from normal hover-only submenus
- Prevent the tagging submenu from auto-closing on mouse leave while the user is interacting with it
- Stop mouse down events from bubbling out of the tagging submenu root container
- Keep existing outside-click and Escape behavior intact

## Testing

- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows
- **Hardware:** local dev environment

## Validation

- Open image context menu
- Open `Tagging`
- Type multiple characters into the custom tag input
- Confirm the submenu stays open while typing
- Confirm outside click still closes the menu
- Confirm Escape still closes the menu

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors relevant to this change

## AI Disclaimer

- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)

