### PR TITLE
Fixing the ratings fix

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4946,8 +4946,8 @@ pub fn run() {
                 let window_for_handler = window.clone();
                 let pending_state_for_handler = pending_window_state.clone();
 
-                window.on_window_event(move |event| match event {
-                    tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) => {
+                window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::Resized(_) | tauri::WindowEvent::Moved(_) = event {
                         #[cfg(any(windows, target_os = "linux"))]
                         let maximized = window_for_handler.is_maximized().unwrap_or(false);
                         #[cfg(not(any(windows, target_os = "linux")))]
@@ -4988,7 +4988,6 @@ pub fn run() {
 
                         *pending_state_for_handler.lock().unwrap() = Some(state);
                     }
-                    _ => {}
                 });
             }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,6 +230,7 @@ const RIGHT_PANEL_ORDER = [
 ];
 
 const DEBUG = false;
+const LOCAL_RATING_GUARD_MS = 1200;
 
 const getParentDir = (filePath: string): string => {
   const separator = filePath.includes('/') ? '/' : '\\';
@@ -285,6 +286,7 @@ function App() {
   const [pinnedFolderTrees, setPinnedFolderTrees] = useState<any[]>([]);
   const [imageList, setImageList] = useState<Array<ImageFile>>([]);
   const [imageRatings, setImageRatings] = useState<Record<string, number>>({});
+  const recentLocalRatingRef = useRef<Record<string, { rating: number; updatedAt: number }>>({});
   const [sortCriteria, setSortCriteria] = useState<SortCriteria>({ key: 'name', order: SortDirection.Ascending });
   const [filterCriteria, setFilterCriteria] = useState<FilterCriteria>({
     colors: [],
@@ -2746,6 +2748,11 @@ function App() {
       }
       
       const finalRating = newRating === currentRating ? 0 : newRating;
+      const now = Date.now();
+
+      pathsToRate.forEach((path: string) => {
+        recentLocalRatingRef.current[path] = { rating: finalRating, updatedAt: now };
+      });
 
       setImageRatings((prev: Record<string, number>) => {
         const newRatings = { ...prev };
@@ -3275,6 +3282,18 @@ function App() {
             setThumbnails((prev) => ({ ...prev, [path]: data }));
           }
           if (rating !== undefined) {
+            const localRating = recentLocalRatingRef.current[path];
+            if (localRating) {
+              const isStillFresh = Date.now() - localRating.updatedAt < LOCAL_RATING_GUARD_MS;
+
+              if (isStillFresh && rating !== localRating.rating) {
+                return;
+              }
+
+              if (!isStillFresh || rating === localRating.rating) {
+                delete recentLocalRatingRef.current[path];
+              }
+            }
             setImageRatings((prev) => ({ ...prev, [path]: rating }));
           }
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2735,7 +2735,6 @@ function App() {
         return;
       }
 
-      const activePath = selectedImage?.path || libraryActivePath;
       let currentRating = 0;
       
       if (selectedImage && pathsToRate.includes(selectedImage.path)) {

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { ImageFile, Panel, SelectedImage } from '../components/ui/AppProperties';
 import { BrushSettings } from '../components/ui/AppProperties';
 
@@ -107,6 +107,8 @@ export const useKeyboardShortcuts = ({
   brushSettings,  
   setBrushSettings,  
 }: KeyboardShortcutsProps) => {
+  const pressedRatingKeysRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     const handleKeyDown = (event: any) => {
       if (isModalOpen) {
@@ -314,7 +316,12 @@ export const useKeyboardShortcuts = ({
         }
       }
 
-      if (code.startsWith('Digit') && !isCtrl) {
+      if (code.startsWith('Digit') && !isCtrl && !event.repeat) {
+        if (pressedRatingKeysRef.current.has(code)) {
+          return;
+        }
+        pressedRatingKeysRef.current.add(code);
+
         event.preventDefault();
         const keyNum = parseInt(code.replace('Digit', ''), 10);
 
@@ -330,7 +337,13 @@ export const useKeyboardShortcuts = ({
             handleRate(keyNum);
           }
         }
-      } else if (['0', '1', '2', '3', '4', '5'].includes(key) && !isCtrl) {
+      } else if (['0', '1', '2', '3', '4', '5'].includes(key) && !isCtrl && !event.repeat) {
+        const ratingKeyId = code || key;
+        if (pressedRatingKeysRef.current.has(ratingKeyId)) {
+          return;
+        }
+        pressedRatingKeysRef.current.add(ratingKeyId);
+
         event.preventDefault();
         handleRate(parseInt(key, 10));
       }
@@ -450,9 +463,28 @@ export const useKeyboardShortcuts = ({
         }
       }
     };
+    const handleKeyUp = (event: any) => {
+      const key = event.key.toLowerCase();
+      const code = event.code;
+      const ratingKeyId = code || key;
+
+      if (code.startsWith('Digit') || ['0', '1', '2', '3', '4', '5'].includes(key)) {
+        pressedRatingKeysRef.current.delete(ratingKeyId);
+      }
+    };
+
+    const handleWindowBlur = () => {
+      pressedRatingKeysRef.current.clear();
+    };
+
     window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleWindowBlur);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', handleWindowBlur);
+      pressedRatingKeysRef.current.clear();
     };
   }, [
     activeAiPatchContainerId,


### PR DESCRIPTION
Reverts CyberTimon/RapidRAW#1046

fixes my pull request

issue(s):

currentRating was read from imageRatings and then overwritten by either adjustments.rating or libraryActiveAdjustments.rating, they're panel level values that can lag / differ from per-image rating state during multi-selection

Keyboard auto-repeat can re-fire rating updates quickly and trigger additional toggles while key is held causing the flickering

To solve them:

Use only imageRatings to get the currentRating in handleRate

Remove the dependency on adjustments.rating and libraryActiveAdjustments.rating in the callback

Ignore repeated keydown events in useKeyboardShortcuts.tsx for digit rating shortcuts, they shouldn't change at all until a different rating key is pressed