### PR TITLE
Feat gradient sliders for color grading panel

### DIFF
--- a/src/components/ui/ColorWheel.tsx
+++ b/src/components/ui/ColorWheel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useId } from 'react';
 import Slider from './Slider';
 import Wheel from '@uiw/react-color-wheel';
 import { ColorResult, HsvaColor, hsvaToHex } from '@uiw/color-convert';
@@ -31,13 +31,14 @@ const ColorWheel = ({
   const [isWheelDragging, setIsWheelDragging] = useState(false);
   const [isSliderDragging, setIsSliderDragging] = useState(false);
   const [isLabelHovered, setIsLabelHovered] = useState(false);
+  const instanceId = useId().replace(/:/g, '');
 
   const isDragging = isWheelDragging || isSliderDragging;
 
   useEffect(() => {
-    document.documentElement.style.setProperty('--cg-hue', hue.toString());
-    document.documentElement.style.setProperty('--cg-sat', `${saturation}%`);
-  }, [hue, saturation]);
+    document.documentElement.style.setProperty(`--cg-hue-${instanceId}`, hue.toString());
+    document.documentElement.style.setProperty(`--cg-sat-${instanceId}`, `${saturation}%`);
+  }, [hue, saturation, instanceId]);
 
   useEffect(() => {
     const observer = new ResizeObserver((entries) => {
@@ -110,6 +111,12 @@ const ColorWheel = ({
 
   const pointerSize = isWheelDragging ? 14 : 12;
   const pointerOffset = pointerSize / 2;
+
+  const satWrapperStyle = { '--cg-hue': `var(--cg-hue-${instanceId})` } as React.CSSProperties;
+  const lumWrapperStyle = { 
+    '--cg-hue': `var(--cg-hue-${instanceId})`,
+    '--cg-sat': `var(--cg-sat-${instanceId})`
+  } as React.CSSProperties;
 
   return (
     <div className="relative flex flex-col items-center gap-2" ref={containerRef}>
@@ -215,7 +222,7 @@ const ColorWheel = ({
               />
             </div>
 
-            <div className="w-full">
+            <div className="w-full" style={satWrapperStyle}>
               <Slider
                 defaultValue={defaultValue.saturation}
                 label="Saturation"
@@ -232,7 +239,7 @@ const ColorWheel = ({
         )}
       </AnimatePresence>
 
-      <div className="w-full">
+      <div className="w-full" style={lumWrapperStyle}>
         <Slider
           defaultValue={defaultValue.luminance}
           label={isExpanded ? 'Luminance' : <Sun size={16} className="text-text-secondary" />}

--- a/src/components/ui/ColorWheel.tsx
+++ b/src/components/ui/ColorWheel.tsx
@@ -35,6 +35,11 @@ const ColorWheel = ({
   const isDragging = isWheelDragging || isSliderDragging;
 
   useEffect(() => {
+    document.documentElement.style.setProperty('--cg-hue', hue.toString());
+    document.documentElement.style.setProperty('--cg-sat', `${saturation}%`);
+  }, [hue, saturation]);
+
+  useEffect(() => {
     const observer = new ResizeObserver((entries) => {
       if (entries[0]) {
         const width = entries[0].contentRect.width;
@@ -206,6 +211,7 @@ const ColorWheel = ({
                 onDragStateChange={setIsSliderDragging}
                 step={1}
                 value={hue}
+                trackClassName="cg-hue-gradient"
               />
             </div>
 
@@ -219,6 +225,7 @@ const ColorWheel = ({
                 onDragStateChange={setIsSliderDragging}
                 step={1}
                 value={saturation}
+                trackClassName="cg-sat-gradient"
               />
             </div>
           </motion.div>
@@ -235,6 +242,7 @@ const ColorWheel = ({
           onDragStateChange={setIsSliderDragging}
           step={1}
           value={luminance}
+          trackClassName="cg-lum-gradient"
         />
       </div>
     </div>

--- a/src/styles.css
+++ b/src/styles.css
@@ -248,34 +248,22 @@
   }
 }
 
+  /*
+    Color grading sliders
+  */
+
 .cg-hue-gradient {
-  background: linear-gradient(to right, 
-    hsl(0, 100%, 50%) 0%,
-    hsl(30, 100%, 50%) 8.33%,
-    hsl(60, 100%, 50%) 16.66%,
-    hsl(90, 100%, 50%) 25%,
-    hsl(120, 100%, 50%) 33.33%,
-    hsl(150, 100%, 50%) 41.66%,
-    hsl(180, 100%, 50%) 50%,
-    hsl(210, 100%, 50%) 58.33%,
-    hsl(240, 100%, 50%) 66.66%,
-    hsl(270, 100%, 50%) 75%,
-    hsl(300, 100%, 50%) 83.33%,
-    hsl(330, 100%, 50%) 91.66%,
-    hsl(360, 100%, 50%) 100%) !important;
+  background: linear-gradient(to right, hsl(0, 100%, 50%) 0%, hsl(30, 100%, 50%) 8.33%, hsl(60, 100%, 50%) 16.66%, hsl(90, 100%, 50%) 25%, hsl(120, 100%, 50%) 33.33%, hsl(150, 100%, 50%) 41.66%, hsl(180, 100%, 50%) 50%, hsl(210, 100%, 50%) 58.33%, hsl(240, 100%, 50%) 66.66%, hsl(270, 100%, 50%) 75%, hsl(300, 100%, 50%) 83.33%, hsl(330, 100%, 50%) 91.66%, hsl(360, 100%, 50%) 100%) !important;
 }
 
 .cg-sat-gradient {
   background: linear-gradient(to right, 
-    hsl(var(--cg-hue), 0%, 50%) 0%, 
-    hsl(var(--cg-hue), 100%, 50%) 100%) !important;
+    hsl(var(--cg-hue), 0%, 50%) 0%, hsl(var(--cg-hue), 100%, 50%) 100%) !important;
 }
 
 .cg-lum-gradient {
   background: linear-gradient(to right, 
-    hsl(var(--cg-hue), var(--cg-sat), 0%) 0%, 
-    hsl(var(--cg-hue), var(--cg-sat), 50%) 50%,
-    hsl(var(--cg-hue), var(--cg-sat), 100%) 100%) !important;
+    hsl(var(--cg-hue), var(--cg-sat), 0%) 0%, hsl(var(--cg-hue), var(--cg-sat), 50%) 50%, hsl(var(--cg-hue), var(--cg-sat), 100%) 100%) !important;
 }
 
 @layer utilities {

--- a/src/styles.css
+++ b/src/styles.css
@@ -248,6 +248,36 @@
   }
 }
 
+.cg-hue-gradient {
+  background: linear-gradient(to right, 
+    hsl(0, 100%, 50%) 0%,
+    hsl(30, 100%, 50%) 8.33%,
+    hsl(60, 100%, 50%) 16.66%,
+    hsl(90, 100%, 50%) 25%,
+    hsl(120, 100%, 50%) 33.33%,
+    hsl(150, 100%, 50%) 41.66%,
+    hsl(180, 100%, 50%) 50%,
+    hsl(210, 100%, 50%) 58.33%,
+    hsl(240, 100%, 50%) 66.66%,
+    hsl(270, 100%, 50%) 75%,
+    hsl(300, 100%, 50%) 83.33%,
+    hsl(330, 100%, 50%) 91.66%,
+    hsl(360, 100%, 50%) 100%) !important;
+}
+
+.cg-sat-gradient {
+  background: linear-gradient(to right, 
+    hsl(var(--cg-hue), 0%, 50%) 0%, 
+    hsl(var(--cg-hue), 100%, 50%) 100%) !important;
+}
+
+.cg-lum-gradient {
+  background: linear-gradient(to right, 
+    hsl(var(--cg-hue), var(--cg-sat), 0%) 0%, 
+    hsl(var(--cg-hue), var(--cg-sat), 50%) 50%,
+    hsl(var(--cg-hue), var(--cg-sat), 100%) 100%) !important;
+}
+
 @layer utilities {
   .text-shadow-shiny {
     text-shadow: 0 0 18px rgba(255, 255, 255, 0.35);


### PR DESCRIPTION
## Description
Dynamic gradient shades for Hue Saturation and Luminance sliders in Color Grading Panel.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Hue slider now has a gradient fill of complete hue spectrum (0°-360°).
- Saturation slider now has a gradient fill of 0% saturated shade of selected hue to 100% saturated shade of selected hue. Updates dynamically when hue changes.
- Luminance slider now has a gradient fill of -100% light shade of selected hue to 100% light shade of selected hue and saturation. Updates dynamically when hue or saturation changes.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 10
- **Hardware:** Intel i5

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [x] This PR contains only blood, sweat, and coffee (AI-free)