### PR TITLE
fix(macos): init GPU context on main thread (#1047)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4891,6 +4891,17 @@ pub fn run() {
 
             #[cfg(not(target_os = "android"))]
             {
+                // Metal requires creating the window surface on the main thread. Preview and
+                // thumbnail work runs on background threads; initialize once here so they only
+                // clone the cached GpuContext (avoids panic + erroneous OpenGL fallback).
+                let app_state = app.state::<AppState>();
+                if let Err(error) = get_or_init_gpu_context(&app_state, app.handle()) {
+                    log::warn!(
+                        "GPU pre-initialization failed (editing and thumbnails may be degraded): {}",
+                        error
+                    );
+                }
+
                 if let Ok(config_dir) = app.path().app_config_dir() {
                     let path = config_dir.join("window_state.json");
                     if let Ok(contents) = std::fs::read_to_string(&path) {


### PR DESCRIPTION
Hi after setting up my dev environment for the first time, I was unable to get passed this crash/issue.

I believe that this commit earlier today may have been the cause: [“implement direct wgpu renderer”](https://github.com/CyberTimon/RapidRAW/commit/5edd9fb17fa446ae3399dfc682aa782a6dfa4a11) or similar changes?

## Summary
Pre-initializes `get_or_init_gpu_context` on the **main thread** immediately after the main window is built in `setup`.

On macOS, Metal requires `get_metal_layer` / surface creation on the UI thread. Thumbnail generation (Rayon) and the preview worker call `get_or_init_gpu_context` from **background threads**; if they run first, the process can panic and crash recovery incorrectly forces OpenGL.

## Changes
- After `window_builder.build()`, call `get_or_init_gpu_context` once (non-Android) so later callers only clone the cached context.

Fixes #1047

Assisted by [Cursor](https://cursor.com)