### PR TITLE
feat(masking): create new mask when duplicating and inverting a component

### DIFF
--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -570,7 +570,8 @@ export default function AIPanel({
 
   const handleDuplicateAndInvertPatchContainer = (container: AiPatch) => {
     const patchIndex = (adjustments.aiPatches || []).findIndex((patch) => patch.id === container.id);
-    const duplicatedContainer = clonePatchData(container, { invert: true, rename: true });
+    const duplicatedContainer = clonePatchData(container, { invert: true, rename: false });
+    duplicatedContainer.name = `${container.name} Inverted`;
 
     insertPatchContainer(duplicatedContainer, patchIndex >= 0 ? patchIndex + 1 : undefined);
   };
@@ -593,9 +594,19 @@ export default function AIPanel({
     insertSubMaskIntoContainer(containerId, duplicatedSubMask, insertIndex);
   };
 
-  const handleDuplicateAndInvertSubMask = (containerId: string, subMask: SubMask, insertIndex?: number) => {
-    const duplicatedSubMask = cloneSubMaskData(subMask, { invert: true, rename: true });
-    insertSubMaskIntoContainer(containerId, duplicatedSubMask, insertIndex);
+  const handleDuplicateAndInvertSubMask = (containerId: string, subMask: SubMask) => {
+    const parentContainer = (adjustments.aiPatches || []).find((p) => p.id === containerId);
+    if (!parentContainer) return;
+
+    const duplicatedSubMask = cloneSubMaskData(subMask, { invert: true, rename: false });
+    const newContainer = clonePatchData(parentContainer, { rename: false });
+
+    newContainer.name = `${getSubMaskName(subMask)} Inverted`;
+    newContainer.subMasks = [duplicatedSubMask];
+    newContainer.invert = false;
+
+    const parentIndex = (adjustments.aiPatches || []).findIndex((p) => p.id === containerId);
+    insertPatchContainer(newContainer, parentIndex >= 0 ? parentIndex + 1 : undefined);
   };
 
   const handlePasteSubMask = (containerId: string, insertIndex?: number) => {
@@ -1246,7 +1257,7 @@ function ContainerRow({
                   updateSubMask={updateSubMask}
                   handleDelete={() => handleDeleteSubMask(container.id, subMask.id)}
                   handleDuplicate={() => handleDuplicateSubMask(container.id, subMask, index + 1)}
-                  handleDuplicateAndInvert={() => handleDuplicateAndInvertSubMask(container.id, subMask, index + 1)}
+                  handleDuplicateAndInvert={() => handleDuplicateAndInvertSubMask(container.id, subMask)}
                   handlePaste={() => handlePasteSubMask(container.id, index + 1)}
                   handleCopy={() => copySubMaskToClipboard(subMask)}
                   hasCopiedSubMask={!!copiedSubMask}

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -964,7 +964,8 @@ export default function MasksPanel({
 
   const handleDuplicateAndInvertContainer = (container: MaskContainer) => {
     const containerIndex = adjustments.masks.findIndex((mask) => mask.id === container.id);
-    const duplicatedContainer = cloneMaskContainerData(container, { invert: true, rename: true });
+    const duplicatedContainer = cloneMaskContainerData(container, { invert: true, rename: false });
+    duplicatedContainer.name = `${container.name} Inverted`;
 
     insertMaskContainer(duplicatedContainer, containerIndex >= 0 ? containerIndex + 1 : undefined);
   };
@@ -988,10 +989,19 @@ export default function MasksPanel({
     insertSubMaskIntoContainer(containerId, duplicatedSubMask, insertIndex);
   };
 
-  const handleDuplicateAndInvertSubMask = (containerId: string, subMask: SubMask, insertIndex?: number) => {
-    const duplicatedSubMask = cloneSubMaskData(subMask, { invert: true, rename: true });
+  const handleDuplicateAndInvertSubMask = (containerId: string, subMask: SubMask) => {
+    const parentContainer = adjustments.masks.find((m) => m.id === containerId);
+    if (!parentContainer) return;
 
-    insertSubMaskIntoContainer(containerId, duplicatedSubMask, insertIndex);
+    const duplicatedSubMask = cloneSubMaskData(subMask, { invert: true, rename: false });
+    const newContainer = cloneMaskContainerData(parentContainer, { rename: false });
+
+    newContainer.name = `${getSubMaskName(subMask)} Inverted`;
+    newContainer.subMasks = [duplicatedSubMask];
+    newContainer.invert = false;
+
+    const parentIndex = adjustments.masks.findIndex((m) => m.id === containerId);
+    insertMaskContainer(newContainer, parentIndex >= 0 ? parentIndex + 1 : undefined);
   };
 
   const handlePasteSubMask = (containerId: string, insertIndex?: number) => {
@@ -1747,7 +1757,7 @@ function ContainerRow({
                   updateSubMask={updateSubMask}
                   handleDelete={() => handleDeleteSubMask(container.id, subMask.id)}
                   handleDuplicate={() => handleDuplicateSubMask(container.id, subMask, index + 1)}
-                  handleDuplicateAndInvert={() => handleDuplicateAndInvertSubMask(container.id, subMask, index + 1)}
+                  handleDuplicateAndInvert={() => handleDuplicateAndInvertSubMask(container.id, subMask)}
                   handlePaste={() => handlePasteSubMask(container.id, index + 1)}
                   handleCopy={() => copySubMaskToClipboard(subMask)}
                   hasCopiedSubMask={!!copiedSubMask}


### PR DESCRIPTION
## Description
This PR introduces a change where duplicating and inverting a mask component (submask) now automatically creates a new top-level mask, instead of adding it to the existing one. This makes the inversion logic more consistent with common user expectations and workflows, since inverting a mask and adding it to the same mask folder would essentially just cancel out the existing mask.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
<!-- List the specific changes made in this PR -->
- **Component Inversion**: Duplicating and inverting a submask now generates a new  mask folder containing only that inverted component.
- **Naming Convention**: All 'Duplicate and Invert' operations now use an 'Inverted' suffix (e.g., 'Subject Inverted') instead of 'Copy'.
- **Logic Cleanup**: Removed unused index parameters and updated UI calls accordingly.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->
<img width="313" height="242" alt="Screenshot 2026-04-15 at 12 34 34 AM" src="https://github.com/user-attachments/assets/695e121d-17a8-4480-95aa-80ae114c25cc" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** macOS Tahoe 26.4.1
- **Hardware:** Apple M1 Air

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)