### PR TITLE
Fix: await settings save before relaunch on macOS (#835)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1454,10 +1454,10 @@ function App() {
   );
 
   const handleSettingsChange = useCallback(
-    (newSettings: AppSettings) => {
+    (newSettings: AppSettings): Promise<void> => {
       if (!newSettings) {
         console.error('handleSettingsChange was called with null settings. Aborting save operation.');
-        return;
+        return Promise.resolve();
       }
       if (newSettings.theme && newSettings.theme !== theme) {
         setTheme(newSettings.theme);
@@ -1465,7 +1465,7 @@ function App() {
 
       const { searchCriteria: _searchCriteria, ...settingsToSave } = newSettings as any;
       setAppSettings(newSettings);
-      invoke(Invokes.SaveSettings, { settings: settingsToSave }).catch((err) => {
+      return invoke(Invokes.SaveSettings, { settings: settingsToSave }).then(() => {}).catch((err) => {
         console.error('Failed to save settings:', err);
       });
     },

--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -94,7 +94,7 @@ interface MainLibraryProps {
   onImageDoubleClick(path: string): void;
   onLibraryRefresh(): void;
   onOpenFolder(): void;
-  onSettingsChange(settings: AppSettings): void;
+  onSettingsChange(settings: AppSettings): Promise<void>;
   onThumbnailAspectRatioChange(aspectRatio: ThumbnailAspectRatio): void;
   onThumbnailSizeChange(size: ThumbnailSize): void;
   rootPath: string | null;

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -69,7 +69,7 @@ interface SettingsPanelProps {
   appSettings: any;
   onBack(): void;
   onLibraryRefresh(): void;
-  onSettingsChange(settings: any): void;
+  onSettingsChange(settings: any): Promise<void>;
   rootPath: string | null;
 }
 
@@ -413,11 +413,10 @@ export default function SettingsPanel({
   };
 
   const handleSaveAndRelaunch = async () => {
-    onSettingsChange({
+    await onSettingsChange({
       ...appSettings,
       ...processingSettings,
     });
-    await new Promise((resolve) => setTimeout(resolve, 200));
     await relaunch();
   };
 


### PR DESCRIPTION
Fixes #835

## Problem
On macOS, `handleSaveAndRelaunch` calls `onSettingsChange()` which internally fires `invoke(SaveSettings)` — an async write to disk. The promise was never awaited, so `relaunch()` was called before settings finished saving, causing the app to either fail to relaunch or restart with stale settings. The 200ms `setTimeout` was an unreliable workaround.

## Fix
- `handleSettingsChange` in `App.tsx` now returns the `invoke()` promise (`Promise<void>`)
- `onSettingsChange` interface updated from `void` → `Promise<void>` in `SettingsPanel.tsx` and `MainLibrary.tsx`
- `handleSaveAndRelaunch` now properly `await`s the settings save before calling `relaunch()`, replacing the fragile `setTimeout`

## Testing
Tested by changing the processing backend setting and clicking **Save & Relaunch** on macOS Apple Silicon.