### PR TITLE
Rating ui improvement

### DIFF
--- a/src/components/panel/Filmstrip.tsx
+++ b/src/components/panel/Filmstrip.tsx
@@ -212,7 +212,7 @@ const FilmstripThumbnail = memo(
         )}
 
         {(colorLabel || rating > 0) && (
-          <div className="absolute top-1 right-1 bg-primary rounded-full px-1.5 py-0.5 text-xs text-white flex items-center gap-1 backdrop-blur-xs shadow-xs z-10">
+          <div className="absolute top-1 right-1 bg-surface rounded-full px-1.5 py-0.5 text-xs text-white flex items-center gap-1 shadow-xs z-10">
             {colorLabel && (
               <div
                 className="w-3 h-3 rounded-full ring-1 ring-black/20"

--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -1331,7 +1331,7 @@ function Thumbnail({
       </AnimatePresence>
 
       {(colorLabel || rating > 0) && (
-        <div className="absolute top-1.5 right-1.5 bg-bg-primary/50 rounded-full px-1.5 py-0.5 flex items-center gap-1 backdrop-blur-xs">
+        <div className="absolute top-1.5 right-1.5 bg-surface rounded-full px-1.5 py-0.5 flex items-center gap-1">
           {colorLabel && (
             <div
               className="w-3 h-3 rounded-full ring-1 ring-black/20"


### PR DESCRIPTION
## Description
This PR updates thumbnail ratings badges from translucent/blurred styling to solid theme-based backing for better readability across all images, especially bright / white images.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Updated the top-right rating/color badge in filmstrip thumbnails to use a solid surface background instead of translucent blur.
- Updated the top-right rating/color badge in gallery thumbnails to use a solid surface background instead of translucent blur.
- Kept badge position, spacing, and content behaviour unchanged.

## Screenshots
<img width="1421" height="466" alt="before" src="https://github.com/user-attachments/assets/0e874ccf-fd2f-4578-bbfd-95bfbe657a06" />
<img width="1358" height="460" alt="after" src="https://github.com/user-attachments/assets/2a04030c-aa6e-4d2d-b1a3-73ff186045dd" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows
- **Hardware:** Not specified

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
This is a styling-only change intended to align badge visuals with existing theme surface tokens.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)