### PR TITLE
New way of adding masks/components and a new floating mask hierarchy window.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,6 +331,7 @@ function App() {
   const [activeAiPatchContainerId, setActiveAiPatchContainerId] = useState<string | null>(null);
   const [activeAiSubMaskId, setActiveAiSubMaskId] = useState<string | null>(null);
   const [maskHierarchyOverlayHost, setMaskHierarchyOverlayHost] = useState<HTMLDivElement | null>(null);
+  const [isMaskOverlayEnabled, setIsMaskOverlayEnabled] = useState(true);
   const [zoom, setZoom] = useState(1);
   const [displaySize, setDisplaySize] = useState<ImageDimensions>({ width: 0, height: 0 });
   const [previewSize, setPreviewSize] = useState<ImageDimensions>({ width: 0, height: 0 });
@@ -4958,6 +4959,7 @@ function App() {
               isLoading={isViewLoading}
               isSliderDragging={isSliderDragging}
               isMaskControlHovered={isMaskControlHovered}
+              isMaskOverlayEnabled={isMaskOverlayEnabled}
               isStraightenActive={isStraightenActive}
               onBackToLibrary={handleBackToLibrary}
               onContextMenu={handleEditorContextMenu}
@@ -5163,6 +5165,8 @@ function App() {
                             waveformHeight={waveformHeight}
                             setWaveformHeight={setWaveformHeight}
                             setIsMaskControlHovered={setIsMaskControlHovered}
+                            isMaskOverlayEnabled={isMaskOverlayEnabled}
+                            setIsMaskOverlayEnabled={setIsMaskOverlayEnabled}
                           />
                         )}
                         {renderedRightPanel === Panel.Presets && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,7 +331,7 @@ function App() {
   const [activeAiPatchContainerId, setActiveAiPatchContainerId] = useState<string | null>(null);
   const [activeAiSubMaskId, setActiveAiSubMaskId] = useState<string | null>(null);
   const [maskHierarchyOverlayHost, setMaskHierarchyOverlayHost] = useState<HTMLDivElement | null>(null);
-  const [isMaskOverlayEnabled, setIsMaskOverlayEnabled] = useState(true);
+  const [isMaskOverlayEnabled, setIsMaskOverlayEnabled] = useState(false);
   const [zoom, setZoom] = useState(1);
   const [displaySize, setDisplaySize] = useState<ImageDimensions>({ width: 0, height: 0 });
   const [previewSize, setPreviewSize] = useState<ImageDimensions>({ width: 0, height: 0 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -330,6 +330,7 @@ function App() {
   const [activeMaskId, setActiveMaskId] = useState<string | null>(null);
   const [activeAiPatchContainerId, setActiveAiPatchContainerId] = useState<string | null>(null);
   const [activeAiSubMaskId, setActiveAiSubMaskId] = useState<string | null>(null);
+  const [maskHierarchyOverlayHost, setMaskHierarchyOverlayHost] = useState<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
   const [displaySize, setDisplaySize] = useState<ImageDimensions>({ width: 0, height: 0 });
   const [previewSize, setPreviewSize] = useState<ImageDimensions>({ width: 0, height: 0 });
@@ -4983,6 +4984,7 @@ function App() {
               uncroppedAdjustedPreviewUrl={uncroppedAdjustedPreviewUrl}
               updateSubMask={updateSubMask}
               onDisplaySizeChange={handleDisplaySizeChange}
+              onMaskHierarchyHostChange={setMaskHierarchyOverlayHost}
               originalSize={originalSize}
               isRotationActive={isRotationActive}
               overlayMode={overlayMode}
@@ -5151,6 +5153,7 @@ function App() {
                             setBrushSettings={setBrushSettings}
                             setCopiedMask={setCopiedMask}
                             setCustomEscapeHandler={setCustomEscapeHandler}
+                            maskHierarchyOverlayHost={maskHierarchyOverlayHost}
                             onDragStateChange={setIsSliderDragging}
                             isWaveformVisible={isWaveformVisible}
                             onToggleWaveform={handleToggleWaveform}

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from 'lucide-react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api/core';
 import { ImageDimensions, useImageRenderSize } from '../../hooks/useImageRenderSize';
-import { Adjustments, AiPatch, Coord, MaskContainer } from '../../utils/adjustments';
+import { Adjustments, AiPatch, Coord, INITIAL_MASK_ADJUSTMENTS, MaskContainer } from '../../utils/adjustments';
 import { calculateCenteredCrop, getOrientedDimensions } from '../../utils/cropUtils';
 import EditorToolbar from './editor/EditorToolbar';
 import ImageCanvas from './editor/ImageCanvas';
@@ -28,6 +28,7 @@ interface EditorProps {
   isLoading: boolean;
   isSliderDragging: boolean;
   isMaskControlHovered: boolean;
+  isMaskOverlayEnabled: boolean;
   isStraightenActive: boolean;
   isRotationActive?: boolean;
   onBackToLibrary(): void;
@@ -81,6 +82,7 @@ export default function Editor({
   isLoading,
   isSliderDragging,
   isMaskControlHovered,
+  isMaskOverlayEnabled,
   isStraightenActive,
   isRotationActive,
   onBackToLibrary,
@@ -400,8 +402,41 @@ export default function Editor({
     [processOverlayQueue],
   );
 
+  const activeMaskContainer = useMemo(() => {
+    if (activeRightPanel !== Panel.Masks || !activeMaskContainerId) {
+      return null;
+    }
+
+    return adjustments.masks.find((container: MaskContainer) => container.id === activeMaskContainerId) || null;
+  }, [activeMaskContainerId, activeRightPanel, adjustments.masks]);
+
+  const activeMaskHasNoAdjustments = useMemo(() => {
+    if (!activeMaskContainer) {
+      return false;
+    }
+
+    const { sectionVisibility: _currentSectionVisibility, ...currentAdjustments } =
+      activeMaskContainer.adjustments || INITIAL_MASK_ADJUSTMENTS;
+    const { sectionVisibility: _initialSectionVisibility, ...initialAdjustments } = INITIAL_MASK_ADJUSTMENTS;
+
+    return JSON.stringify(currentAdjustments) === JSON.stringify(initialAdjustments);
+  }, [activeMaskContainer]);
+
+  const shouldShowMaskOverlay = useMemo(() => {
+    if (activeRightPanel !== Panel.Masks || !activeMaskContainer) {
+      return false;
+    }
+
+    return isMaskOverlayEnabled || activeMaskHasNoAdjustments;
+  }, [activeMaskContainer, activeMaskHasNoAdjustments, activeRightPanel, isMaskOverlayEnabled]);
+
   const handleLiveMaskPreview = useCallback(
     (maskDef: any) => {
+      if (activeRightPanel === Panel.Masks && !shouldShowMaskOverlay) {
+        setMaskOverlayUrl(null);
+        return;
+      }
+
       let normalizedDef = maskDef;
       if (maskDef && !maskDef.adjustments) {
         normalizedDef = {
@@ -413,14 +448,14 @@ export default function Editor({
 
       requestMaskOverlay(normalizedDef, imageRenderSize, adjustments);
     },
-    [imageRenderSize, adjustments, requestMaskOverlay],
+    [activeRightPanel, adjustments, imageRenderSize, requestMaskOverlay, shouldShowMaskOverlay],
   );
 
   useEffect(() => {
     let maskDefForOverlay = null;
 
-    if (activeRightPanel === Panel.Masks && activeMaskContainerId) {
-      maskDefForOverlay = adjustments.masks.find((c: MaskContainer) => c.id === activeMaskContainerId);
+    if (activeRightPanel === Panel.Masks && shouldShowMaskOverlay) {
+      maskDefForOverlay = activeMaskContainer;
     } else if (activeRightPanel === Panel.Ai && activeAiPatchContainerId) {
       const activePatch = adjustments.aiPatches.find((p: AiPatch) => p.id === activeAiPatchContainerId);
       if (activePatch) {
@@ -435,11 +470,12 @@ export default function Editor({
     requestMaskOverlay(maskDefForOverlay, imageRenderSize, adjustments);
   }, [
     activeRightPanel,
-    activeMaskContainerId,
     activeAiPatchContainerId,
+    activeMaskContainer,
     adjustments,
     imageRenderSize,
     requestMaskOverlay,
+    shouldShowMaskOverlay,
   ]);
 
   useEffect(() => {
@@ -822,6 +858,7 @@ export default function Editor({
               isAiEditing={isAiEditing}
               isCropping={isCropping}
               isMaskControlHovered={isMaskControlHovered}
+              isMaskOverlayEnabled={shouldShowMaskOverlay}
               isMasking={isMasking}
               isStraightenActive={isStraightenActive}
               isRotationActive={isRotationActive}

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -53,6 +53,7 @@ interface EditorProps {
   uncroppedAdjustedPreviewUrl: string | null;
   updateSubMask(id: string | null, subMask: Partial<SubMask>): void;
   onDisplaySizeChange?(size: any): void;
+  onMaskHierarchyHostChange?(element: HTMLDivElement | null): void;
   originalSize?: ImageDimensions;
   isWbPickerActive?: boolean;
   onWbPicked?: () => void;
@@ -104,6 +105,7 @@ export default function Editor({
   uncroppedAdjustedPreviewUrl,
   updateSubMask,
   onDisplaySizeChange,
+  onMaskHierarchyHostChange,
   originalSize,
   isWbPickerActive = false,
   onWbPicked,
@@ -592,6 +594,13 @@ export default function Editor({
 
   const doubleClickProps = useMemo(() => ({ disabled: true }), []);
 
+  const handleMaskHierarchyHostRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      onMaskHierarchyHostChange?.(node);
+    },
+    [onMaskHierarchyHostChange],
+  );
+
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     mouseDownPos.current = { x: e.clientX, y: e.clientY };
   }, []);
@@ -849,6 +858,8 @@ export default function Editor({
             />
           </TransformComponent>
         </TransformWrapper>
+
+        <div ref={handleMaskHierarchyHostRef} className="absolute inset-0 z-30 pointer-events-none" />
       </div>
     </div>
   );

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -594,13 +594,6 @@ export default function Editor({
 
   const doubleClickProps = useMemo(() => ({ disabled: true }), []);
 
-  const handleMaskHierarchyHostRef = useCallback(
-    (node: HTMLDivElement | null) => {
-      onMaskHierarchyHostChange?.(node);
-    },
-    [onMaskHierarchyHostChange],
-  );
-
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     mouseDownPos.current = { x: e.clientX, y: e.clientY };
   }, []);
@@ -859,7 +852,7 @@ export default function Editor({
           </TransformComponent>
         </TransformWrapper>
 
-        <div ref={handleMaskHierarchyHostRef} className="absolute inset-0 z-30 pointer-events-none" />
+        <div ref={onMaskHierarchyHostChange} className="absolute inset-0 z-30 pointer-events-none" />
       </div>
     </div>
   );

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -37,6 +37,7 @@ interface ImageCanvasProps {
   isAiEditing: boolean;
   isCropping: boolean;
   isMaskControlHovered: boolean;
+  isMaskOverlayEnabled: boolean;
   isMasking: boolean;
   isSliderDragging: boolean;
   isStraightenActive: boolean;
@@ -706,6 +707,7 @@ const ImageCanvas = memo(
     isAiEditing,
     isCropping,
     isMaskControlHovered,
+    isMaskOverlayEnabled,
     isMasking,
     isSliderDragging,
     isStraightenActive,
@@ -1828,7 +1830,10 @@ const ImageCanvas = memo(
                   style={{
                     height: `${imageRenderSize.height}px`,
                     left: `${imageRenderSize.offsetX}px`,
-                    opacity: isShowingOriginal || isMaskControlHovered ? 0 : 1,
+                    opacity:
+                      isShowingOriginal || ((isAiEditing || (isMasking && !isMaskOverlayEnabled)) && isMaskControlHovered)
+                        ? 0
+                        : 1,
                     top: `${imageRenderSize.offsetY}px`,
                     transition: 'opacity 300ms ease-in-out',
                     width: `${imageRenderSize.width}px`,

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -16,12 +16,14 @@ import {
   pointerWithin,
 } from '@dnd-kit/core';
 import {
+  ArrowRight,
   ChartArea,
   Circle,
   ClipboardPaste,
   Copy,
   Eye,
   EyeOff,
+  ExternalLink,
   FileEdit,
   FolderOpen,
   Folder as FolderIcon,
@@ -114,6 +116,18 @@ interface DragData {
   maskType?: Mask;
   parentId?: string;
 }
+
+type FloatingHierarchyAnchor = 'top-left' | 'top-right' | 'center-left' | 'center-right' | 'bottom-left' | 'bottom-right';
+
+const FLOATING_HIERARCHY_MARGIN = 16;
+const FLOATING_HIERARCHY_ANCHORS: FloatingHierarchyAnchor[] = [
+  'top-left',
+  'top-right',
+  'center-left',
+  'center-right',
+  'bottom-left',
+  'bottom-right',
+];
 
 const SUB_MASK_CONFIG: Record<Mask, any> = {
   [Mask.Radial]: {
@@ -239,6 +253,8 @@ export default function MasksPanel({
   const [copiedSectionAdjustments, setCopiedSectionAdjustments] = useState<any | null>(null);
   const [isSettingsSectionOpen, setSettingsSectionOpen] = useState(true);
   const [isSettingsPanelEverOpened, setIsSettingsPanelEverOpened] = useState(false);
+  const [isHierarchyFloating, setIsHierarchyFloating] = useState(false);
+  const [floatingHierarchyAnchor, setFloatingHierarchyAnchor] = useState<FloatingHierarchyAnchor>('top-right');
   const hasPerformedInitialSelection = useRef(false);
   const [isMaskListEmpty, setIsMaskListEmpty] = useState(adjustments.masks.length === 0);
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
@@ -777,6 +793,14 @@ export default function MasksPanel({
     ]);
   };
 
+  const showFloatingHierarchy = isHierarchyFloating && !!maskHierarchyOverlayHost;
+  const showInlineHierarchy = isSettingsPanelEverOpened && !showFloatingHierarchy;
+
+  const toggleHierarchyLayout = useCallback((event?: React.MouseEvent) => {
+    event?.stopPropagation();
+    setIsHierarchyFloating((prev) => !prev);
+  }, []);
+
   const hierarchyList = isSettingsPanelEverOpened ? (
     <div
       ref={setRootDroppableRef}
@@ -864,13 +888,43 @@ export default function MasksPanel({
     </div>
   ) : null;
 
+  const hierarchyInlineSection = showInlineHierarchy ? (
+    <motion.div
+      layout
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      className="shrink-0 px-4 pb-2"
+    >
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <p className="text-sm font-semibold text-text-primary">Masks</p>
+        <button
+          className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
+          data-tooltip="Open Hierarchy in Preview"
+          onClick={toggleHierarchyLayout}
+        >
+          <ExternalLink size={16} />
+        </button>
+      </div>
+      <div className="h-[clamp(124px,32vh,320px)] overflow-hidden rounded-xl border border-surface bg-bg-primary/15">
+        {hierarchyList}
+      </div>
+    </motion.div>
+  ) : null;
+
   const hierarchyOverlay =
-    hierarchyList && maskHierarchyOverlayHost
+    hierarchyList && showFloatingHierarchy
       ? createPortal(
-          <FloatingMaskHierarchyWindow setIsMaskControlHovered={setIsMaskControlHovered}>
+          <FloatingMaskHierarchyWindow
+            anchor={floatingHierarchyAnchor}
+            onAnchorChange={setFloatingHierarchyAnchor}
+            onDockToSidebar={() => setIsHierarchyFloating(false)}
+            setIsMaskControlHovered={setIsMaskControlHovered}
+          >
             {hierarchyList}
           </FloatingMaskHierarchyWindow>,
-          maskHierarchyOverlayHost,
+          maskHierarchyOverlayHost!,
         )
       : null;
 
@@ -957,12 +1011,9 @@ export default function MasksPanel({
                 />
               ))}
             </div>
-            {isSettingsPanelEverOpened && (
-              <p className="mt-3 text-xs leading-relaxed text-text-secondary">
-                The mask hierarchy now floats above the preview. Drag its header to snap it to a different corner.
-              </p>
-            )}
           </div>
+
+          {hierarchyInlineSection}
 
           <AnimatePresence>
             {isSettingsPanelEverOpened && (
@@ -1080,21 +1131,22 @@ function NewMaskDropZone({ isOver }: { isOver: boolean }) {
   );
 }
 
-type FloatingHierarchyCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
-
-const FLOATING_HIERARCHY_MARGIN = 16;
-
 function FloatingMaskHierarchyWindow({
+  anchor,
   children,
+  onAnchorChange,
+  onDockToSidebar,
   setIsMaskControlHovered,
 }: {
+  anchor: FloatingHierarchyAnchor;
   children: any;
+  onAnchorChange(anchor: FloatingHierarchyAnchor): void;
+  onDockToSidebar(): void;
   setIsMaskControlHovered(hovered: boolean): void;
 }) {
   const boundsRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const dragControls = useDragControls();
-  const [corner, setCorner] = useState<FloatingHierarchyCorner>('top-right');
   const [targetPosition, setTargetPosition] = useState({ x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN });
   const [isReady, setIsReady] = useState(false);
   const [isWindowDragging, setIsWindowDragging] = useState(false);
@@ -1105,7 +1157,7 @@ function FloatingMaskHierarchyWindow({
     };
   }, [setIsMaskControlHovered]);
 
-  const getCornerPosition = useCallback((targetCorner: FloatingHierarchyCorner) => {
+  const getAnchorPosition = useCallback((targetAnchor: FloatingHierarchyAnchor) => {
     const bounds = boundsRef.current;
     const panel = panelRef.current;
     if (!bounds || !panel) {
@@ -1117,20 +1169,32 @@ function FloatingMaskHierarchyWindow({
       FLOATING_HIERARCHY_MARGIN,
       bounds.clientHeight - panel.offsetHeight - FLOATING_HIERARCHY_MARGIN,
     );
+    const centerY = Math.min(maxY, Math.max(FLOATING_HIERARCHY_MARGIN, (bounds.clientHeight - panel.offsetHeight) / 2));
 
-    return {
-      x: targetCorner.endsWith('right') ? maxX : FLOATING_HIERARCHY_MARGIN,
-      y: targetCorner.startsWith('bottom') ? maxY : FLOATING_HIERARCHY_MARGIN,
-    };
+    switch (targetAnchor) {
+      case 'top-left':
+        return { x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN };
+      case 'top-right':
+        return { x: maxX, y: FLOATING_HIERARCHY_MARGIN };
+      case 'center-left':
+        return { x: FLOATING_HIERARCHY_MARGIN, y: centerY };
+      case 'center-right':
+        return { x: maxX, y: centerY };
+      case 'bottom-left':
+        return { x: FLOATING_HIERARCHY_MARGIN, y: maxY };
+      case 'bottom-right':
+      default:
+        return { x: maxX, y: maxY };
+    }
   }, []);
 
   const syncToCorner = useCallback(
-    (targetCorner: FloatingHierarchyCorner) => {
+    (targetAnchor: FloatingHierarchyAnchor) => {
       if (isWindowDragging) {
         return;
       }
 
-      const nextPosition = getCornerPosition(targetCorner);
+      const nextPosition = getAnchorPosition(targetAnchor);
       if (!nextPosition) {
         return;
       }
@@ -1138,17 +1202,17 @@ function FloatingMaskHierarchyWindow({
       setTargetPosition(nextPosition);
       setIsReady(true);
     },
-    [getCornerPosition, isWindowDragging],
+    [getAnchorPosition, isWindowDragging],
   );
 
   useLayoutEffect(() => {
-    const frame = window.requestAnimationFrame(() => syncToCorner(corner));
+    const frame = window.requestAnimationFrame(() => syncToCorner(anchor));
 
     if (typeof ResizeObserver === 'undefined') {
       return () => window.cancelAnimationFrame(frame);
     }
 
-    const observer = new ResizeObserver(() => syncToCorner(corner));
+    const observer = new ResizeObserver(() => syncToCorner(anchor));
 
     if (boundsRef.current) {
       observer.observe(boundsRef.current);
@@ -1162,7 +1226,7 @@ function FloatingMaskHierarchyWindow({
       window.cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, [corner, syncToCorner]);
+  }, [anchor, syncToCorner]);
 
   const handleDragEnd = useCallback(() => {
     setIsWindowDragging(false);
@@ -1180,10 +1244,8 @@ function FloatingMaskHierarchyWindow({
       y: panelRect.top - boundsRect.top + panelRect.height / 2,
     };
 
-    const corners: FloatingHierarchyCorner[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
-
-    const nearestCorner = corners.reduce((closest, candidate) => {
-      const candidatePosition = getCornerPosition(candidate);
+    const nearestAnchor = FLOATING_HIERARCHY_ANCHORS.reduce((closest, candidate) => {
+      const candidatePosition = getAnchorPosition(candidate);
       if (!candidatePosition) {
         return closest;
       }
@@ -1195,29 +1257,24 @@ function FloatingMaskHierarchyWindow({
       const distance = Math.hypot(candidateCenter.x - currentCenter.x, candidateCenter.y - currentCenter.y);
 
       if (!closest || distance < closest.distance) {
-        return { corner: candidate, distance };
+        return { anchor: candidate, distance };
       }
 
       return closest;
-    }, null as { corner: FloatingHierarchyCorner; distance: number } | null);
+    }, null as { anchor: FloatingHierarchyAnchor; distance: number } | null);
 
-    if (!nearestCorner) {
+    if (!nearestAnchor) {
       return;
     }
 
-    setCorner(nearestCorner.corner);
+    onAnchorChange(nearestAnchor.anchor);
 
-    const snappedPosition = getCornerPosition(nearestCorner.corner);
+    const snappedPosition = getAnchorPosition(nearestAnchor.anchor);
     if (snappedPosition) {
       setTargetPosition(snappedPosition);
       setIsReady(true);
     }
-  }, [getCornerPosition]);
-
-  const cornerLabel = corner
-    .split('-')
-    .map((value) => value.charAt(0).toUpperCase() + value.slice(1))
-    .join(' ');
+  }, [getAnchorPosition, onAnchorChange]);
 
   return (
     <div ref={boundsRef} className="absolute inset-0 pointer-events-none">
@@ -1264,7 +1321,17 @@ function FloatingMaskHierarchyWindow({
               <GripHorizontal size={14} className="text-text-secondary" />
               <span>Mask Hierarchy</span>
             </div>
-            <span className="text-[10px] uppercase tracking-[0.18em] text-text-secondary">{cornerLabel}</span>
+            <button
+              className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
+              data-tooltip="Dock Hierarchy in Sidebar"
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                onDockToSidebar();
+              }}
+            >
+              <ArrowRight size={16} />
+            </button>
           </div>
           <div className="min-h-0 flex-1">{children}</div>
         </div>

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -50,6 +50,7 @@ import Resizer from '../../ui/Resizer';
 
 import {
   Mask,
+  MaskType,
   SubMask,
   MASK_PANEL_CREATION_TYPES,
   OTHERS_MASK_TYPES,
@@ -808,8 +809,36 @@ export default function MasksPanel({
     ]);
   };
 
-  const showFloatingHierarchy = isHierarchyFloating && !!maskHierarchyOverlayHost;
-  const showInlineHierarchy = !showFloatingHierarchy;
+  const handleGridClick = useCallback(
+    (type: Mask | null) => {
+      if (!type) {
+        return;
+      }
+
+      handleAddMaskContainer(type);
+    },
+    [handleAddMaskContainer],
+  );
+
+  const handleAddOthersMask = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+
+      const rect = event.currentTarget.getBoundingClientRect();
+      const options = OTHERS_MASK_TYPES.map((maskType) => ({
+        label: maskType.name,
+        icon: maskType.icon,
+        onClick: () => handleAddMaskContainer(maskType.type),
+      }));
+
+      showContextMenu(rect.left, rect.bottom + 5, options);
+    },
+    [handleAddMaskContainer, showContextMenu],
+  );
+
+  const hasMasks = adjustments.masks.length > 0;
+  const showFloatingHierarchy = hasMasks && isHierarchyFloating && !!maskHierarchyOverlayHost;
+  const showInlineHierarchy = hasMasks && !showFloatingHierarchy;
 
   const toggleHierarchyLayout = useCallback((event?: React.MouseEvent) => {
     event?.stopPropagation();
@@ -923,6 +952,34 @@ export default function MasksPanel({
       )
     : null;
 
+  const emptyMaskCreationSection = !hasMasks ? (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2, ease: 'easeOut' }}
+      className="shrink-0 px-4 pb-2 pt-4"
+    >
+      <p className="mb-3 text-sm font-semibold text-text-primary">Create New Mask</p>
+      <div className="grid grid-cols-3 gap-2" onClick={(event) => event.stopPropagation()}>
+        {MASK_PANEL_CREATION_TYPES.map((maskType: MaskType) => (
+          <MaskCreationGridItem
+            key={maskType.type || maskType.id}
+            maskType={maskType}
+            onClick={(event) => {
+              if (maskType.id === 'others') {
+                handleAddOthersMask(event);
+                return;
+              }
+
+              handleGridClick(maskType.type);
+            }}
+          />
+        ))}
+      </div>
+    </motion.div>
+  ) : null;
+
   return (
     <DndContext
       sensors={sensors}
@@ -988,6 +1045,7 @@ export default function MasksPanel({
         </AnimatePresence>
 
         <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col min-h-0">
+          {emptyMaskCreationSection}
           {hierarchyInlineSection}
 
           <AnimatePresence>
@@ -1069,6 +1127,37 @@ export default function MasksPanel({
         ) : null}
       </DragOverlay>
     </DndContext>
+  );
+}
+
+function MaskCreationGridItem({
+  maskType,
+  onClick,
+}: {
+  maskType: MaskType;
+  onClick(event: React.MouseEvent<HTMLButtonElement>): void;
+}) {
+  const tooltip = maskType.disabled
+    ? 'Coming Soon'
+    : maskType.id === 'others'
+      ? 'Show More Mask Types'
+      : `Create New ${maskType.name} Mask`;
+
+  return (
+    <button
+      type="button"
+      disabled={maskType.disabled}
+      onClick={onClick}
+      className={clsx(
+        'aspect-square rounded-lg bg-surface p-2 text-text-primary transition-colors',
+        'flex flex-col items-center justify-center gap-1.5',
+        maskType.disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-card-active active:bg-accent/20',
+      )}
+      data-tooltip={tooltip}
+    >
+      <maskType.icon size={24} />
+      <span className="text-xs">{maskType.name}</span>
+    </button>
   );
 }
 

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -1574,7 +1574,7 @@ function ContainerRow({
         {...listeners}
         {...attributes}
         className={`flex items-center gap-2 p-2 rounded-md transition-colors group
-             ${isSelected ? 'bg-surface' : 'hover:bg-card-active'}
+             ${isSelected ? 'bg-card-active ring-1 ring-inset ring-border-color/60' : 'hover:bg-surface'}
              ${borderClass}`}
         onClick={(e) => {
           e.stopPropagation();
@@ -1798,7 +1798,7 @@ function SubMaskRow({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       className={`flex items-center gap-2 p-2 rounded-md transition-colors group mt-0.5 cursor-pointer
-            ${isActive ? 'bg-surface' : 'hover:bg-card-active'}
+            ${isActive ? 'bg-card-active ring-1 ring-inset ring-border-color/60' : 'hover:bg-surface'}
             ${isOver && !isDraggingContainer ? 'border-t-2 border-accent' : ''}
             ${isDragging ? 'opacity-40 z-50' : ''}
             ${parentVisible === false ? 'opacity-50' : ''}

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -98,6 +98,8 @@ interface MasksPanelProps {
   setCopiedMask(mask: MaskContainer): void;
   setCustomEscapeHandler(handler: any): void;
   setIsMaskControlHovered(hovered: boolean): void;
+  isMaskOverlayEnabled: boolean;
+  setIsMaskOverlayEnabled(enabled: boolean): void;
   maskHierarchyOverlayHost?: HTMLDivElement | null;
   onDragStateChange?: (isDragging: boolean) => void;
   isWaveformVisible?: boolean;
@@ -278,6 +280,8 @@ export default function MasksPanel({
   setCopiedMask,
   setCustomEscapeHandler,
   setIsMaskControlHovered,
+  isMaskOverlayEnabled,
+  setIsMaskOverlayEnabled,
   maskHierarchyOverlayHost,
   onDragStateChange,
   isWaveformVisible,
@@ -845,6 +849,14 @@ export default function MasksPanel({
     setIsHierarchyFloating((prev) => !prev);
   }, []);
 
+  const toggleMaskOverlay = useCallback(
+    (event?: React.MouseEvent) => {
+      event?.stopPropagation();
+      setIsMaskOverlayEnabled(!isMaskOverlayEnabled);
+    },
+    [isMaskOverlayEnabled, setIsMaskOverlayEnabled],
+  );
+
   const hierarchyList = (isFloating: boolean) => (
     <div
       ref={setRootDroppableRef}
@@ -926,13 +938,25 @@ export default function MasksPanel({
     >
       <div className="flex items-center justify-between gap-3 px-4 pb-2 pt-4">
         <p className="text-sm font-semibold text-text-primary">Masks</p>
-        <button
-          className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
-          data-tooltip="Open Hierarchy in Preview"
-          onClick={toggleHierarchyLayout}
-        >
-          <ExternalLink size={16} />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            className={clsx(
+              'rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary',
+              isMaskOverlayEnabled && 'bg-surface text-text-primary',
+            )}
+            data-tooltip={isMaskOverlayEnabled ? 'Hide Mask Overlay' : 'Show Mask Overlay'}
+            onClick={toggleMaskOverlay}
+          >
+            {isMaskOverlayEnabled ? <Eye size={16} /> : <EyeOff size={16} />}
+          </button>
+          <button
+            className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
+            data-tooltip="Open Hierarchy in Preview"
+            onClick={toggleHierarchyLayout}
+          >
+            <ExternalLink size={16} />
+          </button>
+        </div>
       </div>
       {hierarchyList(false)}
     </motion.div>
@@ -942,8 +966,10 @@ export default function MasksPanel({
     ? createPortal(
         <FloatingMaskHierarchyWindow
           anchor={floatingHierarchyAnchor}
+          isMaskOverlayEnabled={isMaskOverlayEnabled}
           onAnchorChange={setFloatingHierarchyAnchor}
           onDockToSidebar={() => setIsHierarchyFloating(false)}
+          onToggleMaskOverlay={toggleMaskOverlay}
           setIsMaskControlHovered={setIsMaskControlHovered}
         >
           {hierarchyList(true)}
@@ -1195,14 +1221,18 @@ function HierarchyActionRow({
 function FloatingMaskHierarchyWindow({
   anchor,
   children,
+  isMaskOverlayEnabled,
   onAnchorChange,
   onDockToSidebar,
+  onToggleMaskOverlay,
   setIsMaskControlHovered,
 }: {
   anchor: FloatingHierarchyAnchor;
   children: any;
+  isMaskOverlayEnabled: boolean;
   onAnchorChange(anchor: FloatingHierarchyAnchor): void;
   onDockToSidebar(): void;
+  onToggleMaskOverlay(event?: React.MouseEvent): void;
   setIsMaskControlHovered(hovered: boolean): void;
 }) {
   const boundsRef = useRef<HTMLDivElement | null>(null);
@@ -1492,17 +1522,33 @@ function FloatingMaskHierarchyWindow({
               <GripHorizontal size={14} className="text-text-secondary" />
               <span>Mask Hierarchy</span>
             </div>
-            <button
-              className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
-              data-tooltip="Dock Hierarchy in Sidebar"
-              onPointerDown={(event) => event.stopPropagation()}
-              onClick={(event) => {
-                event.stopPropagation();
-                onDockToSidebar();
-              }}
-            >
-              <ArrowRight size={16} />
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                className={clsx(
+                  'rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary',
+                  isMaskOverlayEnabled && 'bg-surface text-text-primary',
+                )}
+                data-tooltip={isMaskOverlayEnabled ? 'Hide Mask Overlay' : 'Show Mask Overlay'}
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onToggleMaskOverlay(event);
+                }}
+              >
+                {isMaskOverlayEnabled ? <Eye size={16} /> : <EyeOff size={16} />}
+              </button>
+              <button
+                className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
+                data-tooltip="Dock Hierarchy in Sidebar"
+                onPointerDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDockToSidebar();
+                }}
+              >
+                <ArrowRight size={16} />
+              </button>
+            </div>
           </div>
           <div className="min-h-0 flex-1">{children}</div>
         </div>

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -117,6 +117,9 @@ interface DragData {
 type FloatingHierarchyAnchor = 'top-left' | 'top-right' | 'center-left' | 'center-right' | 'bottom-left' | 'bottom-right';
 
 const FLOATING_HIERARCHY_MARGIN = 16;
+const FLOATING_HIERARCHY_DEFAULT_WIDTH = 340;
+const FLOATING_HIERARCHY_MIN_WIDTH = 260;
+const FLOATING_HIERARCHY_MAX_WIDTH = 640;
 const FLOATING_HIERARCHY_ANCHORS: FloatingHierarchyAnchor[] = [
   'top-left',
   'top-right',
@@ -1055,8 +1058,11 @@ function FloatingMaskHierarchyWindow({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const dragControls = useDragControls();
   const [targetPosition, setTargetPosition] = useState({ x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN });
+  const [floatingWidth, setFloatingWidth] = useState(FLOATING_HIERARCHY_DEFAULT_WIDTH);
   const [isReady, setIsReady] = useState(false);
   const [isWindowDragging, setIsWindowDragging] = useState(false);
+  const [isWindowResizing, setIsWindowResizing] = useState(false);
+  const isRightAnchored = anchor.endsWith('right');
 
   useEffect(() => {
     return () => {
@@ -1183,6 +1189,47 @@ function FloatingMaskHierarchyWindow({
     }
   }, [getAnchorPosition, onAnchorChange]);
 
+  const handleResizeStart = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+
+      const panel = panelRef.current;
+      const bounds = boundsRef.current;
+      if (!panel || !bounds) {
+        return;
+      }
+
+      const startX = event.clientX;
+      const startWidth = panel.offsetWidth;
+      const maxAllowedWidth = Math.max(
+        FLOATING_HIERARCHY_MIN_WIDTH,
+        Math.min(FLOATING_HIERARCHY_MAX_WIDTH, bounds.clientWidth - FLOATING_HIERARCHY_MARGIN * 2),
+      );
+      const resizeDirection = isRightAnchored ? -1 : 1;
+
+      setIsWindowResizing(true);
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        const nextWidth = Math.max(
+          FLOATING_HIERARCHY_MIN_WIDTH,
+          Math.min(maxAllowedWidth, startWidth + (moveEvent.clientX - startX) * resizeDirection),
+        );
+        setFloatingWidth(nextWidth);
+      };
+
+      const handleMouseUp = () => {
+        setIsWindowResizing(false);
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [isRightAnchored],
+  );
+
   return (
     <div ref={boundsRef} className="absolute inset-0 pointer-events-none">
       <motion.div
@@ -1197,7 +1244,7 @@ function FloatingMaskHierarchyWindow({
         onDragEnd={handleDragEnd}
         animate={isReady ? { x: targetPosition.x, y: targetPosition.y, opacity: 1, scale: 1 } : { opacity: 0 }}
         transition={
-          isWindowDragging
+          isWindowDragging || isWindowResizing
             ? { duration: 0 }
             : {
                 type: 'spring',
@@ -1208,7 +1255,9 @@ function FloatingMaskHierarchyWindow({
         }
         className="absolute left-0 top-0 pointer-events-auto"
         style={{
-          width: 'min(340px, calc(100% - 32px))',
+          width: floatingWidth,
+          minWidth: FLOATING_HIERARCHY_MIN_WIDTH,
+          maxWidth: 'calc(100% - 32px)',
           maxHeight: 'min(520px, calc(100% - 32px))',
         }}
         onMouseEnter={() => setIsMaskControlHovered(true)}
@@ -1217,6 +1266,13 @@ function FloatingMaskHierarchyWindow({
         onContextMenu={(event) => event.stopPropagation()}
       >
         <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-bg-secondary shadow-2xl">
+          <div
+            className={clsx(
+              'absolute bottom-0 top-0 z-10 w-2 cursor-col-resize transition-colors hover:bg-surface/80',
+              isRightAnchored ? 'left-0' : 'right-0',
+            )}
+            onMouseDown={handleResizeStart}
+          />
           <div
             className="flex cursor-grab items-center justify-between gap-3 border-b border-surface px-3 py-2 active:cursor-grabbing"
             onPointerDown={(event) => {

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -1189,6 +1189,24 @@ function FloatingMaskHierarchyWindow({
     };
   }, [anchor, syncToCorner]);
 
+  useEffect(() => {
+    if (!isReady) {
+      return;
+    }
+
+    let settleFrame = 0;
+    const frame = window.requestAnimationFrame(() => {
+      settleFrame = window.requestAnimationFrame(() => {
+        skipInitialPositionAnimationRef.current = false;
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      window.cancelAnimationFrame(settleFrame);
+    };
+  }, [isReady]);
+
   useLayoutEffect(() => {
     if (!isReady) {
       animationControls.set({ opacity: 0 });
@@ -1204,7 +1222,6 @@ function FloatingMaskHierarchyWindow({
 
     if (skipInitialPositionAnimationRef.current) {
       animationControls.set(nextAnimation);
-      skipInitialPositionAnimationRef.current = false;
       return;
     }
 

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -120,6 +120,8 @@ const FLOATING_HIERARCHY_MARGIN = 16;
 const FLOATING_HIERARCHY_DEFAULT_WIDTH = 340;
 const FLOATING_HIERARCHY_MIN_WIDTH = 260;
 const FLOATING_HIERARCHY_MAX_WIDTH = 640;
+const MASK_HIERARCHY_LAYOUT_STORAGE_KEY = 'rapidraw-mask-hierarchy-layout';
+const MASK_HIERARCHY_ANCHOR_STORAGE_KEY = 'rapidraw-mask-hierarchy-anchor';
 const FLOATING_HIERARCHY_ANCHORS: FloatingHierarchyAnchor[] = [
   'top-left',
   'top-right',
@@ -132,6 +134,31 @@ const HIERARCHY_CREATION_TYPES = [
   ...MASK_PANEL_CREATION_TYPES.filter((maskType) => maskType.id !== 'others'),
   ...OTHERS_MASK_TYPES,
 ];
+
+const getStoredHierarchyLayout = () => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return window.localStorage.getItem(MASK_HIERARCHY_LAYOUT_STORAGE_KEY) === 'floating';
+  } catch {
+    return false;
+  }
+};
+
+const getStoredHierarchyAnchor = (): FloatingHierarchyAnchor => {
+  if (typeof window === 'undefined') {
+    return 'top-right';
+  }
+
+  try {
+    const storedAnchor = window.localStorage.getItem(MASK_HIERARCHY_ANCHOR_STORAGE_KEY) as FloatingHierarchyAnchor | null;
+    return storedAnchor && FLOATING_HIERARCHY_ANCHORS.includes(storedAnchor) ? storedAnchor : 'top-right';
+  } catch {
+    return 'top-right';
+  }
+};
 
 const SUB_MASK_CONFIG: Record<Mask, any> = {
   [Mask.Radial]: {
@@ -257,8 +284,8 @@ export default function MasksPanel({
   const [copiedSectionAdjustments, setCopiedSectionAdjustments] = useState<any | null>(null);
   const [isSettingsSectionOpen, setSettingsSectionOpen] = useState(true);
   const [isSettingsPanelEverOpened, setIsSettingsPanelEverOpened] = useState(false);
-  const [isHierarchyFloating, setIsHierarchyFloating] = useState(false);
-  const [floatingHierarchyAnchor, setFloatingHierarchyAnchor] = useState<FloatingHierarchyAnchor>('top-right');
+  const [isHierarchyFloating, setIsHierarchyFloating] = useState(getStoredHierarchyLayout);
+  const [floatingHierarchyAnchor, setFloatingHierarchyAnchor] = useState<FloatingHierarchyAnchor>(getStoredHierarchyAnchor);
   const hasPerformedInitialSelection = useRef(false);
   const [analyzingSubMaskId, setAnalyzingSubMaskId] = useState<string | null>(null);
   const [isResizingWaveform, setIsResizingWaveform] = useState<boolean>(false);
@@ -338,6 +365,25 @@ export default function MasksPanel({
     else setCustomEscapeHandler(null);
     return () => setCustomEscapeHandler(null);
   }, [activeMaskContainerId, activeMaskId, renamingId, onSelectContainer, onSelectMask, setCustomEscapeHandler]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(
+        MASK_HIERARCHY_LAYOUT_STORAGE_KEY,
+        isHierarchyFloating ? 'floating' : 'docked',
+      );
+    } catch {
+      // Ignore storage failures and keep the session state in memory.
+    }
+  }, [isHierarchyFloating]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(MASK_HIERARCHY_ANCHOR_STORAGE_KEY, floatingHierarchyAnchor);
+    } catch {
+      // Ignore storage failures and keep the session state in memory.
+    }
+  }, [floatingHierarchyAnchor]);
 
   const handleWaveformResize = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -752,20 +798,20 @@ export default function MasksPanel({
     setIsHierarchyFloating((prev) => !prev);
   }, []);
 
-  const hierarchyList = (
+  const hierarchyList = (isFloating: boolean) => (
     <div
       ref={setRootDroppableRef}
       className={clsx(
         'flex flex-col transition-colors',
-        showFloatingHierarchy && 'h-full min-h-0',
-        isRootOver ? 'bg-bg-tertiary/65' : 'bg-transparent',
+        isFloating && 'h-full min-h-0',
+        !isFloating && 'px-4 pb-2',
+        isRootOver && (isFloating ? 'bg-bg-tertiary/65' : 'rounded-lg bg-bg-tertiary/40'),
       )}
       onClick={(e) => e.stopPropagation()}
     >
       <div
         className={clsx(
-          'px-3 py-3',
-          showFloatingHierarchy && 'flex-1 overflow-y-auto overflow-x-hidden',
+          isFloating ? 'flex-1 overflow-y-auto overflow-x-hidden px-3 py-3' : 'flex flex-col',
         )}
       >
         <AnimatePresence initial={false} mode="popLayout">
@@ -824,14 +870,13 @@ export default function MasksPanel({
 
   const hierarchyInlineSection = showInlineHierarchy ? (
     <motion.div
-      layout
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className="shrink-0 p-4 pb-2"
+      className="shrink-0"
     >
-      <div className="mb-3 flex items-center justify-between gap-3">
+      <div className="flex items-center justify-between gap-3 px-4 pb-2 pt-4">
         <p className="text-sm font-semibold text-text-primary">Masks</p>
         <button
           className="rounded-full p-2 text-text-secondary transition-colors hover:bg-surface hover:text-text-primary"
@@ -841,9 +886,7 @@ export default function MasksPanel({
           <ExternalLink size={16} />
         </button>
       </div>
-      <div className="rounded-xl border border-surface bg-bg-primary/15">
-        {hierarchyList}
-      </div>
+      {hierarchyList(false)}
     </motion.div>
   ) : null;
 
@@ -855,7 +898,7 @@ export default function MasksPanel({
           onDockToSidebar={() => setIsHierarchyFloating(false)}
           setIsMaskControlHovered={setIsMaskControlHovered}
         >
-          {hierarchyList}
+          {hierarchyList(true)}
         </FloatingMaskHierarchyWindow>,
         maskHierarchyOverlayHost!,
       )

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -50,14 +50,12 @@ import Resizer from '../../ui/Resizer';
 
 import {
   Mask,
-  MaskType,
   SubMask,
   MASK_PANEL_CREATION_TYPES,
   OTHERS_MASK_TYPES,
   MASK_ICON_MAP,
   SubMaskMode,
   ToolType,
-  formatMaskTypeName,
   getSubMaskName,
 } from './Masks';
 import {
@@ -111,9 +109,8 @@ interface MasksPanelProps {
 }
 
 interface DragData {
-  type: 'Container' | 'SubMask' | 'Creation';
+  type: 'Container' | 'SubMask';
   item?: MaskContainer | SubMask;
-  maskType?: Mask;
   parentId?: string;
 }
 
@@ -127,6 +124,10 @@ const FLOATING_HIERARCHY_ANCHORS: FloatingHierarchyAnchor[] = [
   'center-right',
   'bottom-left',
   'bottom-right',
+];
+const HIERARCHY_CREATION_TYPES = [
+  ...MASK_PANEL_CREATION_TYPES.filter((maskType) => maskType.id !== 'others'),
+  ...OTHERS_MASK_TYPES,
 ];
 
 const SUB_MASK_CONFIG: Record<Mask, any> = {
@@ -256,8 +257,6 @@ export default function MasksPanel({
   const [isHierarchyFloating, setIsHierarchyFloating] = useState(false);
   const [floatingHierarchyAnchor, setFloatingHierarchyAnchor] = useState<FloatingHierarchyAnchor>('top-right');
   const hasPerformedInitialSelection = useRef(false);
-  const [isMaskListEmpty, setIsMaskListEmpty] = useState(adjustments.masks.length === 0);
-  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
   const [analyzingSubMaskId, setAnalyzingSubMaskId] = useState<string | null>(null);
   const [isResizingWaveform, setIsResizingWaveform] = useState<boolean>(false);
 
@@ -296,10 +295,6 @@ export default function MasksPanel({
   }, [adjustments.masks, activeMaskContainerId, onSelectContainer, onSelectMask]);
 
   useEffect(() => {
-    if (adjustments.masks.length > 0) {
-      setIsMaskListEmpty(false);
-    }
-
     if (!hasPerformedInitialSelection.current && !activeMaskContainerId && adjustments.masks.length > 0) {
       const lastMask = adjustments.masks[adjustments.masks.length - 1];
       if (lastMask) {
@@ -416,9 +411,6 @@ export default function MasksPanel({
   };
 
   const handleAddMaskContainer = (type: Mask) => {
-    if (adjustments.masks.length === 0) {
-      setIsMaskListEmpty(false);
-    }
     const subMask = createMaskLogic(type);
     const newContainer = {
       ...INITIAL_MASK_CONTAINER,
@@ -458,29 +450,18 @@ export default function MasksPanel({
     else if (type === Mask.AiSky) onGenerateAiSkyMask(subMask.id);
   };
 
-  const handleGridClick = (type: Mask, forceNewMaskContainer: boolean = false) => {
-    if (!forceNewMaskContainer && activeMaskContainerId) handleAddSubMask(activeMaskContainerId, type);
-    else handleAddMaskContainer(type);
-  };
-
-  const handleGridRightClick = (event: React.MouseEvent, type: Mask | null) => {
-    if (event.button !== 2) return;
-    event.preventDefault();
-    event.stopPropagation();
-    if (!type) return;
-    handleGridClick(type, true);
-  };
-
-  const handleAddOthersMask = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
-    const options = OTHERS_MASK_TYPES.map((maskType) => ({
-      label: maskType.name,
-      icon: maskType.icon,
-      onClick: () => handleGridClick(maskType.type),
-      onRightClick: () => handleGridClick(maskType.type, true),
-    }));
-    showContextMenu(rect.left, rect.bottom + 5, options);
+  const openMaskCreationMenu = (target: HTMLElement, onSelect: (type: Mask) => void) => {
+    const rect = target.getBoundingClientRect();
+    showContextMenu(
+      rect.left,
+      rect.bottom + 5,
+      HIERARCHY_CREATION_TYPES.map((maskType) => ({
+        label: maskType.name,
+        icon: maskType.icon,
+        disabled: maskType.disabled,
+        onClick: () => onSelect(maskType.type),
+      })),
+    );
   };
 
   const updateContainer = (id: string, data: any) =>
@@ -548,10 +529,6 @@ export default function MasksPanel({
   };
 
   const insertMaskContainer = (container: MaskContainer, insertIndex?: number) => {
-    if (adjustments.masks.length === 0) {
-      setIsMaskListEmpty(false);
-    }
-
     setAdjustments((prev: Adjustments) => {
       const newMasks = [...(prev.masks || [])];
       const targetIndex = Math.max(0, Math.min(insertIndex ?? newMasks.length, newMasks.length));
@@ -649,32 +626,6 @@ export default function MasksPanel({
     const dragData = active.data.current as DragData;
     const overData = over?.data.current as DragData;
 
-    if (dragData.type === 'Creation' && dragData.maskType) {
-      const creationFn = () => {
-        if (overData?.type === 'Container') {
-          handleAddSubMask(overData.item!.id, dragData.maskType);
-        } else if (overData?.type === 'SubMask') {
-          const container = adjustments.masks.find((m) => m.id === overData.parentId);
-          if (container) {
-            const targetIndex = container.subMasks.findIndex((sm) => sm.id === over.id);
-            handleAddSubMask(overData.parentId!, dragData.maskType, targetIndex);
-          }
-        } else {
-          handleAddMaskContainer(dragData.maskType);
-        }
-      };
-
-      if (!isMaskListEmpty) {
-        setPendingAction(() => creationFn);
-      } else {
-        creationFn();
-      }
-
-      setActiveDragItem(null);
-      if (onDragStateChange) onDragStateChange(false);
-      return;
-    }
-
     setActiveDragItem(null);
     if (onDragStateChange) onDragStateChange(false);
 
@@ -717,9 +668,6 @@ export default function MasksPanel({
           const subMaskIndex = sourceContainer.subMasks.findIndex((sm: SubMask) => sm.id === dragData.item!.id);
           if (subMaskIndex === -1) return prev;
           const [movedSubMask] = sourceContainer.subMasks.splice(subMaskIndex, 1);
-          if (adjustments.masks.length === 0) {
-            setIsMaskListEmpty(false);
-          }
           const newContainer = {
             ...INITIAL_MASK_CONTAINER,
             id: uuidv4(),
@@ -781,10 +729,10 @@ export default function MasksPanel({
 
   const handlePanelContextMenu = (e: React.MouseEvent) => {
     e.preventDefault();
-    const allTypes = [...MASK_PANEL_CREATION_TYPES.filter((m) => m.id !== 'others'), ...OTHERS_MASK_TYPES];
-    const newMaskSubMenu = allTypes.map((m) => ({
+    const newMaskSubMenu = HIERARCHY_CREATION_TYPES.map((m) => ({
       label: m.name,
       icon: m.icon,
+      disabled: m.disabled,
       onClick: () => handleAddMaskContainer(m.type),
     }));
     showContextMenu(e.clientX, e.clientY, [
@@ -794,14 +742,14 @@ export default function MasksPanel({
   };
 
   const showFloatingHierarchy = isHierarchyFloating && !!maskHierarchyOverlayHost;
-  const showInlineHierarchy = isSettingsPanelEverOpened && !showFloatingHierarchy;
+  const showInlineHierarchy = !showFloatingHierarchy;
 
   const toggleHierarchyLayout = useCallback((event?: React.MouseEvent) => {
     event?.stopPropagation();
     setIsHierarchyFloating((prev) => !prev);
   }, []);
 
-  const hierarchyList = isSettingsPanelEverOpened ? (
+  const hierarchyList = (
     <div
       ref={setRootDroppableRef}
       className={clsx(
@@ -811,82 +759,59 @@ export default function MasksPanel({
       onClick={(e) => e.stopPropagation()}
     >
       <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-3">
-        <AnimatePresence
-          initial={false}
-          mode="popLayout"
-          onExitComplete={() => {
-            if (adjustments.masks.length === 0) {
-              setIsMaskListEmpty(true);
-            }
-          }}
-        >
-          {isMaskListEmpty ? (
-            <motion.div
-              key="empty-masks-placeholder"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="py-4 text-center text-sm text-text-secondary opacity-70"
-            >
-              No masks created.
-            </motion.div>
-          ) : (
-            adjustments.masks.map((container) => (
-              <ContainerRow
-                key={container.id}
-                container={container}
-                isSelected={activeMaskContainerId === container.id && activeMaskId === null}
-                hasActiveChild={activeMaskContainerId === container.id && activeMaskId !== null}
-                isExpanded={expandedContainers.has(container.id)}
-                onToggle={() => handleToggleExpand(container.id)}
-                onSelect={() => {
-                  onSelectContainer(container.id);
-                  onSelectMask(null);
-                }}
-                renamingId={renamingId}
-                setRenamingId={setRenamingId}
-                tempName={tempName}
-                setTempName={setTempName}
-                updateContainer={updateContainer}
-                handleDelete={handleDeleteContainer}
-                handleDuplicate={handleDuplicateContainer}
-                handleDuplicateAndInvert={handleDuplicateAndInvertContainer}
-                handlePasteMask={handlePasteMask}
-                copyMaskToClipboard={copyMaskToClipboard}
-                copiedMask={copiedMask}
-                presets={presets}
-                setAdjustments={setAdjustments}
-                activeDragItem={activeDragItem}
-                activeMaskId={activeMaskId}
-                onSelectContainer={onSelectContainer}
-                onSelectMask={onSelectMask}
-                updateSubMask={updateSubMask}
-                handleDeleteSubMask={handleDeleteSubMask}
-                handleDuplicateSubMask={handleDuplicateSubMask}
-                handleDuplicateAndInvertSubMask={handleDuplicateAndInvertSubMask}
-                handlePasteSubMask={handlePasteSubMask}
-                copySubMaskToClipboard={copySubMaskToClipboard}
-                copiedSubMask={copiedSubMask}
-                analyzingSubMaskId={analyzingSubMaskId}
-                setIsMaskControlHovered={setIsMaskControlHovered}
-              />
-            ))
-          )}
+        <AnimatePresence initial={false} mode="popLayout">
+          {adjustments.masks.map((container) => (
+            <ContainerRow
+              key={container.id}
+              container={container}
+              isSelected={activeMaskContainerId === container.id && activeMaskId === null}
+              hasActiveChild={activeMaskContainerId === container.id && activeMaskId !== null}
+              isExpanded={expandedContainers.has(container.id)}
+              onToggle={() => handleToggleExpand(container.id)}
+              onSelect={() => {
+                onSelectContainer(container.id);
+                onSelectMask(null);
+              }}
+              renamingId={renamingId}
+              setRenamingId={setRenamingId}
+              tempName={tempName}
+              setTempName={setTempName}
+              updateContainer={updateContainer}
+              handleDelete={handleDeleteContainer}
+              handleDuplicate={handleDuplicateContainer}
+              handleDuplicateAndInvert={handleDuplicateAndInvertContainer}
+              handlePasteMask={handlePasteMask}
+              copyMaskToClipboard={copyMaskToClipboard}
+              copiedMask={copiedMask}
+              presets={presets}
+              setAdjustments={setAdjustments}
+              activeDragItem={activeDragItem}
+              activeMaskId={activeMaskId}
+              onSelectContainer={onSelectContainer}
+              onSelectMask={onSelectMask}
+              updateSubMask={updateSubMask}
+              handleDeleteSubMask={handleDeleteSubMask}
+              handleDuplicateSubMask={handleDuplicateSubMask}
+              handleDuplicateAndInvertSubMask={handleDuplicateAndInvertSubMask}
+              handlePasteSubMask={handlePasteSubMask}
+              copySubMaskToClipboard={copySubMaskToClipboard}
+              copiedSubMask={copiedSubMask}
+              analyzingSubMaskId={analyzingSubMaskId}
+              setIsMaskControlHovered={setIsMaskControlHovered}
+              onOpenCreateSubMaskMenu={(containerId: string, target: HTMLElement) =>
+                openMaskCreationMenu(target, (type) => handleAddSubMask(containerId, type))
+              }
+            />
+          ))}
         </AnimatePresence>
-
-        <AnimatePresence
-          onExitComplete={() => {
-            if (pendingAction) {
-              pendingAction();
-              setPendingAction(null);
-            }
-          }}
-        >
-          {activeDragItem?.type === 'Creation' && !isMaskListEmpty && <NewMaskDropZone isOver={isRootOver} />}
-        </AnimatePresence>
+        <HierarchyActionRow
+          label="Add New Mask"
+          onOpenMenu={(target) => openMaskCreationMenu(target, handleAddMaskContainer)}
+          className="mt-2"
+        />
       </div>
     </div>
-  ) : null;
+  );
 
   const hierarchyInlineSection = showInlineHierarchy ? (
     <motion.div
@@ -913,20 +838,19 @@ export default function MasksPanel({
     </motion.div>
   ) : null;
 
-  const hierarchyOverlay =
-    hierarchyList && showFloatingHierarchy
-      ? createPortal(
-          <FloatingMaskHierarchyWindow
-            anchor={floatingHierarchyAnchor}
-            onAnchorChange={setFloatingHierarchyAnchor}
-            onDockToSidebar={() => setIsHierarchyFloating(false)}
-            setIsMaskControlHovered={setIsMaskControlHovered}
-          >
-            {hierarchyList}
-          </FloatingMaskHierarchyWindow>,
-          maskHierarchyOverlayHost!,
-        )
-      : null;
+  const hierarchyOverlay = showFloatingHierarchy
+    ? createPortal(
+        <FloatingMaskHierarchyWindow
+          anchor={floatingHierarchyAnchor}
+          onAnchorChange={setFloatingHierarchyAnchor}
+          onDockToSidebar={() => setIsHierarchyFloating(false)}
+          setIsMaskControlHovered={setIsMaskControlHovered}
+        >
+          {hierarchyList}
+        </FloatingMaskHierarchyWindow>,
+        maskHierarchyOverlayHost!,
+      )
+    : null;
 
   return (
     <DndContext
@@ -993,26 +917,6 @@ export default function MasksPanel({
         </AnimatePresence>
 
         <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col min-h-0">
-          <div className="p-4 pb-2 z-10 shrink-0">
-            <p className="text-sm mb-3 font-semibold text-text-primary">
-              {activeMaskContainerId ? 'Add to Mask' : 'Create New Mask'}
-            </p>
-            <div className="grid grid-cols-3 gap-2" onClick={(e) => e.stopPropagation()}>
-              {MASK_PANEL_CREATION_TYPES.map((maskType: MaskType) => (
-                <DraggableGridItem
-                  key={maskType.type || maskType.id}
-                  maskType={maskType}
-                  onClick={(e: any) =>
-                    maskType.id === 'others' ? handleAddOthersMask(e) : handleGridClick(maskType.type)
-                  }
-                  onRightClick={(e: React.MouseEvent) => handleGridRightClick(e, maskType.type)}
-                  isDraggable={maskType.id !== 'others'}
-                  activeMaskContainerId={activeMaskContainerId}
-                />
-              ))}
-            </div>
-          </div>
-
           {hierarchyInlineSection}
 
           <AnimatePresence>
@@ -1090,25 +994,6 @@ export default function MasksPanel({
                 </div>
               </div>
             )}
-
-            {activeDragItem.type === 'Creation' && (
-              <div className="bg-surface text-text-primary rounded-lg p-2 flex flex-col items-center justify-center gap-1.5 aspect-square w-20 shadow-xl opacity-90">
-                {(() => {
-                  const maskType =
-                    MASK_PANEL_CREATION_TYPES.find((m) => m.type === activeDragItem.maskType) ||
-                    OTHERS_MASK_TYPES.find((m) => m.type === activeDragItem.maskType);
-                  const Icon = maskType?.icon || Circle;
-                  return (
-                    <>
-                      <Icon size={24} />
-                      <span className="text-xs text-center">
-                        {activeDragItem.maskType ? formatMaskTypeName(activeDragItem.maskType) : 'Mask'}
-                      </span>
-                    </>
-                  );
-                })()}
-              </div>
-            )}
           </div>
         ) : null}
       </DragOverlay>
@@ -1116,18 +1001,34 @@ export default function MasksPanel({
   );
 }
 
-function NewMaskDropZone({ isOver }: { isOver: boolean }) {
+function HierarchyActionRow({
+  label,
+  onOpenMenu,
+  className,
+}: {
+  label: string;
+  onOpenMenu(target: HTMLElement): void;
+  className?: string;
+}) {
+  const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onOpenMenu(event.currentTarget);
+  };
+
   return (
-    <motion.div
-      layout
-      initial={{ opacity: 0, height: 0, marginTop: 0 }}
-      animate={{ opacity: 1, height: 'auto', marginTop: '4px' }}
-      exit={{ opacity: 0, height: 0, marginTop: 0 }}
-      transition={{ duration: 0.2, ease: 'easeOut' }}
-      className={`p-4 rounded-lg text-center ${isOver ? 'border border-accent/80 bg-bg-tertiary/50' : ''}`}
+    <button
+      type="button"
+      className={clsx(
+        'flex w-full items-center gap-2 rounded-md p-2 text-sm text-text-secondary transition-colors hover:bg-card-active hover:text-text-primary',
+        className,
+      )}
+      onClick={handleOpenMenu}
+      onContextMenu={handleOpenMenu}
     >
-      <p className="text-sm font-medium text-text-secondary">Drop here to create a new mask</p>
-    </motion.div>
+      <Plus size={16} className="shrink-0" />
+      <span>{label}</span>
+    </button>
   );
 }
 
@@ -1340,45 +1241,6 @@ function FloatingMaskHierarchyWindow({
   );
 }
 
-function DraggableGridItem({ maskType, onClick, onRightClick, isDraggable, activeMaskContainerId }: any) {
-  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
-    id: `create-${maskType.id || maskType.type}`,
-    data: { type: 'Creation', maskType: maskType.type },
-    disabled: !isDraggable,
-  });
-
-  const tooltip = maskType.disabled
-    ? 'Coming Soon'
-    : maskType.id === 'others'
-      ? 'Show More Mask Types'
-      : activeMaskContainerId
-        ? `Add ${maskType.name} to Current Mask or Create New (Right-click)`
-        : `Create New ${maskType.name} Mask`;
-
-  return (
-    <button
-      ref={setNodeRef}
-      {...listeners}
-      {...attributes}
-      disabled={maskType.disabled}
-      onClick={onClick}
-      onContextMenu={(event) => {
-        event.preventDefault();
-        event.stopPropagation();
-      }}
-      onMouseDown={(event) => {
-        if (event.button !== 2) return;
-        onRightClick(event);
-      }}
-      className={`bg-surface text-text-primary rounded-lg p-2 flex flex-col items-center justify-center gap-1.5 aspect-square transition-colors
-                ${maskType.disabled ? 'opacity-50 cursor-not-allowed' : 'hover:bg-card-active active:bg-accent/20'} ${isDragging ? 'opacity-50' : ''}`}
-      data-tooltip={tooltip}
-    >
-      <maskType.icon size={24} /> <span className="text-xs">{maskType.name}</span>
-    </button>
-  );
-}
-
 function ContainerRow({
   container,
   isSelected,
@@ -1412,6 +1274,7 @@ function ContainerRow({
   copiedSubMask,
   analyzingSubMaskId,
   setIsMaskControlHovered,
+  onOpenCreateSubMaskMenu,
 }: any) {
   const { setNodeRef: setDroppableRef, isOver } = useDroppable({
     id: container.id,
@@ -1423,14 +1286,7 @@ function ContainerRow({
     setNodeRef: setDraggableRef,
     isDragging,
   } = useDraggable({ id: container.id, data: { type: 'Container', item: container } });
-  const [isSubMaskListEmpty, setIsSubMaskListEmpty] = useState(container.subMasks.length === 0);
   const { showContextMenu } = useContextMenu();
-
-  useEffect(() => {
-    if (container.subMasks.length > 0 && isSubMaskListEmpty) {
-      setIsSubMaskListEmpty(false);
-    }
-  }, [container.subMasks.length, isSubMaskListEmpty]);
 
   const setCombinedRef = (node: HTMLElement | null) => {
     setDroppableRef(node);
@@ -1520,10 +1376,7 @@ function ContainerRow({
   if (isOver) {
     if (isDraggingContainer) {
       borderClass = 'border-t-2 border-accent';
-    } else if (
-      (activeDragItem?.type === 'SubMask' && activeDragItem?.parentId !== container.id) ||
-      activeDragItem?.type === 'Creation'
-    ) {
+    } else if (activeDragItem?.type === 'SubMask' && activeDragItem?.parentId !== container.id) {
       borderClass = 'bg-card-active border border-accent/50';
     }
   }
@@ -1616,15 +1469,7 @@ function ContainerRow({
             className="overflow-hidden pl-2 border-l border-border-color/20 ml-[15px]"
             layout
           >
-            <AnimatePresence
-              mode="popLayout"
-              initial={false}
-              onExitComplete={() => {
-                if (container.subMasks.length === 0) {
-                  setIsSubMaskListEmpty(true);
-                }
-              }}
-            >
+            <AnimatePresence mode="popLayout" initial={false}>
               {container.subMasks.map((subMask: SubMask, index: number) => (
                 <SubMaskRow
                   key={subMask.id}
@@ -1655,16 +1500,11 @@ function ContainerRow({
                 />
               ))}
             </AnimatePresence>
-            {isSubMaskListEmpty && (
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                className="p-3 text-xs text-text-secondary text-center italic"
-              >
-                No mask components.
-              </motion.div>
-            )}
+            <HierarchyActionRow
+              label="Add New Component"
+              onOpenMenu={(target) => onOpenCreateSubMaskMenu(container.id, target)}
+              className="mt-1"
+            />
           </motion.div>
         )}
       </AnimatePresence>

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -1216,7 +1216,7 @@ function FloatingMaskHierarchyWindow({
         onClick={(event) => event.stopPropagation()}
         onContextMenu={(event) => event.stopPropagation()}
       >
-        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-bg-secondary/92 shadow-2xl backdrop-blur-md">
+        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-bg-secondary shadow-2xl">
           <div
             className="flex cursor-grab items-center justify-between gap-3 border-b border-surface px-3 py-2 active:cursor-grabbing"
             onPointerDown={(event) => {

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -816,7 +816,7 @@ export default function MasksPanel({
         <HierarchyActionRow
           label="Add New Mask"
           onOpenMenu={(target) => openMaskCreationMenu(target, handleAddMaskContainer)}
-          className="mt-2"
+          className={adjustments.masks.length > 0 ? 'mt-2' : undefined}
         />
       </div>
     </div>
@@ -829,7 +829,7 @@ export default function MasksPanel({
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.2, ease: 'easeOut' }}
-      className="shrink-0 px-4 pb-2"
+      className="shrink-0 p-4 pb-2"
     >
       <div className="mb-3 flex items-center justify-between gap-3">
         <p className="text-sm font-semibold text-text-primary">Masks</p>
@@ -1056,6 +1056,7 @@ function FloatingMaskHierarchyWindow({
 }) {
   const boundsRef = useRef<HTMLDivElement | null>(null);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const skipInitialPositionAnimationRef = useRef(true);
   const dragControls = useDragControls();
   const [targetPosition, setTargetPosition] = useState({ x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN });
   const [floatingWidth, setFloatingWidth] = useState(FLOATING_HIERARCHY_DEFAULT_WIDTH);
@@ -1112,17 +1113,21 @@ function FloatingMaskHierarchyWindow({
         return;
       }
 
+      if (!isReady) {
+        skipInitialPositionAnimationRef.current = true;
+      }
+
       setTargetPosition(nextPosition);
       setIsReady(true);
     },
-    [getAnchorPosition, isWindowDragging],
+    [getAnchorPosition, isReady, isWindowDragging],
   );
 
   useLayoutEffect(() => {
-    const frame = window.requestAnimationFrame(() => syncToCorner(anchor));
+    syncToCorner(anchor);
 
     if (typeof ResizeObserver === 'undefined') {
-      return () => window.cancelAnimationFrame(frame);
+      return;
     }
 
     const observer = new ResizeObserver(() => syncToCorner(anchor));
@@ -1136,10 +1141,17 @@ function FloatingMaskHierarchyWindow({
     }
 
     return () => {
-      window.cancelAnimationFrame(frame);
       observer.disconnect();
     };
   }, [anchor, syncToCorner]);
+
+  useEffect(() => {
+    if (!isReady || !skipInitialPositionAnimationRef.current) {
+      return;
+    }
+
+    skipInitialPositionAnimationRef.current = false;
+  }, [isReady, targetPosition.x, targetPosition.y]);
 
   const handleDragEnd = useCallback(() => {
     setIsWindowDragging(false);
@@ -1244,7 +1256,7 @@ function FloatingMaskHierarchyWindow({
         onDragEnd={handleDragEnd}
         animate={isReady ? { x: targetPosition.x, y: targetPosition.y, opacity: 1, scale: 1 } : { opacity: 0 }}
         transition={
-          isWindowDragging || isWindowResizing
+          isWindowDragging || isWindowResizing || skipInitialPositionAnimationRef.current
             ? { duration: 0 }
             : {
                 type: 'spring',

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -753,12 +753,18 @@ export default function MasksPanel({
     <div
       ref={setRootDroppableRef}
       className={clsx(
-        'flex h-full min-h-0 flex-col transition-colors',
+        'flex flex-col transition-colors',
+        showFloatingHierarchy && 'h-full min-h-0',
         isRootOver ? 'bg-bg-tertiary/65' : 'bg-transparent',
       )}
       onClick={(e) => e.stopPropagation()}
     >
-      <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-3">
+      <div
+        className={clsx(
+          'px-3 py-3',
+          showFloatingHierarchy && 'flex-1 overflow-y-auto overflow-x-hidden',
+        )}
+      >
         <AnimatePresence initial={false} mode="popLayout">
           {adjustments.masks.map((container) => (
             <ContainerRow
@@ -832,7 +838,7 @@ export default function MasksPanel({
           <ExternalLink size={16} />
         </button>
       </div>
-      <div className="h-[clamp(124px,32vh,320px)] overflow-hidden rounded-xl border border-surface bg-bg-primary/15">
+      <div className="rounded-xl border border-surface bg-bg-primary/15">
         {hierarchyList}
       </div>
     </motion.div>

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -1383,7 +1383,7 @@ function FloatingMaskHierarchyWindow({
         onClick={(event) => event.stopPropagation()}
         onContextMenu={(event) => event.stopPropagation()}
       >
-        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-bg-secondary shadow-2xl">
+        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-surface">
           <div
             className={clsx(
               'absolute bottom-0 top-0 z-10 w-2 cursor-col-resize transition-colors hover:bg-surface/80',

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -871,6 +871,7 @@ export default function MasksPanel({
               copiedSubMask={copiedSubMask}
               analyzingSubMaskId={analyzingSubMaskId}
               setIsMaskControlHovered={setIsMaskControlHovered}
+              isFloatingHierarchy={isFloating}
               onOpenCreateSubMaskMenu={(containerId: string, target: HTMLElement) =>
                 openMaskCreationMenu(target, (type) => handleAddSubMask(containerId, type))
               }
@@ -1383,7 +1384,7 @@ function FloatingMaskHierarchyWindow({
         onClick={(event) => event.stopPropagation()}
         onContextMenu={(event) => event.stopPropagation()}
       >
-        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-surface">
+        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-border-color/70 bg-surface">
           <div
             className={clsx(
               'absolute bottom-0 top-0 z-10 w-2 cursor-col-resize transition-colors hover:bg-surface/80',
@@ -1392,7 +1393,7 @@ function FloatingMaskHierarchyWindow({
             onMouseDown={handleResizeStart}
           />
           <div
-            className="flex cursor-grab items-center justify-between gap-3 border-b border-surface px-3 py-2 active:cursor-grabbing"
+            className="flex cursor-grab items-center justify-between gap-3 border-b border-border-color/70 px-3 py-2 active:cursor-grabbing"
             onPointerDown={(event) => {
               event.stopPropagation();
               dragControls.start(event);
@@ -1454,6 +1455,7 @@ function ContainerRow({
   copiedSubMask,
   analyzingSubMaskId,
   setIsMaskControlHovered,
+  isFloatingHierarchy,
   onOpenCreateSubMaskMenu,
 }: any) {
   const { setNodeRef: setDroppableRef, isOver } = useDroppable({
@@ -1574,7 +1576,15 @@ function ContainerRow({
         {...listeners}
         {...attributes}
         className={`flex items-center gap-2 p-2 rounded-md transition-colors group
-             ${isSelected ? 'bg-card-active ring-1 ring-inset ring-border-color/60' : 'hover:bg-surface'}
+             ${
+               isFloatingHierarchy
+                 ? isSelected
+                   ? 'bg-card-active ring-1 ring-inset ring-border-color/60 hover:bg-bg-secondary'
+                   : 'hover:bg-bg-secondary'
+                 : isSelected
+                   ? 'bg-surface'
+                   : 'hover:bg-card-active'
+             }
              ${borderClass}`}
         onClick={(e) => {
           e.stopPropagation();
@@ -1677,6 +1687,7 @@ function ContainerRow({
                   tempName={tempName}
                   setTempName={setTempName}
                   setIsMaskControlHovered={setIsMaskControlHovered}
+                  isFloatingHierarchy={isFloatingHierarchy}
                 />
               ))}
             </AnimatePresence>
@@ -1714,6 +1725,7 @@ function SubMaskRow({
   tempName,
   setTempName,
   setIsMaskControlHovered,
+  isFloatingHierarchy,
 }: any) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: subMask.id,
@@ -1798,7 +1810,15 @@ function SubMaskRow({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       className={`flex items-center gap-2 p-2 rounded-md transition-colors group mt-0.5 cursor-pointer
-            ${isActive ? 'bg-card-active ring-1 ring-inset ring-border-color/60' : 'hover:bg-surface'}
+            ${
+              isFloatingHierarchy
+                ? isActive
+                  ? 'bg-card-active ring-1 ring-inset ring-border-color/60 hover:bg-bg-secondary'
+                  : 'hover:bg-bg-secondary'
+                : isActive
+                  ? 'bg-surface'
+                  : 'hover:bg-card-active'
+            }
             ${isOver && !isDraggingContainer ? 'border-t-2 border-accent' : ''}
             ${isDragging ? 'opacity-40 z-50' : ''}
             ${parentVisible === false ? 'opacity-50' : ''}

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react
 import { v4 as uuidv4 } from 'uuid';
 import clsx from 'clsx';
 import { createPortal } from 'react-dom';
-import { motion, AnimatePresence, useDragControls } from 'framer-motion';
+import { motion, AnimatePresence, useDragControls, useAnimation } from 'framer-motion';
 import {
   DndContext,
   DragOverlay,
@@ -1058,6 +1058,7 @@ function FloatingMaskHierarchyWindow({
   const panelRef = useRef<HTMLDivElement | null>(null);
   const skipInitialPositionAnimationRef = useRef(true);
   const dragControls = useDragControls();
+  const animationControls = useAnimation();
   const [targetPosition, setTargetPosition] = useState({ x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN });
   const [floatingWidth, setFloatingWidth] = useState(FLOATING_HIERARCHY_DEFAULT_WIDTH);
   const [isReady, setIsReady] = useState(false);
@@ -1117,7 +1118,7 @@ function FloatingMaskHierarchyWindow({
         skipInitialPositionAnimationRef.current = true;
       }
 
-      setTargetPosition(nextPosition);
+      setTargetPosition((prev) => (prev.x === nextPosition.x && prev.y === nextPosition.y ? prev : nextPosition));
       setIsReady(true);
     },
     [getAnchorPosition, isReady, isWindowDragging],
@@ -1145,13 +1146,41 @@ function FloatingMaskHierarchyWindow({
     };
   }, [anchor, syncToCorner]);
 
-  useEffect(() => {
-    if (!isReady || !skipInitialPositionAnimationRef.current) {
+  useLayoutEffect(() => {
+    if (!isReady) {
+      animationControls.set({ opacity: 0 });
       return;
     }
 
-    skipInitialPositionAnimationRef.current = false;
-  }, [isReady, targetPosition.x, targetPosition.y]);
+    const nextAnimation = {
+      x: targetPosition.x,
+      y: targetPosition.y,
+      opacity: 1,
+      scale: 1,
+    };
+
+    if (skipInitialPositionAnimationRef.current) {
+      animationControls.set(nextAnimation);
+      skipInitialPositionAnimationRef.current = false;
+      return;
+    }
+
+    if (isWindowDragging) {
+      return;
+    }
+
+    void animationControls.start({
+      ...nextAnimation,
+      transition: isWindowResizing
+        ? { duration: 0 }
+        : {
+            type: 'spring',
+            stiffness: 420,
+            damping: 34,
+            mass: 0.8,
+          },
+    });
+  }, [animationControls, isReady, isWindowDragging, isWindowResizing, targetPosition.x, targetPosition.y]);
 
   const handleDragEnd = useCallback(() => {
     setIsWindowDragging(false);
@@ -1196,7 +1225,7 @@ function FloatingMaskHierarchyWindow({
 
     const snappedPosition = getAnchorPosition(nearestAnchor.anchor);
     if (snappedPosition) {
-      setTargetPosition(snappedPosition);
+      setTargetPosition((prev) => (prev.x === snappedPosition.x && prev.y === snappedPosition.y ? prev : snappedPosition));
       setIsReady(true);
     }
   }, [getAnchorPosition, onAnchorChange]);
@@ -1247,6 +1276,7 @@ function FloatingMaskHierarchyWindow({
       <motion.div
         ref={panelRef}
         drag
+        initial={{ opacity: 0 }}
         dragControls={dragControls}
         dragListener={false}
         dragMomentum={false}
@@ -1254,17 +1284,7 @@ function FloatingMaskHierarchyWindow({
         dragConstraints={boundsRef}
         onDragStart={() => setIsWindowDragging(true)}
         onDragEnd={handleDragEnd}
-        animate={isReady ? { x: targetPosition.x, y: targetPosition.y, opacity: 1, scale: 1 } : { opacity: 0 }}
-        transition={
-          isWindowDragging || isWindowResizing || skipInitialPositionAnimationRef.current
-            ? { duration: 0 }
-            : {
-                type: 'spring',
-                stiffness: 420,
-                damping: 34,
-                mass: 0.8,
-              }
-        }
+        animate={animationControls}
         className="absolute left-0 top-0 pointer-events-auto"
         style={{
           width: floatingWidth,

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback, useLayoutEffect } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import clsx from 'clsx';
-import { motion, AnimatePresence } from 'framer-motion';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence, useDragControls } from 'framer-motion';
 import {
   DndContext,
   DragOverlay,
@@ -24,6 +25,7 @@ import {
   FileEdit,
   FolderOpen,
   Folder as FolderIcon,
+  GripHorizontal,
   Loader2,
   Minus,
   Plus,
@@ -95,6 +97,7 @@ interface MasksPanelProps {
   setCopiedMask(mask: MaskContainer): void;
   setCustomEscapeHandler(handler: any): void;
   setIsMaskControlHovered(hovered: boolean): void;
+  maskHierarchyOverlayHost?: HTMLDivElement | null;
   onDragStateChange?: (isDragging: boolean) => void;
   isWaveformVisible?: boolean;
   onToggleWaveform?: () => void;
@@ -211,6 +214,7 @@ export default function MasksPanel({
   setCopiedMask,
   setCustomEscapeHandler,
   setIsMaskControlHovered,
+  maskHierarchyOverlayHost,
   onDragStateChange,
   isWaveformVisible,
   onToggleWaveform,
@@ -773,6 +777,103 @@ export default function MasksPanel({
     ]);
   };
 
+  const hierarchyList = isSettingsPanelEverOpened ? (
+    <div
+      ref={setRootDroppableRef}
+      className={clsx(
+        'flex h-full min-h-0 flex-col transition-colors',
+        isRootOver ? 'bg-bg-tertiary/65' : 'bg-transparent',
+      )}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex-1 overflow-y-auto overflow-x-hidden px-3 py-3">
+        <AnimatePresence
+          initial={false}
+          mode="popLayout"
+          onExitComplete={() => {
+            if (adjustments.masks.length === 0) {
+              setIsMaskListEmpty(true);
+            }
+          }}
+        >
+          {isMaskListEmpty ? (
+            <motion.div
+              key="empty-masks-placeholder"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              className="py-4 text-center text-sm text-text-secondary opacity-70"
+            >
+              No masks created.
+            </motion.div>
+          ) : (
+            adjustments.masks.map((container) => (
+              <ContainerRow
+                key={container.id}
+                container={container}
+                isSelected={activeMaskContainerId === container.id && activeMaskId === null}
+                hasActiveChild={activeMaskContainerId === container.id && activeMaskId !== null}
+                isExpanded={expandedContainers.has(container.id)}
+                onToggle={() => handleToggleExpand(container.id)}
+                onSelect={() => {
+                  onSelectContainer(container.id);
+                  onSelectMask(null);
+                }}
+                renamingId={renamingId}
+                setRenamingId={setRenamingId}
+                tempName={tempName}
+                setTempName={setTempName}
+                updateContainer={updateContainer}
+                handleDelete={handleDeleteContainer}
+                handleDuplicate={handleDuplicateContainer}
+                handleDuplicateAndInvert={handleDuplicateAndInvertContainer}
+                handlePasteMask={handlePasteMask}
+                copyMaskToClipboard={copyMaskToClipboard}
+                copiedMask={copiedMask}
+                presets={presets}
+                setAdjustments={setAdjustments}
+                activeDragItem={activeDragItem}
+                activeMaskId={activeMaskId}
+                onSelectContainer={onSelectContainer}
+                onSelectMask={onSelectMask}
+                updateSubMask={updateSubMask}
+                handleDeleteSubMask={handleDeleteSubMask}
+                handleDuplicateSubMask={handleDuplicateSubMask}
+                handleDuplicateAndInvertSubMask={handleDuplicateAndInvertSubMask}
+                handlePasteSubMask={handlePasteSubMask}
+                copySubMaskToClipboard={copySubMaskToClipboard}
+                copiedSubMask={copiedSubMask}
+                analyzingSubMaskId={analyzingSubMaskId}
+                setIsMaskControlHovered={setIsMaskControlHovered}
+              />
+            ))
+          )}
+        </AnimatePresence>
+
+        <AnimatePresence
+          onExitComplete={() => {
+            if (pendingAction) {
+              pendingAction();
+              setPendingAction(null);
+            }
+          }}
+        >
+          {activeDragItem?.type === 'Creation' && !isMaskListEmpty && <NewMaskDropZone isOver={isRootOver} />}
+        </AnimatePresence>
+      </div>
+    </div>
+  ) : null;
+
+  const hierarchyOverlay =
+    hierarchyList && maskHierarchyOverlayHost
+      ? createPortal(
+          <FloatingMaskHierarchyWindow setIsMaskControlHovered={setIsMaskControlHovered}>
+            {hierarchyList}
+          </FloatingMaskHierarchyWindow>,
+          maskHierarchyOverlayHost,
+        )
+      : null;
+
   return (
     <DndContext
       sensors={sensors}
@@ -856,96 +957,12 @@ export default function MasksPanel({
                 />
               ))}
             </div>
-          </div>
-
-          <AnimatePresence>
             {isSettingsPanelEverOpened && (
-              <motion.div
-                ref={setRootDroppableRef}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-                exit={{ opacity: 0 }}
-                transition={{ duration: 0.2 }}
-                className={`flex-col px-4 pb-2 space-y-1 transition-colors ${isRootOver ? 'bg-surface' : ''}`}
-              >
-                <p className="text-sm my-3 font-semibold text-text-primary">Masks</p>
-
-                <AnimatePresence
-                  initial={false}
-                  mode="popLayout"
-                  onExitComplete={() => {
-                    if (adjustments.masks.length === 0) {
-                      setIsMaskListEmpty(true);
-                    }
-                  }}
-                >
-                  {isMaskListEmpty ? (
-                    <motion.div
-                      key="empty-masks-placeholder"
-                      initial={{ opacity: 0 }}
-                      animate={{ opacity: 1 }}
-                      exit={{ opacity: 0 }}
-                      className="text-center text-text-secondary text-sm py-4 opacity-70"
-                    >
-                      No masks created.
-                    </motion.div>
-                  ) : (
-                    adjustments.masks.map((container) => (
-                      <ContainerRow
-                        key={container.id}
-                        container={container}
-                        isSelected={activeMaskContainerId === container.id && activeMaskId === null}
-                        hasActiveChild={activeMaskContainerId === container.id && activeMaskId !== null}
-                        isExpanded={expandedContainers.has(container.id)}
-                        onToggle={() => handleToggleExpand(container.id)}
-                        onSelect={() => {
-                          onSelectContainer(container.id);
-                          onSelectMask(null);
-                        }}
-                        renamingId={renamingId}
-                        setRenamingId={setRenamingId}
-                        tempName={tempName}
-                        setTempName={setTempName}
-                        updateContainer={updateContainer}
-                        handleDelete={handleDeleteContainer}
-                        handleDuplicate={handleDuplicateContainer}
-                        handleDuplicateAndInvert={handleDuplicateAndInvertContainer}
-                        handlePasteMask={handlePasteMask}
-                        copyMaskToClipboard={copyMaskToClipboard}
-                        copiedMask={copiedMask}
-                        presets={presets}
-                        setAdjustments={setAdjustments}
-                        activeDragItem={activeDragItem}
-                        activeMaskId={activeMaskId}
-                        onSelectContainer={onSelectContainer}
-                        onSelectMask={onSelectMask}
-                        updateSubMask={updateSubMask}
-                        handleDeleteSubMask={handleDeleteSubMask}
-                        handleDuplicateSubMask={handleDuplicateSubMask}
-                        handleDuplicateAndInvertSubMask={handleDuplicateAndInvertSubMask}
-                        handlePasteSubMask={handlePasteSubMask}
-                        copySubMaskToClipboard={copySubMaskToClipboard}
-                        copiedSubMask={copiedSubMask}
-                        analyzingSubMaskId={analyzingSubMaskId}
-                        setIsMaskControlHovered={setIsMaskControlHovered}
-                      />
-                    ))
-                  )}
-                </AnimatePresence>
-
-                <AnimatePresence
-                  onExitComplete={() => {
-                    if (pendingAction) {
-                      pendingAction();
-                      setPendingAction(null);
-                    }
-                  }}
-                >
-                  {activeDragItem?.type === 'Creation' && !isMaskListEmpty && <NewMaskDropZone isOver={isRootOver} />}
-                </AnimatePresence>
-              </motion.div>
+              <p className="mt-3 text-xs leading-relaxed text-text-secondary">
+                The mask hierarchy now floats above the preview. Drag its header to snap it to a different corner.
+              </p>
             )}
-          </AnimatePresence>
+          </div>
 
           <AnimatePresence>
             {isSettingsPanelEverOpened && (
@@ -984,6 +1001,8 @@ export default function MasksPanel({
           </AnimatePresence>
         </div>
       </div>
+
+      {hierarchyOverlay}
 
       <DragOverlay dropAnimation={{ duration: 150, easing: 'cubic-bezier(0.18, 0.67, 0.6, 1.22)' }}>
         {activeDragItem ? (
@@ -1058,6 +1077,199 @@ function NewMaskDropZone({ isOver }: { isOver: boolean }) {
     >
       <p className="text-sm font-medium text-text-secondary">Drop here to create a new mask</p>
     </motion.div>
+  );
+}
+
+type FloatingHierarchyCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+const FLOATING_HIERARCHY_MARGIN = 16;
+
+function FloatingMaskHierarchyWindow({
+  children,
+  setIsMaskControlHovered,
+}: {
+  children: any;
+  setIsMaskControlHovered(hovered: boolean): void;
+}) {
+  const boundsRef = useRef<HTMLDivElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+  const dragControls = useDragControls();
+  const [corner, setCorner] = useState<FloatingHierarchyCorner>('top-right');
+  const [targetPosition, setTargetPosition] = useState({ x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN });
+  const [isReady, setIsReady] = useState(false);
+  const [isWindowDragging, setIsWindowDragging] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      setIsMaskControlHovered(false);
+    };
+  }, [setIsMaskControlHovered]);
+
+  const getCornerPosition = useCallback((targetCorner: FloatingHierarchyCorner) => {
+    const bounds = boundsRef.current;
+    const panel = panelRef.current;
+    if (!bounds || !panel) {
+      return null;
+    }
+
+    const maxX = Math.max(FLOATING_HIERARCHY_MARGIN, bounds.clientWidth - panel.offsetWidth - FLOATING_HIERARCHY_MARGIN);
+    const maxY = Math.max(
+      FLOATING_HIERARCHY_MARGIN,
+      bounds.clientHeight - panel.offsetHeight - FLOATING_HIERARCHY_MARGIN,
+    );
+
+    return {
+      x: targetCorner.endsWith('right') ? maxX : FLOATING_HIERARCHY_MARGIN,
+      y: targetCorner.startsWith('bottom') ? maxY : FLOATING_HIERARCHY_MARGIN,
+    };
+  }, []);
+
+  const syncToCorner = useCallback(
+    (targetCorner: FloatingHierarchyCorner) => {
+      if (isWindowDragging) {
+        return;
+      }
+
+      const nextPosition = getCornerPosition(targetCorner);
+      if (!nextPosition) {
+        return;
+      }
+
+      setTargetPosition(nextPosition);
+      setIsReady(true);
+    },
+    [getCornerPosition, isWindowDragging],
+  );
+
+  useLayoutEffect(() => {
+    const frame = window.requestAnimationFrame(() => syncToCorner(corner));
+
+    if (typeof ResizeObserver === 'undefined') {
+      return () => window.cancelAnimationFrame(frame);
+    }
+
+    const observer = new ResizeObserver(() => syncToCorner(corner));
+
+    if (boundsRef.current) {
+      observer.observe(boundsRef.current);
+    }
+
+    if (panelRef.current) {
+      observer.observe(panelRef.current);
+    }
+
+    return () => {
+      window.cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [corner, syncToCorner]);
+
+  const handleDragEnd = useCallback(() => {
+    setIsWindowDragging(false);
+
+    const bounds = boundsRef.current;
+    const panel = panelRef.current;
+    if (!bounds || !panel) {
+      return;
+    }
+
+    const boundsRect = bounds.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    const currentCenter = {
+      x: panelRect.left - boundsRect.left + panelRect.width / 2,
+      y: panelRect.top - boundsRect.top + panelRect.height / 2,
+    };
+
+    const corners: FloatingHierarchyCorner[] = ['top-left', 'top-right', 'bottom-left', 'bottom-right'];
+
+    const nearestCorner = corners.reduce((closest, candidate) => {
+      const candidatePosition = getCornerPosition(candidate);
+      if (!candidatePosition) {
+        return closest;
+      }
+
+      const candidateCenter = {
+        x: candidatePosition.x + panelRect.width / 2,
+        y: candidatePosition.y + panelRect.height / 2,
+      };
+      const distance = Math.hypot(candidateCenter.x - currentCenter.x, candidateCenter.y - currentCenter.y);
+
+      if (!closest || distance < closest.distance) {
+        return { corner: candidate, distance };
+      }
+
+      return closest;
+    }, null as { corner: FloatingHierarchyCorner; distance: number } | null);
+
+    if (!nearestCorner) {
+      return;
+    }
+
+    setCorner(nearestCorner.corner);
+
+    const snappedPosition = getCornerPosition(nearestCorner.corner);
+    if (snappedPosition) {
+      setTargetPosition(snappedPosition);
+      setIsReady(true);
+    }
+  }, [getCornerPosition]);
+
+  const cornerLabel = corner
+    .split('-')
+    .map((value) => value.charAt(0).toUpperCase() + value.slice(1))
+    .join(' ');
+
+  return (
+    <div ref={boundsRef} className="absolute inset-0 pointer-events-none">
+      <motion.div
+        ref={panelRef}
+        drag
+        dragControls={dragControls}
+        dragListener={false}
+        dragMomentum={false}
+        dragElastic={0.08}
+        dragConstraints={boundsRef}
+        onDragStart={() => setIsWindowDragging(true)}
+        onDragEnd={handleDragEnd}
+        animate={isReady ? { x: targetPosition.x, y: targetPosition.y, opacity: 1, scale: 1 } : { opacity: 0 }}
+        transition={
+          isWindowDragging
+            ? { duration: 0 }
+            : {
+                type: 'spring',
+                stiffness: 420,
+                damping: 34,
+                mass: 0.8,
+              }
+        }
+        className="absolute left-0 top-0 pointer-events-auto"
+        style={{
+          width: 'min(340px, calc(100% - 32px))',
+          maxHeight: 'min(520px, calc(100% - 32px))',
+        }}
+        onMouseEnter={() => setIsMaskControlHovered(true)}
+        onMouseLeave={() => setIsMaskControlHovered(false)}
+        onClick={(event) => event.stopPropagation()}
+        onContextMenu={(event) => event.stopPropagation()}
+      >
+        <div className="flex max-h-full min-h-0 flex-col overflow-hidden rounded-xl border border-surface bg-bg-secondary/92 shadow-2xl backdrop-blur-md">
+          <div
+            className="flex cursor-grab items-center justify-between gap-3 border-b border-surface px-3 py-2 active:cursor-grabbing"
+            onPointerDown={(event) => {
+              event.stopPropagation();
+              dragControls.start(event);
+            }}
+          >
+            <div className="flex items-center gap-2 text-sm font-semibold text-text-primary">
+              <GripHorizontal size={14} className="text-text-secondary" />
+              <span>Mask Hierarchy</span>
+            </div>
+            <span className="text-[10px] uppercase tracking-[0.18em] text-text-secondary">{cornerLabel}</span>
+          </div>
+          <div className="min-h-0 flex-1">{children}</div>
+        </div>
+      </motion.div>
+    </div>
   );
 }
 

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -122,6 +122,7 @@ const FLOATING_HIERARCHY_MIN_WIDTH = 260;
 const FLOATING_HIERARCHY_MAX_WIDTH = 640;
 const MASK_HIERARCHY_LAYOUT_STORAGE_KEY = 'rapidraw-mask-hierarchy-layout';
 const MASK_HIERARCHY_ANCHOR_STORAGE_KEY = 'rapidraw-mask-hierarchy-anchor';
+const MASK_HIERARCHY_WIDTH_STORAGE_KEY = 'rapidraw-mask-hierarchy-width';
 const FLOATING_HIERARCHY_ANCHORS: FloatingHierarchyAnchor[] = [
   'top-left',
   'top-right',
@@ -157,6 +158,23 @@ const getStoredHierarchyAnchor = (): FloatingHierarchyAnchor => {
     return storedAnchor && FLOATING_HIERARCHY_ANCHORS.includes(storedAnchor) ? storedAnchor : 'top-right';
   } catch {
     return 'top-right';
+  }
+};
+
+const getStoredHierarchyWidth = () => {
+  if (typeof window === 'undefined') {
+    return FLOATING_HIERARCHY_DEFAULT_WIDTH;
+  }
+
+  try {
+    const storedWidth = Number(window.localStorage.getItem(MASK_HIERARCHY_WIDTH_STORAGE_KEY));
+    if (!Number.isFinite(storedWidth)) {
+      return FLOATING_HIERARCHY_DEFAULT_WIDTH;
+    }
+
+    return Math.max(FLOATING_HIERARCHY_MIN_WIDTH, Math.min(FLOATING_HIERARCHY_MAX_WIDTH, storedWidth));
+  } catch {
+    return FLOATING_HIERARCHY_DEFAULT_WIDTH;
   }
 };
 
@@ -1103,7 +1121,7 @@ function FloatingMaskHierarchyWindow({
   const dragControls = useDragControls();
   const animationControls = useAnimation();
   const [targetPosition, setTargetPosition] = useState({ x: FLOATING_HIERARCHY_MARGIN, y: FLOATING_HIERARCHY_MARGIN });
-  const [floatingWidth, setFloatingWidth] = useState(FLOATING_HIERARCHY_DEFAULT_WIDTH);
+  const [floatingWidth, setFloatingWidth] = useState(getStoredHierarchyWidth);
   const [isReady, setIsReady] = useState(false);
   const [isWindowDragging, setIsWindowDragging] = useState(false);
   const [isWindowResizing, setIsWindowResizing] = useState(false);
@@ -1114,6 +1132,14 @@ function FloatingMaskHierarchyWindow({
       setIsMaskControlHovered(false);
     };
   }, [setIsMaskControlHovered]);
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(MASK_HIERARCHY_WIDTH_STORAGE_KEY, String(floatingWidth));
+    } catch {
+      // Ignore storage failures and keep the session state in memory.
+    }
+  }, [floatingWidth]);
 
   const getAnchorPosition = useCallback((targetAnchor: FloatingHierarchyAnchor) => {
     const bounds = boundsRef.current;


### PR DESCRIPTION
## Description
The masking panel was taking up so much vertical space on smaller devices with the big buttons to add masks. And on most screens there is more horizontal space, thats why I added the option for a floating mask hierarchy window too.

## Type of Change
- [x] New feature
- [x] UI/UX improvement

## Changes Made
- Added a floating mask hierarchy
- Removed the big buttons to add masks (Screenshots)

## Screenshots/Videos
<img width="700" height="1051" alt="Screenshot from 2026-04-04 22-53-34" src="https://github.com/user-attachments/assets/5ec3ac87-2aba-4eb3-81b2-2d37383c0f43" />

<img width="700" height="1051" alt="Screenshot from 2026-04-04 22-53-27" src="https://github.com/user-attachments/assets/1c04232d-a4b8-4142-839a-1ec4056f4885" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
