### PR TITLE
Feat target adjustment tool for color mix and tone curves

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,6 +86,7 @@ import {
   normalizeLoadedAdjustments,
   PasteMode,
   CopyPasteSettings,
+  ActiveChannel,
 } from './utils/adjustments';
 import { calculateCenteredCrop } from './utils/cropUtils';
 import { generatePaletteFromImage } from './utils/palette';
@@ -375,6 +376,11 @@ function App() {
   const [copiedAdjustments, setCopiedAdjustments] = useState<Adjustments | null>(null);
   const [isStraightenActive, setIsStraightenActive] = useState(false);
   const [isWbPickerActive, setIsWbPickerActive] = useState(false);
+  const [isColorMixerTatPickerActive, setIsColorMixerTatPickerActive] = useState(false);
+  const [colorMixerTATSelection, setColorMixerTATSelection] = useState<string | null>(null);
+  const [isToneCurveTatPickerActive, setIsToneCurveTatPickerActive] = useState(false);
+  const [toneCurveTatPickedValue, setToneCurveTatPickedValue] = useState<{ channel: ActiveChannel; value: number } | null>(null);
+  const [activeCurveChannel, setActiveCurveChannel] = useState<ActiveChannel>(ActiveChannel.Luma);
   const [liveRotation, setLiveRotation] = useState<number | null>(null);
   const [copiedFilePaths, setCopiedFilePaths] = useState<Array<string>>([]);
   const [aiModelDownloadStatus, setAiModelDownloadStatus] = useState<string | null>(null);
@@ -592,10 +598,47 @@ function App() {
 
   const toggleWbPicker = useCallback(() => {
     setIsWbPickerActive((prev) => !prev);
-  }, []);
+    // Ensure only one picker is active at a time
+    if (!isWbPickerActive) {
+      setIsColorMixerTatPickerActive(false);
+      setIsToneCurveTatPickerActive(false);
+    }
+  }, [isWbPickerActive]);
 
   const handleWbPicked = useCallback(() => {
     //setIsWbPickerActive(false); // lets keep it active
+  }, []);
+
+  const toggleColorMixerTatPicker = useCallback(() => {
+    setIsColorMixerTatPickerActive((prev) => !prev);
+    // Ensure only one picker is active at a time
+    if (!isColorMixerTatPickerActive) {
+      setIsWbPickerActive(false);
+      setIsToneCurveTatPickerActive(false);
+    }
+  }, [isColorMixerTatPickerActive]);
+
+  const handleColorMixerTatPicked = useCallback((selectedColor: string) => {
+    // Store the selected color for Color.tsx to watch
+    setColorMixerTATSelection(selectedColor);
+  }, []);
+
+  const toggleToneCurveTatPicker = useCallback(() => {
+    setIsToneCurveTatPickerActive((prev) => !prev);
+    // Ensure only one picker is active at a time
+    if (!isToneCurveTatPickerActive) {
+      setIsWbPickerActive(false);
+      setIsColorMixerTatPickerActive(false);
+    }
+  }, [isToneCurveTatPickerActive]);
+
+  const handleToneCurveTatPicked = useCallback((channel: ActiveChannel, value: number) => {
+    // Store the detected value for ControlsPanel to pass to Curves.tsx
+    setToneCurveTatPickedValue({ channel, value });
+    // Clear it after a short delay so it only processes once
+    setTimeout(() => {
+      setToneCurveTatPickedValue(null);
+    }, 50);
   }, []);
 
   useEffect(() => {
@@ -5095,6 +5138,12 @@ function App() {
               selectedImage={selectedImage}
               isWbPickerActive={isWbPickerActive}
               onWbPicked={handleWbPicked}
+              isColorMixerTatPickerActive={isColorMixerTatPickerActive}
+              onColorMixerTatPicked={handleColorMixerTatPicked}
+              isToneCurveTatPickerActive={isToneCurveTatPickerActive}
+              onToneCurveTatPicked={handleToneCurveTatPicked}
+              activeCurveChannel={activeCurveChannel}
+              setActiveCurveChannel={setActiveCurveChannel}
               setAdjustments={setAdjustments}
               setShowOriginal={setShowOriginal}
               showOriginal={showOriginal}
@@ -5217,6 +5266,14 @@ function App() {
                             appSettings={appSettings}
                             isWbPickerActive={isWbPickerActive}
                             toggleWbPicker={toggleWbPicker}
+                            isColorMixerTatPickerActive={isColorMixerTatPickerActive}
+                            toggleColorMixerTatPicker={toggleColorMixerTatPicker}
+                            colorMixerTATSelection={colorMixerTATSelection}
+                            isToneCurveTatPickerActive={isToneCurveTatPickerActive}
+                            toggleToneCurveTatPicker={toggleToneCurveTatPicker}
+                            toneCurveTatPickedValue={toneCurveTatPickedValue}
+                            activeCurveChannel={activeCurveChannel}
+                            setActiveCurveChannel={setActiveCurveChannel}
                             onDragStateChange={setIsSliderDragging}
                             isWaveformVisible={isWaveformVisible}
                             waveform={waveform}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5143,7 +5143,6 @@ function App() {
               isToneCurveTatPickerActive={isToneCurveTatPickerActive}
               onToneCurveTatPicked={handleToneCurveTatPicked}
               activeCurveChannel={activeCurveChannel}
-              setActiveCurveChannel={setActiveCurveChannel}
               setAdjustments={setAdjustments}
               setShowOriginal={setShowOriginal}
               showOriginal={showOriginal}

--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { Pipette } from 'lucide-react';
 import Slider from '../ui/Slider';
 import ColorWheel from '../ui/ColorWheel';
@@ -20,6 +20,9 @@ interface ColorPanelProps {
   isForMask?: boolean;
   isWbPickerActive?: boolean;
   toggleWbPicker?: () => void;
+  isColorMixerTatPickerActive?: boolean;
+  toggleColorMixerTatPicker?: () => void;
+  colorMixerTATSelection?: string | null;
   onDragStateChange?: (isDragging: boolean) => void;
 }
 
@@ -298,10 +301,20 @@ export default function ColorPanel({
   isForMask = false,
   isWbPickerActive = false,
   toggleWbPicker,
+  isColorMixerTatPickerActive = false,
+  toggleColorMixerTatPicker,
+  colorMixerTATSelection,
   onDragStateChange,
 }: ColorPanelProps) {
   const [activeColor, setActiveColor] = useState('reds');
   const adjustmentVisibility = appSettings?.adjustmentVisibility || {};
+
+  // When TAT picker selects a color, update the active color
+  useEffect(() => {
+    if (colorMixerTATSelection) {
+      setActiveColor(colorMixerTATSelection);
+    }
+  }, [colorMixerTATSelection]);
 
   const handleGlobalChange = (key: ColorAdjustment, value: string) => {
     setAdjustments((prev: Partial<Adjustments>) => ({ ...prev, [key]: parseFloat(value) }));
@@ -398,9 +411,20 @@ export default function ColorPanel({
       </div>
 
       <div className="p-2 bg-bg-tertiary rounded-md">
-        <Text variant={TextVariants.heading} className="mb-3">
-          Color Mixer
-        </Text>
+        <div className="flex justify-between items-center mb-3">
+          <Text variant={TextVariants.heading}>Color Mixer</Text>
+          {!isForMask && toggleColorMixerTatPicker && (
+            <button
+              onClick={toggleColorMixerTatPicker}
+              className={`p-1.5 rounded-md transition-colors ${
+                isColorMixerTatPickerActive ? 'bg-accent text-button-text' : 'hover:bg-bg-secondary text-text-secondary'
+              }`}
+              data-tooltip="Color Mixer TAT Picker"
+            >
+              <Pipette size={16} />
+            </button>
+          )}
+        </div>
         <div className="flex justify-between mb-4 px-1">
           {HSL_COLORS.map(({ name, color }) => (
             <ColorSwatch

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { RotateCcw, Copy, ClipboardPaste } from 'lucide-react';
+import { RotateCcw, Copy, ClipboardPaste, Pipette } from 'lucide-react';
 import { ActiveChannel, Adjustments, Coord } from '../../utils/adjustments';
 import { Theme, OPTION_SEPARATOR } from '../ui/AppProperties';
 import { useContextMenu } from '../../context/ContextMenuContext';
@@ -29,6 +29,11 @@ interface CurveGraphProps {
   setAdjustments(updater: (prev: any) => any): void;
   theme: string;
   onDragStateChange?: (isDragging: boolean) => void;
+  activeChannel?: ActiveChannel;
+  setActiveChannel?: (channel: ActiveChannel) => void;
+  isToneCurveTatPickerActive?: boolean;
+  toggleToneCurveTatPicker?: () => void;
+  toneCurveTatPickedValue?: { channel: ActiveChannel; value: number } | null;
 }
 
 function getCurvePath(points: Array<Coord>) {
@@ -156,9 +161,18 @@ export default function CurveGraph({
   theme,
   isForMask,
   onDragStateChange,
+  activeChannel: externalActiveChannel,
+  setActiveChannel: externalSetActiveChannel,
+  isToneCurveTatPickerActive,
+  toggleToneCurveTatPicker,
+  toneCurveTatPickedValue,
 }: CurveGraphProps) {
   const { showContextMenu } = useContextMenu();
-  const [activeChannel, setActiveChannel] = useState<ActiveChannel>(ActiveChannel.Luma);
+  
+  // Use external activeChannel if provided, otherwise use local state
+  const [localActiveChannel, setLocalActiveChannel] = useState<ActiveChannel>(ActiveChannel.Luma);
+  const activeChannel = externalActiveChannel ?? localActiveChannel;
+  const setActiveChannelLocal = externalSetActiveChannel ?? setLocalActiveChannel;
   const [draggingPointIndex, setDraggingPointIndex] = useState<number | null>(null);
   const [localPoints, setLocalPoints] = useState<Array<Coord> | null>(null);
   const [isHovered, setIsHovered] = useState(false);
@@ -193,6 +207,67 @@ export default function CurveGraph({
     onDragStateChange?.(isDragging);
     draggingIndexRef.current = draggingPointIndex;
   }, [draggingPointIndex, onDragStateChange]);
+
+  // Handle TAT picker value - add point to curve at detected input value
+  useEffect(() => {
+    if (!toneCurveTatPickedValue) return;
+    if (toneCurveTatPickedValue.channel !== activeChannel) return;
+
+    const propPoints = adjustments?.curves?.[activeChannel];
+    if (!propPoints) return;
+
+    const inputValue = toneCurveTatPickedValue.value;
+    
+    // Clamp to valid range
+    const clampedInputValue = Math.max(0, Math.min(255, inputValue));
+    
+    // Check if a point already exists at this x position (within 8 units)
+    const existingPoint = propPoints.find((p) => Math.abs(p.x - clampedInputValue) < 8);
+    if (existingPoint) {
+      // Point already exists, just return
+      return;
+    }
+
+    // Find where the curve currently is at this input value using interpolation
+    let outputValue = inputValue;
+
+    if (propPoints.length >= 2) {
+      // Find the two points that bracket this input value
+      let before = null;
+      let after = null;
+
+      for (let i = 0; i < propPoints.length - 1; i++) {
+        if (propPoints[i].x <= inputValue && propPoints[i + 1].x >= inputValue) {
+          before = propPoints[i];
+          after = propPoints[i + 1];
+          break;
+        }
+      }
+
+      if (before && after) {
+        // Linear interpolation between the two points
+        const t = (inputValue - before.x) / (after.x - before.x);
+        outputValue = before.y + t * (after.y - before.y);
+      } else if (inputValue < propPoints[0].x) {
+        outputValue = propPoints[0].y;
+      } else if (inputValue > propPoints[propPoints.length - 1].x) {
+        outputValue = propPoints[propPoints.length - 1].y;
+      }
+    }
+
+    // Add the new point
+    const newPoints = [...propPoints, { x: inputValue, y: outputValue }].sort(
+      (a: Coord, b: Coord) => a.x - b.x,
+    );
+
+    setLocalPoints(newPoints);
+    localPointsRef.current = newPoints;
+
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      curves: { ...prev.curves, [activeChannel]: newPoints },
+    }));
+  }, [toneCurveTatPickedValue, activeChannel, setAdjustments]);
 
   useEffect(() => {
     const handleGlobalMouseMove = (e: MouseEvent) => {
@@ -485,7 +560,9 @@ export default function CurveGraph({
               }
               ${channel === ActiveChannel.Luma ? 'text-text-primary' : ''}`}
               key={channel}
-              onClick={() => setActiveChannel(channel as ActiveChannel)}
+              onClick={() => {
+                setActiveChannelLocal(channel as ActiveChannel);
+              }}
               style={{
                 backgroundColor:
                   channel !== ActiveChannel.Luma && activeChannel !== channel
@@ -499,6 +576,17 @@ export default function CurveGraph({
             </button>
           ))}
         </div>
+        {toggleToneCurveTatPicker && (
+          <button
+            onClick={toggleToneCurveTatPicker}
+            className={`p-1.5 rounded-md transition-colors ${
+              isToneCurveTatPickerActive ? 'bg-accent text-button-text' : 'bg-surface-secondary hover:bg-surface-tertiary'
+            }`}
+            data-tooltip="Tone Curve TAT Picker"
+          >
+            <Pipette size={16} />
+          </button>
+        )}
       </div>
 
       <div

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from 'lucide-react';
 import clsx from 'clsx';
 import { invoke } from '@tauri-apps/api/core';
 import { ImageDimensions, useImageRenderSize } from '../../hooks/useImageRenderSize';
-import { Adjustments, AiPatch, Coord, MaskContainer } from '../../utils/adjustments';
+import { Adjustments, AiPatch, Coord, MaskContainer, ActiveChannel } from '../../utils/adjustments';
 import { calculateCenteredCrop, getOrientedDimensions } from '../../utils/cropUtils';
 import EditorToolbar from './editor/EditorToolbar';
 import ImageCanvas from './editor/ImageCanvas';
@@ -57,6 +57,11 @@ interface EditorProps {
   originalSize?: ImageDimensions;
   isWbPickerActive?: boolean;
   onWbPicked?: () => void;
+  isColorMixerTatPickerActive?: boolean;
+  onColorMixerTatPicked?: (selectedColor: string) => void;
+  isToneCurveTatPickerActive?: boolean;
+  onToneCurveTatPicked?: (channel: ActiveChannel, value: number) => void;
+  activeCurveChannel?: ActiveChannel;
   overlayMode?: OverlayMode;
   overlayRotation?: number;
   adjustmentsHistory: any[];
@@ -109,6 +114,11 @@ export default function Editor({
   originalSize,
   isWbPickerActive = false,
   onWbPicked,
+  isColorMixerTatPickerActive = false,
+  onColorMixerTatPicked,
+  isToneCurveTatPickerActive = false,
+  onToneCurveTatPicked,
+  activeCurveChannel,
   overlayMode = 'none',
   overlayRotation = 0,
   adjustmentsHistory,
@@ -604,7 +614,7 @@ export default function Editor({
       const wrapper = transformWrapperRef.current;
       if (!wrapper) return;
 
-      if (isCropping || isMasking || isAiEditing || isWbPickerActive) return;
+      if (isCropping || isMasking || isAiEditing || isWbPickerActive || isColorMixerTatPickerActive || isToneCurveTatPickerActive) return;
 
       if (mouseDownPos.current) {
         const dx = Math.abs(e.clientX - mouseDownPos.current.x);
@@ -670,7 +680,7 @@ export default function Editor({
         }
       }
     },
-    [isCropping, isMasking, isAiEditing, isWbPickerActive, transformWrapperRef, transformConfig.maxScale],
+    [isCropping, isMasking, isAiEditing, isWbPickerActive, isColorMixerTatPickerActive, isToneCurveTatPickerActive, transformWrapperRef, transformConfig.maxScale],
   );
 
   if (!selectedImage) {
@@ -714,7 +724,7 @@ export default function Editor({
         activeSubMask?.type === Mask.Luminance ||
         activeSubMask?.parameters?.isInitialDraw));
 
-  const isZoomActionActive = !isCropping && !isMasking && !isAiEditing && !isWbPickerActive;
+  const isZoomActionActive = !isCropping && !isMasking && !isAiEditing && !isWbPickerActive && !isColorMixerTatPickerActive && !isToneCurveTatPickerActive;
   const isMaxZoom = transformState.scale >= transformConfig.maxScale - 0.5;
 
   let cursorStyle = 'default';
@@ -844,6 +854,11 @@ export default function Editor({
               updateSubMask={updateSubMask}
               isWbPickerActive={isWbPickerActive}
               onWbPicked={onWbPicked}
+              isColorMixerTatPickerActive={isColorMixerTatPickerActive}
+              onColorMixerTatPicked={onColorMixerTatPicked}
+              isToneCurveTatPickerActive={isToneCurveTatPickerActive}
+              onToneCurveTatPicked={onToneCurveTatPicked}
+              activeCurveChannel={activeCurveChannel}
               setAdjustments={setAdjustments}
               overlayRotation={overlayRotation}
               overlayMode={overlayMode}

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -3,7 +3,7 @@ import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { Stage, Layer, Ellipse, Line, Transformer, Group, Circle, Rect } from 'react-konva';
 import { PercentCrop, Crop } from 'react-image-crop';
-import { Adjustments, AiPatch, Coord, MaskContainer } from '../../../utils/adjustments';
+import { Adjustments, AiPatch, Coord, MaskContainer, getColorNameFromHue, rgbToHsv, rgbToLuma, ActiveChannel } from '../../../utils/adjustments';
 import { Mask, SubMask, SubMaskMode, ToolType } from '../right/Masks';
 import { BrushSettings, SelectedImage } from '../../ui/AppProperties';
 import { RenderSize } from '../../../hooks/useImageRenderSize';
@@ -58,6 +58,11 @@ interface ImageCanvasProps {
   interactivePatch?: { url: string; normX: number; normY: number; normW: number; normH: number } | null;
   isWbPickerActive?: boolean;
   onWbPicked?: () => void;
+  isColorMixerTatPickerActive?: boolean;
+  onColorMixerTatPicked?: (selectedColor: string) => void;
+  isToneCurveTatPickerActive?: boolean;
+  onToneCurveTatPicked?: (channel: ActiveChannel, value: number) => void;
+  activeCurveChannel?: ActiveChannel;
   setAdjustments(fn: (prev: Adjustments) => Adjustments): void;
   overlayMode?: OverlayMode;
   overlayRotation?: number;
@@ -729,6 +734,11 @@ const ImageCanvas = memo(
     updateSubMask,
     isWbPickerActive = false,
     onWbPicked,
+    isColorMixerTatPickerActive = false,
+    onColorMixerTatPicked,
+    isToneCurveTatPickerActive = false,
+    onToneCurveTatPicked,
+    activeCurveChannel,
     setAdjustments,
     overlayRotation,
     overlayMode,
@@ -1026,12 +1036,194 @@ const ImageCanvas = memo(
       [isWbPickerActive, finalPreviewUrl, imageRenderSize, onWbPicked, setAdjustments],
     );
 
+    const handleColorMixerTatClick = useCallback(
+      (e: any) => {
+        if (!isColorMixerTatPickerActive || !finalPreviewUrl || !onColorMixerTatPicked) return;
+
+        const stage = e.target.getStage();
+        const pointerPos = stage.getPointerPosition();
+        if (!pointerPos) return;
+
+        const x = pointerPos.x / imageRenderSize.scale;
+        const y = pointerPos.y / imageRenderSize.scale;
+
+        const imgLogicalWidth = imageRenderSize.width / imageRenderSize.scale;
+        const imgLogicalHeight = imageRenderSize.height / imageRenderSize.scale;
+
+        if (x < 0 || x > imgLogicalWidth || y < 0 || y > imgLogicalHeight) return;
+
+        const img = new Image();
+        img.crossOrigin = 'Anonymous';
+        img.src = finalPreviewUrl;
+
+        img.onload = () => {
+          const radius = 5;
+          const side = radius * 2 + 1;
+
+          const canvas = document.createElement('canvas');
+          canvas.width = side;
+          canvas.height = side;
+          const ctx = canvas.getContext('2d', { willReadFrequently: true });
+          if (!ctx) return;
+
+          const scaleX = img.width / imgLogicalWidth;
+          const scaleY = img.height / imgLogicalHeight;
+          const srcX = Math.floor(x * scaleX);
+          const srcY = Math.floor(y * scaleY);
+
+          const startX = Math.max(0, srcX - radius);
+          const startY = Math.max(0, srcY - radius);
+          const endX = Math.min(img.width, srcX + radius + 1);
+          const endY = Math.min(img.height, srcY + radius + 1);
+          const sw = endX - startX;
+          const sh = endY - startY;
+
+          if (sw <= 0 || sh <= 0) return;
+
+          ctx.drawImage(img, startX, startY, sw, sh, 0, 0, sw, sh);
+
+          const imageData = ctx.getImageData(0, 0, sw, sh);
+          const data = imageData.data;
+
+          let rTotal = 0,
+            gTotal = 0,
+            bTotal = 0;
+          let count = 0;
+
+          for (let i = 0; i < data.length; i += 4) {
+            rTotal += data[i];
+            gTotal += data[i + 1];
+            bTotal += data[i + 2];
+            count++;
+          }
+
+          if (count === 0) return;
+
+          const avgR = rTotal / count;
+          const avgG = gTotal / count;
+          const avgB = bTotal / count;
+
+          // Convert to HSV to get hue
+          const { h: hue } = rgbToHsv(avgR, avgG, avgB);
+
+          // Determine which color range this hue belongs to
+          const selectedColor = getColorNameFromHue(hue);
+
+          onColorMixerTatPicked(selectedColor);
+        };
+      },
+      [isColorMixerTatPickerActive, finalPreviewUrl, imageRenderSize, onColorMixerTatPicked],
+    );
+
+    const handleToneCurveTatClick = useCallback(
+      (e: any) => {
+        if (!isToneCurveTatPickerActive || !finalPreviewUrl || !onToneCurveTatPicked || !activeCurveChannel) return;
+
+        const stage = e.target.getStage();
+        const pointerPos = stage.getPointerPosition();
+        if (!pointerPos) return;
+
+        const x = pointerPos.x / imageRenderSize.scale;
+        const y = pointerPos.y / imageRenderSize.scale;
+
+        const imgLogicalWidth = imageRenderSize.width / imageRenderSize.scale;
+        const imgLogicalHeight = imageRenderSize.height / imageRenderSize.scale;
+
+        if (x < 0 || x > imgLogicalWidth || y < 0 || y > imgLogicalHeight) return;
+
+        const img = new Image();
+        img.crossOrigin = 'Anonymous';
+        img.src = finalPreviewUrl;
+
+        img.onload = () => {
+          const radius = 5;
+          const side = radius * 2 + 1;
+
+          const canvas = document.createElement('canvas');
+          canvas.width = side;
+          canvas.height = side;
+          const ctx = canvas.getContext('2d', { willReadFrequently: true });
+          if (!ctx) return;
+
+          const scaleX = img.width / imgLogicalWidth;
+          const scaleY = img.height / imgLogicalHeight;
+          const srcX = Math.floor(x * scaleX);
+          const srcY = Math.floor(y * scaleY);
+
+          const startX = Math.max(0, srcX - radius);
+          const startY = Math.max(0, srcY - radius);
+          const endX = Math.min(img.width, srcX + radius + 1);
+          const endY = Math.min(img.height, srcY + radius + 1);
+          const sw = endX - startX;
+          const sh = endY - startY;
+
+          if (sw <= 0 || sh <= 0) return;
+
+          ctx.drawImage(img, startX, startY, sw, sh, 0, 0, sw, sh);
+
+          const imageData = ctx.getImageData(0, 0, sw, sh);
+          const data = imageData.data;
+
+          let rTotal = 0,
+            gTotal = 0,
+            bTotal = 0;
+          let count = 0;
+
+          for (let i = 0; i < data.length; i += 4) {
+            rTotal += data[i];
+            gTotal += data[i + 1];
+            bTotal += data[i + 2];
+            count++;
+          }
+
+          if (count === 0) return;
+
+          const avgR = rTotal / count;
+          const avgG = gTotal / count;
+          const avgB = bTotal / count;
+
+          // Determine value based on active curve channel
+          let detectedValue: number;
+
+          switch (activeCurveChannel) {
+            case ActiveChannel.Luma:
+              detectedValue = rgbToLuma(avgR, avgG, avgB);
+              break;
+            case ActiveChannel.Red:
+              detectedValue = Math.round(avgR);
+              break;
+            case ActiveChannel.Green:
+              detectedValue = Math.round(avgG);
+              break;
+            case ActiveChannel.Blue:
+              detectedValue = Math.round(avgB);
+              break;
+            default:
+              return;
+          }
+
+          onToneCurveTatPicked(activeCurveChannel, detectedValue);
+        };
+      },
+      [isToneCurveTatPickerActive, finalPreviewUrl, imageRenderSize, onToneCurveTatPicked, activeCurveChannel],
+    );
+
     const handleMouseDown = useCallback(
       (e: any) => {
         e.evt.preventDefault();
 
         if (isWbPickerActive) {
           handleWbClick(e);
+          return;
+        }
+
+        if (isColorMixerTatPickerActive) {
+          handleColorMixerTatClick(e);
+          return;
+        }
+
+        if (isToneCurveTatPickerActive) {
+          handleToneCurveTatClick(e);
           return;
         }
 
@@ -1784,12 +1976,14 @@ const ImageCanvas = memo(
 
     const effectiveCursor = useMemo(() => {
       if (isWbPickerActive) return 'crosshair';
+      if (isColorMixerTatPickerActive) return 'crosshair';
+      if (isToneCurveTatPickerActive) return 'crosshair';
       if (isParametricActive) return 'crosshair';
       if (isInitialDrawing) return 'crosshair';
       if (isBrushActive) return 'none';
       if (isAiSubjectActive) return 'crosshair';
       return cursorStyle;
-    }, [isWbPickerActive, isInitialDrawing, isBrushActive, isAiSubjectActive, isParametricActive, cursorStyle]);
+    }, [isWbPickerActive, isColorMixerTatPickerActive, isToneCurveTatPickerActive, isInitialDrawing, isBrushActive, isAiSubjectActive, isParametricActive, cursorStyle]);
 
     const handlePreviewUpdate = useCallback(
       (id: string, subMaskPreview: Partial<SubMask>) => {
@@ -1933,7 +2127,7 @@ const ImageCanvas = memo(
             </div>
           </div>
 
-          {(isMasking || isAiEditing || isWbPickerActive) && (
+          {(isMasking || isAiEditing || isWbPickerActive || isColorMixerTatPickerActive || isToneCurveTatPickerActive) && (
             <Stage
               height={imageRenderSize.height}
               onMouseDown={handleMouseDown}

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -10,7 +10,7 @@ import EffectsPanel from '../../adjustments/Effects';
 import CollapsibleSection from '../../ui/CollapsibleSection';
 import Waveform from '../editor/Waveform';
 import Resizer from '../../ui/Resizer';
-import { Adjustments, SectionVisibility, INITIAL_ADJUSTMENTS, ADJUSTMENT_SECTIONS } from '../../../utils/adjustments';
+import { Adjustments, SectionVisibility, INITIAL_ADJUSTMENTS, ADJUSTMENT_SECTIONS, ActiveChannel } from '../../../utils/adjustments';
 import { useContextMenu } from '../../../context/ContextMenuContext';
 import { OPTION_SEPARATOR, SelectedImage, AppSettings, WaveformData, Orientation } from '../../ui/AppProperties';
 import { ChannelConfig } from '../../adjustments/Curves';
@@ -38,6 +38,15 @@ interface ControlsProps {
   appSettings: AppSettings | null;
   isWbPickerActive?: boolean;
   toggleWbPicker?: () => void;
+  isColorMixerTatPickerActive?: boolean;
+  toggleColorMixerTatPicker?: () => void;
+  colorMixerTATSelection?: string | null;
+  onColorMixerTatPicked?: (selectedColor: string) => void;
+  isToneCurveTatPickerActive?: boolean;
+  toggleToneCurveTatPicker?: () => void;
+  toneCurveTatPickedValue?: { channel: ActiveChannel; value: number } | null;
+  activeCurveChannel?: ActiveChannel;
+  setActiveCurveChannel?: (channel: ActiveChannel) => void;
   onDragStateChange?: (isDragging: boolean) => void;
   isWaveformVisible?: boolean;
   onToggleWaveform?: () => void;
@@ -63,6 +72,15 @@ export default function Controls({
   appSettings,
   isWbPickerActive,
   toggleWbPicker,
+  isColorMixerTatPickerActive,
+  toggleColorMixerTatPicker,
+  colorMixerTATSelection,
+  onColorMixerTatPicked,
+  isToneCurveTatPickerActive,
+  toggleToneCurveTatPicker,
+  toneCurveTatPickedValue,
+  activeCurveChannel,
+  setActiveCurveChannel,
   onDragStateChange,
   isWaveformVisible,
   onToggleWaveform,
@@ -295,6 +313,14 @@ export default function Controls({
                   appSettings={appSettings}
                   isWbPickerActive={isWbPickerActive}
                   toggleWbPicker={toggleWbPicker}
+                  isColorMixerTatPickerActive={isColorMixerTatPickerActive}
+                  toggleColorMixerTatPicker={toggleColorMixerTatPicker}
+                  colorMixerTATSelection={colorMixerTATSelection}
+                  activeChannel={activeCurveChannel}
+                  setActiveChannel={setActiveCurveChannel}
+                  isToneCurveTatPickerActive={isToneCurveTatPickerActive}
+                  toggleToneCurveTatPicker={toggleToneCurveTatPicker}
+                  toneCurveTatPickedValue={toneCurveTatPickedValue}
                   onDragStateChange={onDragStateChange}
                 />
               </CollapsibleSection>

--- a/src/utils/adjustments.tsx
+++ b/src/utils/adjustments.tsx
@@ -691,3 +691,97 @@ export const ADJUSTMENT_SECTIONS: Sections = {
     Effect.VignetteRoundness,
   ],
 };
+
+// ========== Color Mixer TAT Picker Utilities ==========
+
+interface HslColorRange {
+  name: string;
+  center: number;
+  width: number;
+}
+
+// Color ranges matched to shader.wgsl HSL_RANGES
+export const HSL_COLOR_RANGES: HslColorRange[] = [
+  { name: 'reds', center: 358.0, width: 35.0 },
+  { name: 'oranges', center: 25.0, width: 45.0 },
+  { name: 'yellows', center: 60.0, width: 40.0 },
+  { name: 'greens', center: 115.0, width: 90.0 },
+  { name: 'aquas', center: 180.0, width: 60.0 },
+  { name: 'blues', center: 225.0, width: 60.0 },
+  { name: 'purples', center: 280.0, width: 55.0 },
+  { name: 'magentas', center: 330.0, width: 50.0 },
+];
+
+/**
+ * Calculate HSL influence for a given hue and color range
+ * Uses the same algorithm as get_raw_hsl_influence() in shader.wgsl
+ */
+export function getHslInfluence(hue: number, center: number, width: number): number {
+  const dist = Math.min(Math.abs(hue - center), 360.0 - Math.abs(hue - center));
+  const sharpness = 1.5;
+  const falloff = dist / (width * 0.5);
+  return Math.exp(-sharpness * falloff * falloff);
+}
+
+/**
+ * Find the closest color range for a given hue
+ * Returns the color name (reds, oranges, yellows, etc.)
+ */
+export function getColorNameFromHue(hue: number): string {
+  let maxInfluence = 0;
+  let closestColor = 'reds';
+
+  for (const range of HSL_COLOR_RANGES) {
+    const influence = getHslInfluence(hue, range.center, range.width);
+    if (influence > maxInfluence) {
+      maxInfluence = influence;
+      closestColor = range.name;
+    }
+  }
+
+  return closestColor;
+}
+
+/**
+ * Convert RGB values to HSV (Hue, Saturation, Value)
+ * Returns hue in degrees (0-360), saturation and value as 0-1
+ */
+export function rgbToHsv(r: number, g: number, b: number): { h: number; s: number; v: number } {
+  r /= 255;
+  g /= 255;
+  b /= 255;
+
+  const cMax = Math.max(r, g, b);
+  const cMin = Math.min(r, g, b);
+  const delta = cMax - cMin;
+
+  let h = 0;
+  if (delta !== 0) {
+    if (cMax === r) {
+      h = ((g - b) / delta) % 6;
+    } else if (cMax === g) {
+      h = (b - r) / delta + 2;
+    } else {
+      h = (r - g) / delta + 4;
+    }
+    h *= 60;
+  }
+
+  if (h < 0) h += 360;
+
+  const s = cMax === 0 ? 0 : delta / cMax;
+  const v = cMax;
+
+  return { h, s, v };
+}
+
+/**
+ * Calculate luma (perceived brightness) from RGB values
+ * Uses ITU-R BT.709 standard
+ * Returns value 0-255 matching tone curve input range
+ */
+export function rgbToLuma(r: number, g: number, b: number): number {
+  // ITU-R BT.709 luma coefficients
+  const luma = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+  return Math.round(Math.max(0, Math.min(255, luma)));
+}


### PR DESCRIPTION
## Description
Added two Target Adjustment Tools (TATs): one for Color Mix and one for Tone Curves.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- For Color Mix In Color Panel:
    - The TAT now takes the user directly to the correct color range.
    - Users no longer need to guess which color to adjust.
- For Tone Curves In Curves Panel:
    - The TAT creates points on the curve based on the selected luminance, which can then be adjusted manually.
    - Works for all channels (Luminance, Red, Green, Blue).
    - Removes the need for guesswork when adjusting curves.
    
## Video
https://streamable.com/sxy9nw (Uploaded because of size issue, it will expire in 2 days, sorry for the inconvenience)

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 10
- **Hardware:** Intel i5

## Checklist
- [x] My code follows the project's code style
- [ ] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

## Issues Closure:
- Closes https://github.com/CyberTimon/RapidRAW/issues/960