### PR TITLE
feat(masking): add intersect mode and refactor sub-mask context menus

### DIFF
--- a/src-tauri/src/mask_generation.rs
+++ b/src-tauri/src/mask_generation.rs
@@ -14,6 +14,7 @@ use std::f32::consts::PI;
 pub enum SubMaskMode {
     Additive,
     Subtractive,
+    Intersect,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1213,6 +1214,12 @@ pub fn generate_mask_bitmap(
                     for (x, y, pixel) in final_mask.enumerate_pixels_mut() {
                         let sub_pixel = sub_bitmap.get_pixel(x, y);
                         pixel[0] = pixel[0].saturating_sub(sub_pixel[0]);
+                    }
+                }
+                SubMaskMode::Intersect => {
+                    for (x, y, pixel) in final_mask.enumerate_pixels_mut() {
+                        let sub_pixel = sub_bitmap.get_pixel(x, y);
+                        pixel[0] = pixel[0].min(sub_pixel[0]);
                     }
                 }
             }

--- a/src-tauri/src/mask_generation.rs
+++ b/src-tauri/src/mask_generation.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::f32::consts::PI;
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(crate = "serde")]
 #[serde(rename_all = "camelCase")]
 pub enum SubMaskMode {
     Additive,
@@ -17,7 +18,8 @@ pub enum SubMaskMode {
     Intersect,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(crate = "serde")]
 #[serde(rename_all = "camelCase")]
 pub struct SubMask {
     pub id: String,
@@ -36,7 +38,8 @@ fn default_opacity() -> f32 {
     100.0
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(crate = "serde")]
 #[serde(rename_all = "camelCase")]
 pub struct MaskDefinition {
     pub id: String,
@@ -57,14 +60,16 @@ impl MaskDefinition {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(crate = "serde")]
 #[serde(rename_all = "camelCase")]
 pub struct PatchData {
     pub color: String,
     pub mask: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(crate = "serde")]
 #[serde(rename_all = "camelCase")]
 pub struct AiPatchDefinition {
     pub id: String,

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -346,7 +346,13 @@ const MaskOverlay = memo(
       onClick: handleSelect,
       onTap: handleSelect,
       opacity: isSelected ? 1 : 0.7,
-      stroke: isSelected ? '#0ea5e9' : subMask.mode === SubMaskMode.Subtractive ? '#f43f5e' : 'white',
+      stroke: isSelected
+        ? '#0ea5e9'
+        : subMask.mode === SubMaskMode.Subtractive
+          ? '#f43f5e'
+          : subMask.mode === SubMaskMode.Intersect
+            ? '#a855f7'
+            : 'white',
       strokeScaleEnabled: false,
       strokeWidth: isSelected ? 3 : 2,
     };

--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -29,6 +29,7 @@ import {
   Wand2,
   Send,
   FolderOpen,
+  Combine,
 } from 'lucide-react';
 
 import CollapsibleSection from '../../ui/CollapsibleSection';
@@ -349,8 +350,8 @@ export default function AIPanel({
     setAdjustments((prev: Adjustments) => ({ ...prev, aiPatches: [] }));
   };
 
-  const createMaskLogic = (type: Mask) => {
-    const subMask = createSubMask(type, selectedImage);
+  const createMaskLogic = (type: Mask, mode: SubMaskMode = SubMaskMode.Additive) => {
+    const subMask = createSubMask(type, selectedImage, mode);
 
     const steps = adjustments?.orientationSteps || 0;
     const isRotated = steps === 1 || steps === 3;
@@ -418,8 +419,13 @@ export default function AIPanel({
     if (type === Mask.AiForeground) onGenerateAiForegroundMask(subMask.id);
   };
 
-  const handleAddSubMask = (containerId: string, type: Mask, insertIndex: number = -1) => {
-    const subMask = createMaskLogic(type);
+  const handleAddSubMask = (
+    containerId: string,
+    type: Mask,
+    mode: SubMaskMode = SubMaskMode.Additive,
+    insertIndex: number = -1,
+  ) => {
+    const subMask = createMaskLogic(type, mode);
     setAdjustments((prev: Adjustments) => ({
       ...prev,
       aiPatches: prev.aiPatches?.map((c: AiPatch) => {
@@ -443,21 +449,49 @@ export default function AIPanel({
     event.stopPropagation();
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
 
-    const types = targetContainerId ? AI_SUB_MASK_COMPONENT_TYPES : AI_PANEL_CREATION_TYPES;
+    const buildMenu = (types: MaskType[], mode: SubMaskMode = SubMaskMode.Additive) =>
+      types
+        .filter((mt) => !mt.disabled)
+        .map((maskType: MaskType) => ({
+          label: maskType.name,
+          icon: maskType.icon,
+          onClick: () => {
+            if (targetContainerId) {
+              handleAddSubMask(targetContainerId, maskType.type, mode);
+            } else {
+              handleAddAiPatchContainer(maskType.type);
+            }
+          },
+        }));
 
-    const options = types
-      .filter((mt) => !mt.disabled)
-      .map((maskType: MaskType) => ({
-        label: maskType.name,
-        icon: maskType.icon,
-        onClick: () => {
-          if (targetContainerId) {
-            handleAddSubMask(targetContainerId, maskType.type);
-          } else {
-            handleAddAiPatchContainer(maskType.type);
-          }
-        },
-      }));
+    const container = targetContainerId ? adjustments.aiPatches.find((m) => m.id === targetContainerId) : null;
+    const hasComponents = container && container.subMasks.length > 0;
+
+    let options: any[];
+
+    if (!targetContainerId) {
+      // For a brand new mask, just show the types directly
+      options = buildMenu(AI_PANEL_CREATION_TYPES, SubMaskMode.Additive);
+    } else {
+      // For an existing mask, show the types directly at the top level
+      options = buildMenu(AI_SUB_MASK_COMPONENT_TYPES, SubMaskMode.Additive);
+
+      if (hasComponents) {
+        options.push(
+          { type: OPTION_SEPARATOR },
+          {
+            label: 'Subtract from Edit',
+            icon: Minus,
+            submenu: buildMenu(AI_SUB_MASK_COMPONENT_TYPES, SubMaskMode.Subtractive),
+          },
+          {
+            label: 'Intersect Edit with',
+            icon: Combine,
+            submenu: buildMenu(AI_SUB_MASK_COMPONENT_TYPES, SubMaskMode.Intersect),
+          },
+        );
+      }
+    }
 
     showContextMenu(rect.left, rect.bottom + 5, options);
   };
@@ -657,7 +691,7 @@ export default function AIPanel({
           const container = adjustments.aiPatches.find((p) => p.id === overData.parentId);
           if (container) {
             const targetIndex = container.subMasks.findIndex((sm) => sm.id === over!.id);
-            handleAddSubMask(overData.parentId!, dragData.maskType!, targetIndex);
+            handleAddSubMask(overData.parentId!, dragData.maskType!, SubMaskMode.Additive, targetIndex);
           }
         } else {
           handleAddAiPatchContainer(dragData.maskType!);
@@ -1476,18 +1510,37 @@ function SubMaskRow({
         </Text>
       )}
       <div className="flex opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
-          className="p-1 hover:text-text-primary text-text-secondary"
-          data-tooltip={subMask.mode === SubMaskMode.Additive ? 'Switch to Subtract' : 'Switch to Add'}
-          onClick={(e) => {
-            e.stopPropagation();
-            updateSubMask(subMask.id, {
-              mode: subMask.mode === SubMaskMode.Additive ? SubMaskMode.Subtractive : SubMaskMode.Additive,
-            });
-          }}
-        >
-          {subMask.mode === SubMaskMode.Additive ? <Plus size={16} /> : <Minus size={16} />}
-        </button>
+        {index > 1 && (
+          <button
+            className="p-1 hover:text-text-primary text-text-secondary"
+            data-tooltip={
+              subMask.mode === SubMaskMode.Additive
+                ? 'Switch to Subtract'
+                : subMask.mode === SubMaskMode.Subtractive
+                  ? 'Switch to Intersect'
+                  : 'Switch to Add'
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              updateSubMask(subMask.id, {
+                mode:
+                  subMask.mode === SubMaskMode.Additive
+                    ? SubMaskMode.Subtractive
+                    : subMask.mode === SubMaskMode.Subtractive
+                      ? SubMaskMode.Intersect
+                      : SubMaskMode.Additive,
+              });
+            }}
+          >
+            {subMask.mode === SubMaskMode.Additive ? (
+              <Plus size={16} />
+            ) : subMask.mode === SubMaskMode.Subtractive ? (
+              <Minus size={16} />
+            ) : (
+              <Combine size={16} />
+            )}
+          </button>
+        )}
         <button
           className="p-1 hover:text-red-500 text-text-secondary"
           data-tooltip="Delete Component"

--- a/src/components/panel/right/Masks.tsx
+++ b/src/components/panel/right/Masks.tsx
@@ -32,6 +32,7 @@ export enum Mask {
 export enum SubMaskMode {
   Additive = 'additive',
   Subtractive = 'subtractive',
+  Intersect = 'intersect',
 }
 
 export enum ToolType {

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -32,6 +32,7 @@ import {
   RotateCcw,
   Trash2,
   Bookmark,
+  Combine,
 } from 'lucide-react';
 
 import CollapsibleSection from '../../ui/CollapsibleSection';
@@ -700,8 +701,8 @@ export default function MasksPanel({
     setAdjustments((prev: any) => ({ ...prev, masks: [] }));
   };
 
-  const createMaskLogic = (type: Mask) => {
-    const subMask = createSubMask(type, selectedImage);
+  const createMaskLogic = (type: Mask, mode: SubMaskMode = SubMaskMode.Additive) => {
+    const subMask = createSubMask(type, selectedImage, mode);
 
     const steps = adjustments?.orientationSteps || 0;
     const isRotated = steps === 1 || steps === 3;
@@ -760,8 +761,8 @@ export default function MasksPanel({
     else if (type === Mask.AiDepth) onGenerateAiDepthMask(subMask.id, subMask.parameters);
   };
 
-  const handleAddSubMask = (containerId: string, type: Mask, insertIndex: number = -1) => {
-    const subMask = createMaskLogic(type);
+  const handleAddSubMask = (containerId: string, type: Mask, mode: SubMaskMode = SubMaskMode.Additive, insertIndex: number = -1) => {
+    const subMask = createMaskLogic(type, mode);
     setAdjustments((prev: Adjustments) => ({
       ...prev,
       masks: prev.masks?.map((c: MaskContainer) => {
@@ -815,41 +816,60 @@ export default function MasksPanel({
     event.stopPropagation();
     const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
 
-    const buildMenu = (types: MaskType[]) =>
+    const buildMenu = (types: MaskType[], mode: SubMaskMode = SubMaskMode.Additive) =>
       types.map((maskType: MaskType) => ({
         label: maskType.name,
         icon: maskType.icon,
         disabled: maskType.disabled,
         onClick: () => {
           if (targetContainerId) {
-            handleAddSubMask(targetContainerId, maskType.type);
+            handleAddSubMask(targetContainerId, maskType.type, mode);
           } else {
             handleAddMaskContainer(maskType.type);
           }
         },
       }));
 
-    const options = MASK_PANEL_CREATION_TYPES.map((maskType: MaskType) => {
-      if (maskType.id === 'others') {
+    const container = targetContainerId ? adjustments.masks.find((m) => m.id === targetContainerId) : null;
+    const hasComponents = container && container.subMasks.length > 0;
+
+    const buildModeSubmenu = (label: string, icon: any, mode: SubMaskMode) => ({
+      label,
+      icon,
+      submenu: MASK_PANEL_CREATION_TYPES.map((maskType) => {
+        if (maskType.id === 'others') {
+          return {
+            label: maskType.name,
+            icon: maskType.icon,
+            submenu: buildMenu(OTHERS_MASK_TYPES, mode),
+          };
+        }
         return {
           label: maskType.name,
           icon: maskType.icon,
-          submenu: buildMenu(OTHERS_MASK_TYPES),
+          disabled: maskType.disabled,
+          onClick: () => handleAddSubMask(targetContainerId!, maskType.type, mode),
         };
-      }
-      return {
-        label: maskType.name,
-        icon: maskType.icon,
-        disabled: maskType.disabled,
-        onClick: () => {
-          if (targetContainerId) {
-            handleAddSubMask(targetContainerId, maskType.type);
-          } else {
-            handleAddMaskContainer(maskType.type);
-          }
-        },
-      };
+      }),
     });
+
+    const options: any[] = buildMenu(MASK_PANEL_CREATION_TYPES.filter((m) => m.id !== 'others'), SubMaskMode.Additive);
+    const others = MASK_PANEL_CREATION_TYPES.find((m) => m.id === 'others');
+    if (others) {
+      options.push({
+        label: others.name,
+        icon: others.icon,
+        submenu: buildMenu(OTHERS_MASK_TYPES, SubMaskMode.Additive),
+      });
+    }
+
+    if (targetContainerId && hasComponents) {
+      options.push(
+        { type: OPTION_SEPARATOR },
+        buildModeSubmenu('Subtract from Mask', Minus, SubMaskMode.Subtractive),
+        buildModeSubmenu('Intersect Mask with', Combine, SubMaskMode.Intersect),
+      );
+    }
 
     showContextMenu(rect.left, rect.bottom + 5, options);
   };
@@ -1982,18 +2002,37 @@ function SubMaskRow({
         </Text>
       )}
       <div className="flex opacity-0 group-hover:opacity-100 transition-opacity">
-        <button
-          className="p-1 hover:text-text-primary text-text-secondary"
-          data-tooltip={subMask.mode === SubMaskMode.Additive ? 'Switch to Subtract' : 'Switch to Add'}
-          onClick={(e) => {
-            e.stopPropagation();
-            updateSubMask(subMask.id, {
-              mode: subMask.mode === SubMaskMode.Additive ? SubMaskMode.Subtractive : SubMaskMode.Additive,
-            });
-          }}
-        >
-          {subMask.mode === SubMaskMode.Additive ? <Plus size={16} /> : <Minus size={16} />}
-        </button>
+        {index > 1 && (
+          <button
+            className="p-1 hover:text-text-primary text-text-secondary"
+            data-tooltip={
+              subMask.mode === SubMaskMode.Additive
+                ? 'Switch to Subtract'
+                : subMask.mode === SubMaskMode.Subtractive
+                  ? 'Switch to Intersect'
+                  : 'Switch to Add'
+            }
+            onClick={(e) => {
+              e.stopPropagation();
+              updateSubMask(subMask.id, {
+                mode:
+                  subMask.mode === SubMaskMode.Additive
+                    ? SubMaskMode.Subtractive
+                    : subMask.mode === SubMaskMode.Subtractive
+                      ? SubMaskMode.Intersect
+                      : SubMaskMode.Additive,
+              });
+            }}
+          >
+            {subMask.mode === SubMaskMode.Additive ? (
+              <Plus size={16} />
+            ) : subMask.mode === SubMaskMode.Subtractive ? (
+              <Minus size={16} />
+            ) : (
+              <Combine size={16} />
+            )}
+          </button>
+        )}
         <button
           className="p-1 hover:text-text-primary text-text-secondary"
           data-tooltip={subMask.visible ? 'Hide Component' : 'Show Component'}

--- a/src/utils/maskUtils.tsx
+++ b/src/utils/maskUtils.tsx
@@ -2,14 +2,18 @@ import { v4 as uuidv4 } from 'uuid';
 import { Mask, SubMaskMode, formatMaskTypeName } from '../components/panel/right/Masks';
 import { ImageDimensions } from '../hooks/useImageRenderSize';
 
-export const createSubMask = (type: Mask, imageDimensions: ImageDimensions) => {
+export const createSubMask = (
+  type: Mask,
+  imageDimensions: ImageDimensions,
+  mode: SubMaskMode = SubMaskMode.Additive
+) => {
   const { width, height } = imageDimensions || { width: 1000, height: 1000 };
   const common = {
     id: uuidv4(),
     visible: true,
     invert: false,
     opacity: 100,
-    mode: SubMaskMode.Additive,
+    mode,
     name: formatMaskTypeName(type),
     type,
   };


### PR DESCRIPTION
## Description
Add a new **Intersect** mask blending mode alongside the existing Additive and Subtractive modes, and refactor the context menus in both AIPanel and MasksPanel to expose all three modes in a structured way.

Additionally, this PR includes a **linker fix** for macOS targets by using explicit  crate paths in the backend, resolving 'Undefined symbols' errors caused by toolchain version mismatches.

## Type of Change
- [x] New feature
- [x] UI/UX improvement
- [x] Bug fix (linker/build)

## Changes Made
### Frontend
- Added  enum variant to support three-way mask blending
- Refactored context menus in AIPanel and MasksPanel to show **Subtract from Edit/Mask** and **Intersect Edit/Mask with** submenus when a container already has components
- Updated SubMaskRow mode toggle button to cycle through Add → Subtract → Intersect (with matching icons: Plus, Minus, Combine)
- Hidden the mode toggle on the first sub-mask component (index ≤ 1) since it has no predecessor to blend against
- Threaded the `mode` parameter through `createSubMask`, `createMaskLogic`, and `handleAddSubMask` so new components respect the selected mode
- Added purple visual feedback for intersection masks on the canvas

### Backend (Rust)
- Added intersect case to the Rust `mask_generation` backend using a 'Min' blend operation
- **Build Fix**: Hardened `serde` derives in `mask_generation.rs` using `#[serde(crate = "serde")]` and fully qualified paths to resolve linker issues on macOS arm64.

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues
- [x] Verified that the Rust backend correctly handles the new 'Intersect' mode logic
- [x] Subtract/Intersect options don't show up for first component in the mask

<img width="977" height="450" alt="Screenshot 2026-04-16 at 12 01 42 AM" src="https://github.com/user-attachments/assets/9f47bb5b-ac39-48a5-b0b8-5304895ad683" />
<img width="950" height="506" alt="Screenshot 2026-04-16 at 12 02 03 AM" src="https://github.com/user-attachments/assets/f80f154e-cec9-49b9-b942-e51c6291387d" />
<img width="956" height="472" alt="Screenshot 2026-04-16 at 12 02 34 AM" src="https://github.com/user-attachments/assets/d527f7ae-4822-41d4-8e30-80f9b3c10694" />

**Test Configuration:**
- **OS:** macOS
- **Hardware:** Apple Silicon (M-series)

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
- [x] This PR is AI-generated but guided by a human