### PR TITLE
ci: only lint code in RapidRAW for now

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Check formatting
         working-directory: src-tauri
-        run: cargo fmt --all -- --check
+        run: cargo fmt -p RapidRAW -- --check
 
   clippy:
     name: cargo clippy
@@ -50,4 +50,4 @@ jobs:
 
       - name: Clippy
         working-directory: src-tauri
-        run: cargo clippy --all-targets -- -W clippy::all
+        run: cargo clippy -p RapidRAW --all-targets -- -W clippy::all


### PR DESCRIPTION
## Description
Let's limit the scope of the linter to RapidRAW for now until there is a consensus how to best handle the `rawler` dependency. 

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [X] Build/CI or Dependency update

## Changes Made
- Limit the scope of linter checks to just RapidRAW

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [X] This PR contains only blood, sweat, and coffee (AI-free)