### PR TITLE
Revert "Rating assignment fix"

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2757,17 +2757,13 @@ function App() {
         return;
       }
 
-      const activePath = selectedImage?.path || libraryActivePath;
       let currentRating = 0;
-      
       if (selectedImage && pathsToRate.includes(selectedImage.path)) {
-        currentRating = imageRatings[selectedImage.path] || 0;
+        currentRating = adjustments.rating;
       } else if (libraryActivePath && pathsToRate.includes(libraryActivePath)) {
-        currentRating = imageRatings[libraryActivePath] || 0;
-      } else if (pathsToRate.length > 0) {
-        currentRating = imageRatings[pathsToRate[0]] || 0;
+        currentRating = libraryActiveAdjustments.rating;
       }
-      
+
       const finalRating = newRating === currentRating ? 0 : newRating;
 
       setImageRatings((prev: Record<string, number>) => {
@@ -2797,7 +2793,8 @@ function App() {
       multiSelectedPaths,
       selectedImage,
       libraryActivePath,
-      imageRatings,
+      adjustments.rating,
+      libraryActiveAdjustments.rating,
       setAdjustments,
     ],
   );


### PR DESCRIPTION
Reverts CyberTimon/RapidRAW#1042. Causes a lot of unexpected bugs when using multiple selected paths. Maybe @Thespacemanfil you can look into this? For you to reproduce: Try to select like 5 images and then press the key "4" to rate them with 4 stars. It will flash and flicker around endlessly...