### PR TITLE
Add option to preserve export file timestamps from EXIF capture date

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "bytemuck",
  "chrono",
  "fern",
+ "filetime",
  "futures",
  "futures-util",
  "fuzzy-matcher",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -66,6 +66,7 @@ mozjpeg-rs = "0.9.0"
 webp = "0.3"
 jxl-oxide = { version = "0.12.5", features = ["image"] }
 jxl-encoder = "0.1.3"
+filetime = "0.2"
 libc = "0.2.183"
 rgb = "0.8.53"
 imgref = "1.12.0"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -40,6 +40,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose};
+use filetime;
 use image::codecs::jpeg::JpegEncoder;
 use image::{
     DynamicImage, GenericImageView, GrayImage, ImageBuffer, ImageFormat, Luma, Rgb, RgbImage, Rgba,
@@ -234,6 +235,8 @@ struct ExportSettings {
     jpeg_quality: u8,
     resize: Option<ResizeOptions>,
     keep_metadata: bool,
+    #[serde(default)]
+    preserve_timestamps: bool,
     strip_gps: bool,
     filename_template: Option<String>,
     watermark: Option<WatermarkSettings>,
@@ -1784,6 +1787,14 @@ fn process_image_for_export_pipeline(
     )
 }
 
+fn set_timestamps_from_exif(src: &Path, dst: &Path) {
+    let capture_dt = exif_processing::get_creation_date_from_path(src);
+    let ft = filetime::FileTime::from_unix_time(capture_dt.timestamp(), capture_dt.timestamp_subsec_nanos());
+    if let Err(e) = filetime::set_file_times(dst, ft, ft) {
+        log::warn!("Could not set timestamps on '{}': {}", dst.display(), e);
+    }
+}
+
 fn save_image_with_metadata(
     image: &DynamicImage,
     output_path: &std::path::Path,
@@ -2058,6 +2069,10 @@ fn export_masks_for_image(
                 export_settings,
             )?;
 
+            if export_settings.preserve_timestamps {
+                set_timestamps_from_exif(Path::new(source_path_str), &mask_image_path);
+            }
+
             let alpha_bytes = encode_grayscale_to_png(&alpha_resized)?;
             #[cfg(target_os = "android")]
             {
@@ -2206,6 +2221,10 @@ async fn export_image(
                 &source_path_str,
                 &export_settings,
             )?;
+
+            if export_settings.preserve_timestamps {
+                set_timestamps_from_exif(Path::new(&source_path_str), output_path_obj);
+            }
 
             if export_settings.export_masks {
                 export_masks_for_image(
@@ -2470,6 +2489,10 @@ async fn batch_export_images(
                         )?;
 
                         save_image_with_metadata(&final_image, &output_path, &source_path_str, &export_settings)?;
+
+                        if export_settings.preserve_timestamps {
+                            set_timestamps_from_exif(Path::new(&source_path_str), &output_path);
+                        }
 
                         if export_settings.export_masks {
                             export_masks_for_image(

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -191,6 +191,8 @@ export default function ExportPanel({
     setDontEnlarge,
     keepMetadata,
     setKeepMetadata,
+    preserveTimestamps,
+    setPreserveTimestamps,
     stripGps,
     setStripGps,
     exportMasks,
@@ -334,6 +336,7 @@ export default function ExportPanel({
       filenameTemplate,
       jpegQuality,
       keepMetadata,
+      preserveTimestamps,
       resize: enableResize ? { mode: resizeMode, value: resizeValue, dontEnlarge } : null,
       stripGps,
       watermark:
@@ -361,6 +364,7 @@ export default function ExportPanel({
     resizeValue,
     dontEnlarge,
     keepMetadata,
+    preserveTimestamps,
     stripGps,
     filenameTemplate,
     enableWatermark,
@@ -408,6 +412,7 @@ export default function ExportPanel({
       filenameTemplate: finalFilenameTemplate,
       jpegQuality: jpegQuality,
       keepMetadata,
+      preserveTimestamps,
       resize: enableResize ? { mode: resizeMode, value: resizeValue, dontEnlarge } : null,
       stripGps,
       exportMasks: isEditorContext ? exportMasks : undefined,
@@ -638,6 +643,15 @@ export default function ExportPanel({
                     </Section>
                   </>
                 )}
+
+                <Section title="File Timestamps">
+                  <Switch
+                    checked={preserveTimestamps}
+                    disabled={isExporting}
+                    label="Set File Timestamps from EXIF Capture Date"
+                    onChange={setPreserveTimestamps}
+                  />
+                </Section>
 
                 {isEditorContext && (
                   <Section title="Masks">

--- a/src/components/panel/right/LibraryExportPanel.tsx
+++ b/src/components/panel/right/LibraryExportPanel.tsx
@@ -192,6 +192,8 @@ export default function LibraryExportPanel({
     setDontEnlarge,
     keepMetadata,
     setKeepMetadata,
+    preserveTimestamps,
+    setPreserveTimestamps,
     stripGps,
     setStripGps,
     exportMasks,
@@ -356,6 +358,7 @@ export default function LibraryExportPanel({
       filenameTemplate,
       jpegQuality,
       keepMetadata,
+      preserveTimestamps,
       resize: enableResize ? { mode: resizeMode, value: resizeValue, dontEnlarge } : null,
       stripGps,
       watermark:
@@ -384,6 +387,7 @@ export default function LibraryExportPanel({
     resizeValue,
     dontEnlarge,
     keepMetadata,
+    preserveTimestamps,
     stripGps,
     filenameTemplate,
     enableWatermark,
@@ -435,6 +439,7 @@ export default function LibraryExportPanel({
       filenameTemplate: finalFilenameTemplate,
       jpegQuality: jpegQuality,
       keepMetadata,
+      preserveTimestamps,
       resize: enableResize ? { mode: resizeMode, value: resizeValue, dontEnlarge } : null,
       stripGps,
       exportMasks,
@@ -633,6 +638,15 @@ export default function LibraryExportPanel({
                     </Section>
                   </>
                 )}
+
+                <Section title="File Timestamps">
+                  <Switch
+                    checked={preserveTimestamps}
+                    disabled={isExporting}
+                    label="Set File Timestamps from EXIF Capture Date"
+                    onChange={setPreserveTimestamps}
+                  />
+                </Section>
 
                 <Section title="Masks">
                   <Switch

--- a/src/components/ui/ExportImportProperties.tsx
+++ b/src/components/ui/ExportImportProperties.tsx
@@ -37,6 +37,7 @@ export interface ExportSettings {
   filenameTemplate: string | null;
   jpegQuality: number;
   keepMetadata: boolean;
+  preserveTimestamps: boolean;
   resize: {
     mode: string;
     value: number;
@@ -105,6 +106,7 @@ export interface ExportPreset {
   resizeValue: number;
   dontEnlarge: boolean;
   keepMetadata: boolean;
+  preserveTimestamps: boolean;
   stripGps: boolean;
   exportMasks?: boolean;
   filenameTemplate: string;

--- a/src/hooks/useExportSettings.ts
+++ b/src/hooks/useExportSettings.ts
@@ -9,6 +9,7 @@ export function useExportSettings() {
   const [resizeValue, setResizeValue] = useState(2048);
   const [dontEnlarge, setDontEnlarge] = useState(true);
   const [keepMetadata, setKeepMetadata] = useState(true);
+  const [preserveTimestamps, setPreserveTimestamps] = useState(false);
   const [stripGps, setStripGps] = useState(true);
   const [exportMasks, setExportMasks] = useState(false);
   const [filenameTemplate, setFilenameTemplate] = useState('{original_filename}_edited');
@@ -27,6 +28,7 @@ export function useExportSettings() {
     setResizeValue(preset.resizeValue);
     setDontEnlarge(preset.dontEnlarge);
     setKeepMetadata(preset.keepMetadata);
+    setPreserveTimestamps(preset.preserveTimestamps ?? false);
     setStripGps(preset.stripGps);
     setExportMasks(preset.exportMasks ?? false);
     setFilenameTemplate(preset.filenameTemplate);
@@ -47,6 +49,7 @@ export function useExportSettings() {
       resizeValue,
       dontEnlarge,
       keepMetadata,
+      preserveTimestamps,
       stripGps,
       exportMasks,
       filenameTemplate,
@@ -65,6 +68,7 @@ export function useExportSettings() {
       resizeValue,
       dontEnlarge,
       keepMetadata,
+      preserveTimestamps,
       stripGps,
       exportMasks,
       filenameTemplate,
@@ -92,6 +96,8 @@ export function useExportSettings() {
     setDontEnlarge,
     keepMetadata,
     setKeepMetadata,
+    preserveTimestamps,
+    setPreserveTimestamps,
     stripGps,
     setStripGps,
     exportMasks,


### PR DESCRIPTION
Hi!
Thank you for this project - I am very happy to conveniently post-process the photos in the open-source Ubuntu project.
I have made the change about the exported image timestamps for myself, and thought it might be useful also for others.


## Rationale
I wanted exported photos to be easily sortable by timestamp in external apps. In particular, this was an issue for me in Google Photos, where export ordering is much more reliable when file timestamps align with the original capture time.

## Summary
- add a new export option: **Set File Timestamps from EXIF Capture Date**
- wire the new preserveTimestamps setting through export presets and both export UIs
- when enabled, set output file timestamps (and exported mask files) based on EXIF capture datetime
- include backend support using the filetime crate

## Testing
- tested on Ubuntu 24.04
- verified that enabling the new option writes exported file timestamps from EXIF capture date
- verified that disabled behavior remains unchanged

-------------------

Main branch:
| Exporting | Resulting file |
| :---: | :---: |
| <img width="1655" height="773" alt="image" src="https://github.com/user-attachments/assets/9f477f74-ed05-49b4-bc89-d8522e49b9ee" /> | <img width="488" height="612" alt="image" src="https://github.com/user-attachments/assets/6ae2e697-f997-49ef-825c-41dae68c157e" /> |

Feature, enabled:
| Exporting | Resulting file |
| :---: | :---: |
| <img width="1511" height="797" alt="image" src="https://github.com/user-attachments/assets/55068e51-0a09-4496-b6af-c0dbfe9f3036" /> | <img width="477" height="613" alt="image" src="https://github.com/user-attachments/assets/22dccb79-b441-4c2e-a59d-4e9e8804f9c0" /> |

Feature branch, the feature is disabled (matches the main branch):
| Exporting | Resulting file |
| :---: | :---: |
| <img width="1713" height="846" alt="image" src="https://github.com/user-attachments/assets/b0df0b5a-241c-4071-aaf8-4db15af47fea" /> | <img width="483" height="610" alt="image" src="https://github.com/user-attachments/assets/242afc79-93cb-4109-9553-a5fcc4be0ad0" /> |

