### PR TITLE
ui: Adjust some icons for better clarity

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   CopyPlus,
   Edit,
   FileEdit,
+  FileInput,
   Folder,
   FolderInput,
   FolderPlus,
@@ -28,7 +29,6 @@ import {
   RefreshCw,
   RotateCcw,
   Star,
-  Save,
   SquaresUnite,
   Palette,
   Tag,
@@ -4295,7 +4295,7 @@ function App() {
     const options: Array<Option> = [
       {
         label: 'Export Image',
-        icon: Save,
+        icon: FileInput,
         onClick: () => {
           setRenderedRightPanel(Panel.Export);
           setActiveRightPanel(Panel.Export);
@@ -4596,7 +4596,7 @@ function App() {
               onClick: () => handleImageSelect(finalSelection[0]),
             },
             {
-              icon: Save,
+              icon: FileInput,
               label: exportLabel,
               onClick: onExportClick,
             },
@@ -4604,7 +4604,7 @@ function App() {
           ]
         : [
             {
-              icon: Save,
+              icon: FileInput,
               label: exportLabel,
               onClick: onExportClick,
             },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ import {
   LayoutTemplate,
   Redo,
   RefreshCw,
-  RotateCcw,
+  Eraser,
   Star,
   SquaresUnite,
   Palette,
@@ -4415,7 +4415,7 @@ function App() {
       { type: OPTION_SEPARATOR },
       {
         label: 'Reset Adjustments',
-        icon: RotateCcw,
+        icon: Eraser,
         onClick: () => {
           debouncedSetHistory.cancel();
           const currentRating = adjustments.rating;
@@ -4816,7 +4816,7 @@ function App() {
           );
         },
       },
-      { label: resetLabel, icon: RotateCcw, onClick: () => handleResetAdjustments(finalSelection) },
+      { label: resetLabel, icon: Eraser, onClick: () => handleResetAdjustments(finalSelection) },
       deleteOption,
     ];
     showContextMenu(event.clientX, event.clientY, options);

--- a/src/components/panel/BottomBar.tsx
+++ b/src/components/panel/BottomBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Star, Copy, ClipboardPaste, RotateCcw, ChevronUp, ChevronDown, Check, FileInput, Settings } from 'lucide-react';
+import { Star, Copy, ClipboardPaste, ChevronUp, ChevronDown, Check, FileInput, Settings, Eraser } from 'lucide-react';
 import clsx from 'clsx';
 import { motion, AnimatePresence } from 'framer-motion';
 import Filmstrip from './Filmstrip';
@@ -363,7 +363,7 @@ export default function BottomBar({
               onClick={onReset}
               data-tooltip="Reset All Adjustments"
             >
-              <RotateCcw size={18} />
+              <Eraser size={18} />
             </button>
             <button
               className="w-8 h-8 flex items-center justify-center rounded-md text-text-secondary hover:bg-surface hover:text-text-primary transition-colors disabled:opacity-40 disabled:hover:bg-transparent disabled:cursor-not-allowed"

--- a/src/components/panel/BottomBar.tsx
+++ b/src/components/panel/BottomBar.tsx
@@ -371,7 +371,7 @@ export default function BottomBar({
               onClick={onExportClick}
               data-tooltip="Export"
             >
-              <Save size={18} />
+              <FileInput size={18} />
             </button>
           </div>
         ) : (

--- a/src/components/panel/BottomBar.tsx
+++ b/src/components/panel/BottomBar.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { Star, Copy, ClipboardPaste, RotateCcw, ChevronUp, ChevronDown, Check, Save, Settings } from 'lucide-react';
+import { Star, Copy, ClipboardPaste, RotateCcw, ChevronUp, ChevronDown, Check, FileInput, Settings } from 'lucide-react';
 import clsx from 'clsx';
 import { motion, AnimatePresence } from 'framer-motion';
 import Filmstrip from './Filmstrip';

--- a/src/components/panel/CommunityPage.tsx
+++ b/src/components/panel/CommunityPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { ArrowLeft, CheckCircle2, ChevronDown, Loader2, Search, Users, Layers, Scaling, Github } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, ChevronDown, Loader2, Search, Users, Blend, Crop, Github } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
@@ -317,8 +317,8 @@ const CommunityPage = ({ onBackToLibrary, imageList, currentFolderPath }: Commun
 
                       {/* Optional: Add small icons next to the name if the preset supports them */}
                       <div className="flex justify-center gap-2 mt-1 opacity-60">
-                        {preset.includeMasks && <Layers size={12} title="Includes Masks" />}
-                        {preset.includeCropTransform && <Scaling size={12} title="Includes Geometry" />}
+                        {preset.includeMasks && <Blend size={12} title="Includes Masks" />}
+                        {preset.includeCropTransform && <Crop size={12} title="Includes Geometry" />}
                       </div>
                     </div>
                   </motion.div>

--- a/src/components/panel/CommunityPage.tsx
+++ b/src/components/panel/CommunityPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { invoke } from '@tauri-apps/api/core';
-import { ArrowLeft, CheckCircle2, ChevronDown, Loader2, Search, Users, Blend, Crop, Github } from 'lucide-react';
+import { ArrowLeft, CheckCircle2, ChevronDown, Loader2, Search, Users, Layers, Crop, Github } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Button from '../ui/Button';
 import Input from '../ui/Input';
@@ -317,7 +317,7 @@ const CommunityPage = ({ onBackToLibrary, imageList, currentFolderPath }: Commun
 
                       {/* Optional: Add small icons next to the name if the preset supports them */}
                       <div className="flex justify-center gap-2 mt-1 opacity-60">
-                        {preset.includeMasks && <Blend size={12} title="Includes Masks" />}
+                        {preset.includeMasks && <Layers size={12} title="Includes Masks" />}
                         {preset.includeCropTransform && <Crop size={12} title="Includes Geometry" />}
                       </div>
                     </div>

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { RotateCcw, Copy, ClipboardPaste, Aperture, ChartArea } from 'lucide-react';
+import { RotateCcw, Copy, ClipboardPaste, Aperture, ChartArea, Eraser } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
 import BasicAdjustments from '../../adjustments/Basic';
@@ -230,7 +230,7 @@ export default function Controls({
             onClick={handleResetAdjustments}
             data-tooltip="Reset Adjustments"
           >
-            <RotateCcw size={18} />
+            <Eraser size={18} />
           </button>
         </div>
       </div>

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
-import { Save, CheckCircle, XCircle, Loader, Ban } from 'lucide-react';
+import { FileInput, CheckCircle, XCircle, Loader, Ban } from 'lucide-react';
 import debounce from 'lodash.debounce';
 import Switch from '../../ui/Switch';
 import Button from '../../ui/Button';
@@ -816,7 +816,7 @@ export default function ExportPanel({
             </>
           ) : (
             <>
-              <Save size={18} className="mr-2" /> Export {numImages > 1 ? `${numImages} ${itemLabel}s` : itemLabel}
+              <FileInput size={18} className="mr-2" /> Export {numImages > 1 ? `${numImages} ${itemLabel}s` : itemLabel}
             </>
           )}
         </Button>

--- a/src/components/panel/right/LibraryExportPanel.tsx
+++ b/src/components/panel/right/LibraryExportPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
-import { Save, CheckCircle, XCircle, Loader, X, Ban } from 'lucide-react';
+import { FileInput, CheckCircle, XCircle, Loader, X, Ban } from 'lucide-react';
 import debounce from 'lodash.debounce';
 import Switch from '../../ui/Switch';
 import Button from '../../ui/Button';
@@ -809,7 +809,7 @@ export default function LibraryExportPanel({
             </>
           ) : (
             <>
-              <Save size={18} className="mr-2" /> Export {numImages > 1 ? `${numImages} ${itemLabel}s` : itemLabel}
+              <FileInput size={18} className="mr-2" /> Export {numImages > 1 ? `${numImages} ${itemLabel}s` : itemLabel}
             </>
           )}
         </Button>

--- a/src/components/panel/right/Masks.tsx
+++ b/src/components/panel/right/Masks.tsx
@@ -6,7 +6,7 @@ import {
   Droplet,
   Droplets,
   Eraser,
-  Layers,
+  MoreHorizontal,
   RectangleHorizontal,
   Sparkles,
   TriangleRight,
@@ -124,7 +124,7 @@ export const MASK_PANEL_CREATION_TYPES: Array<MaskType> = [
   },
   {
     disabled: false,
-    icon: Layers,
+    icon: MoreHorizontal,
     id: 'others',
     name: 'Others',
     type: null,
@@ -203,7 +203,7 @@ export const SUB_MASK_COMPONENT_TYPES: Array<MaskType> = [
   },
   {
     disabled: false,
-    icon: Layers,
+    icon: MoreHorizontal,
     id: 'others',
     name: 'Others',
     type: null,

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -31,7 +31,7 @@ import {
   PlusSquare,
   RotateCcw,
   Trash2,
-  Bookmark,
+  SwatchBook,
   SquaresIntersect,
 } from 'lucide-react';
 
@@ -1652,7 +1652,7 @@ function ContainerRow({
       },
       {
         label: 'Apply Preset',
-        icon: Bookmark,
+        icon: SwatchBook,
         submenu: generatePresetSubmenu(presets).length
           ? generatePresetSubmenu(presets)
           : [{ label: 'No presets', disabled: true }],

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -21,12 +21,12 @@ import {
   FolderOpen,
   FolderPlus,
   Loader2,
+  Layers,
   Plus,
   RefreshCw,
   SortAsc,
   Trash2,
   Users,
-  Blend,
   Crop,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -134,7 +134,7 @@ function PresetItemDisplay({ preset, previewUrl, isGeneratingPreviews }: PresetI
 
         {(supportsMasks || supportsGeometry) && (
           <div className="absolute top-1 right-1 bg-primary rounded-full px-1.5 py-0.5 flex items-center gap-1.5 backdrop-blur-xs shadow-xs z-10 pointer-events-none">
-            {supportsMasks && <Blend size={11} className="text-white" />}
+            {supportsMasks && <Layers size={11} className="text-white" />}
             {supportsGeometry && <Crop size={11} className="text-white" />}
           </div>
         )}

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -26,8 +26,8 @@ import {
   SortAsc,
   Trash2,
   Users,
-  Layers,
-  Scaling,
+  Blend,
+  Crop,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import AddPresetModal from '../../modals/AddPresetModal';
@@ -134,8 +134,8 @@ function PresetItemDisplay({ preset, previewUrl, isGeneratingPreviews }: PresetI
 
         {(supportsMasks || supportsGeometry) && (
           <div className="absolute top-1 right-1 bg-primary rounded-full px-1.5 py-0.5 flex items-center gap-1.5 backdrop-blur-xs shadow-xs z-10 pointer-events-none">
-            {supportsMasks && <Layers size={11} className="text-white" />}
-            {supportsGeometry && <Scaling size={11} className="text-white" />}
+            {supportsMasks && <Blend size={11} className="text-white" />}
+            {supportsGeometry && <Crop size={11} className="text-white" />}
           </div>
         )}
       </div>

--- a/src/components/panel/right/RightPanelSwitcher.tsx
+++ b/src/components/panel/right/RightPanelSwitcher.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { SlidersHorizontal, Info, Crop, Blend, Paintbrush, SwatchBook, FileInput } from 'lucide-react';
+import { SlidersHorizontal, Info, Crop, Layers, Paintbrush, SwatchBook, FileInput } from 'lucide-react';
 import { Panel } from '../../ui/AppProperties';
 
 interface PanelOptions {
@@ -19,7 +19,7 @@ const panelGroups: Array<Array<PanelOptions>> = [
   [
     { id: Panel.Adjustments, icon: SlidersHorizontal, title: 'Adjust' },
     { id: Panel.Crop, icon: Crop, title: 'Crop' },
-    { id: Panel.Masks, icon: Blend, title: 'Masks' },
+    { id: Panel.Masks, icon: Layers, title: 'Masks' },
     { id: Panel.Ai, icon: Paintbrush, title: 'Inpaint' },
   ],
   [

--- a/src/components/panel/right/RightPanelSwitcher.tsx
+++ b/src/components/panel/right/RightPanelSwitcher.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { SlidersHorizontal, Info, Scaling, BrushCleaning, Bookmark, Save, Layers } from 'lucide-react';
+import { SlidersHorizontal, Info, Crop, Blend, Paintbrush, SwatchBook, FileInput } from 'lucide-react';
 import { Panel } from '../../ui/AppProperties';
 
 interface PanelOptions {
@@ -18,13 +18,13 @@ const panelGroups: Array<Array<PanelOptions>> = [
   [{ id: Panel.Metadata, icon: Info, title: 'Info' }],
   [
     { id: Panel.Adjustments, icon: SlidersHorizontal, title: 'Adjust' },
-    { id: Panel.Crop, icon: Scaling, title: 'Crop' },
-    { id: Panel.Masks, icon: Layers, title: 'Masks' },
-    { id: Panel.Ai, icon: BrushCleaning, title: 'Inpaint' },
+    { id: Panel.Crop, icon: Crop, title: 'Crop' },
+    { id: Panel.Masks, icon: Blend, title: 'Masks' },
+    { id: Panel.Ai, icon: Paintbrush, title: 'Inpaint' },
   ],
   [
-    { id: Panel.Presets, icon: Bookmark, title: 'Presets' },
-    { id: Panel.Export, icon: Save, title: 'Export' },
+    { id: Panel.Presets, icon: SwatchBook, title: 'Presets' },
+    { id: Panel.Export, icon: FileInput, title: 'Export' },
   ],
 ];
 


### PR DESCRIPTION
Hi this is my first *opinion* based suggestion! I am very interested in both UX and UI flows as a frontend engineer and I found the icons on the tab buttons to be a little bit vague/misleading. Hopefully these changes make sense! I understand if you prefer the old ones.

Updates the right panel switcher to use more specific Lucide icons per tab:

- **Crop** — `Crop` (was `Scaling`)
- **Masks** — `Blend` (was `Layers`)
- **Inpaint** — `Paintbrush` (was `BrushCleaning`)
- **Presets** — `SwatchBook` (was `Bookmark`)
- **Export** — `FileInput` (was `Save`)

- Also adjusted the misleading "Reset Adjustments" icon based on comments in #321 to be "Eraser" instead of "RotateCCW" which gave the impression of a refresh button

Info and Adjust tabs unchanged.
<img width="860" height="668" alt="image" src="https://github.com/user-attachments/assets/022b1124-d119-4376-b30b-553d7197e629" />

