### PR TITLE
Rating assignment fix

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2735,12 +2735,8 @@ function App() {
         return;
       }
 
-      let currentRating = 0;
-      if (selectedImage && pathsToRate.includes(selectedImage.path)) {
-        currentRating = adjustments.rating;
-      } else if (libraryActivePath && pathsToRate.includes(libraryActivePath)) {
-        currentRating = libraryActiveAdjustments.rating;
-      }
+      const activePath = selectedImage?.path || libraryActivePath;
+      const currentRating = activePath ? imageRatings[activePath] || 0 : 0;
 
       const finalRating = newRating === currentRating ? 0 : newRating;
 
@@ -2771,8 +2767,7 @@ function App() {
       multiSelectedPaths,
       selectedImage,
       libraryActivePath,
-      adjustments.rating,
-      libraryActiveAdjustments.rating,
+      imageRatings,
       setAdjustments,
     ],
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2736,8 +2736,16 @@ function App() {
       }
 
       const activePath = selectedImage?.path || libraryActivePath;
-      const currentRating = activePath ? imageRatings[activePath] || 0 : 0;
-
+      let currentRating = 0;
+      
+      if (selectedImage && pathsToRate.includes(selectedImage.path)) {
+        currentRating = imageRatings[selectedImage.path] || 0;
+      } else if (libraryActivePath && pathsToRate.includes(libraryActivePath)) {
+        currentRating = imageRatings[libraryActivePath] || 0;
+      } else if (pathsToRate.length > 0) {
+        currentRating = imageRatings[pathsToRate[0]] || 0;
+      }
+      
       const finalRating = newRating === currentRating ? 0 : newRating;
 
       setImageRatings((prev: Record<string, number>) => {


### PR DESCRIPTION
## Description
Fix inconsistent keyboard rating assignment by using the current image rating as the toggle baseline instead of the laggy adjustment snapshot. This keeps number-key shortcuts from unexpectedly clearing ratings when moving quickly between images.

When rapidly changing ratings via the num and arrow keys, issues such as the following would occur:
Rating removed (changed to 0) instead of updating to the new rating
Rating reverted soon after the press

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Updated the rating handler to read the active image's rating from `imageRatings` before deciding whether a key press should toggle to zero.
- Kept the existing rating write path intact so the UI and backend still receive the same final rating updates.

## Screenshots/Videos
Not applicable.

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows
- **Hardware:** N/A

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)