### PR TITLE
ui: Add alert dialog before resetting adjustments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4238,8 +4238,8 @@ function App() {
         confirmText: 'Reset',
         isOpen: true,
         message: isSingle
-          ? 'This removes all edits for this image and restores defaults. Rating is kept.'
-          : `This removes all edits for ${count} images and restores defaults. Ratings are kept.`,
+          ? 'This will remove all edits from this image and reset the image to its original state and cannot be undone.'
+          : `This will remove all edits from ${count} images and reset the images to their original states and cannot be undone.`,
         onConfirm: () => handleResetAdjustments(pathsToReset),
         title: isSingle ? 'Reset adjustments?' : `Reset adjustments on ${count} images?`,
       });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4226,6 +4226,27 @@ function App() {
     ],
   );
 
+  const promptResetAdjustments = useCallback(
+    (explicitPaths?: Array<string>) => {
+      const pathsToReset = explicitPaths ?? multiSelectedPaths;
+      if (pathsToReset.length === 0) {
+        return;
+      }
+      const count = pathsToReset.length;
+      const isSingle = count === 1;
+      setConfirmModalState({
+        confirmText: 'Reset',
+        isOpen: true,
+        message: isSingle
+          ? 'This removes all edits for this image and restores defaults. Rating is kept.'
+          : `This removes all edits for ${count} images and restores defaults. Ratings are kept.`,
+        onConfirm: () => handleResetAdjustments(pathsToReset),
+        title: isSingle ? 'Reset adjustments?' : `Reset adjustments on ${count} images?`,
+      });
+    },
+    [multiSelectedPaths, handleResetAdjustments],
+  );
+
   const handleImportClick = useCallback(
     async (targetPath: string) => {
       try {
@@ -4416,20 +4437,7 @@ function App() {
       {
         label: 'Reset Adjustments',
         icon: RotateCcw,
-        onClick: () => {
-          debouncedSetHistory.cancel();
-          const currentRating = adjustments.rating;
-
-          const originalAspectRatio =
-            selectedImage.width && selectedImage.height ? selectedImage.width / selectedImage.height : null;
-
-          resetAdjustmentsHistory({
-            ...INITIAL_ADJUSTMENTS,
-            aspectRatio: originalAspectRatio,
-            rating: currentRating,
-            aiPatches: [],
-          });
-        },
+        onClick: () => promptResetAdjustments([selectedImage.path]),
       },
     ];
     showContextMenu(event.clientX, event.clientY, options);
@@ -4816,7 +4824,7 @@ function App() {
           );
         },
       },
-      { label: resetLabel, icon: RotateCcw, onClick: () => handleResetAdjustments(finalSelection) },
+      { label: resetLabel, icon: RotateCcw, onClick: () => promptResetAdjustments(finalSelection) },
       deleteOption,
     ];
     showContextMenu(event.clientX, event.clientY, options);
@@ -5164,7 +5172,7 @@ function App() {
             onOpenCopyPasteSettings={() => setIsCopyPasteSettingsModalOpen(true)}
             onPaste={() => handlePasteAdjustments()}
             onRate={handleRate}
-            onReset={() => handleResetAdjustments()}
+            onReset={() => promptResetAdjustments()}
             rating={libraryActiveAdjustments.rating || 0}
             thumbnailAspectRatio={thumbnailAspectRatio}
             totalImages={imageList.length}

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -309,7 +309,7 @@ export default function Controls({
       <ConfirmModal
         confirmText="Reset"
         isOpen={isResetAdjustmentsConfirmOpen}
-        message="This resets tone, color, curves, details, and effects to defaults. Masks, crop, and rating are kept."
+        message="This will remove all edits from this image and reset the image to its original state and cannot be undone."
         onClose={() => setIsResetAdjustmentsConfirmOpen(false)}
         onConfirm={handleResetAdjustments}
         title="Reset adjustments?"

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -16,6 +16,7 @@ import { OPTION_SEPARATOR, SelectedImage, AppSettings, WaveformData, Orientation
 import { ChannelConfig } from '../../adjustments/Curves';
 import Text from '../../ui/Text';
 import { TextVariants } from '../../../types/typography';
+import ConfirmModal from '../../modals/ConfirmModal';
 
 interface ControlsPanelOption {
   disabled?: boolean;
@@ -76,6 +77,7 @@ export default function Controls({
 }: ControlsProps) {
   const { showContextMenu } = useContextMenu();
   const [isResizingWaveform, setIsResizingWaveform] = useState<boolean>(false);
+  const [isResetAdjustmentsConfirmOpen, setIsResetAdjustmentsConfirmOpen] = useState(false);
 
   const handleWaveformResize = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -227,7 +229,7 @@ export default function Controls({
           <button
             className="p-2 rounded-full hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             disabled={!selectedImage}
-            onClick={handleResetAdjustments}
+            onClick={() => setIsResetAdjustmentsConfirmOpen(true)}
             data-tooltip="Reset Adjustments"
           >
             <RotateCcw size={18} />
@@ -304,6 +306,14 @@ export default function Controls({
           );
         })}
       </div>
+      <ConfirmModal
+        confirmText="Reset"
+        isOpen={isResetAdjustmentsConfirmOpen}
+        message="This resets tone, color, curves, details, and effects to defaults. Masks, crop, and rating are kept."
+        onClose={() => setIsResetAdjustmentsConfirmOpen(false)}
+        onConfirm={handleResetAdjustments}
+        title="Reset adjustments?"
+      />
     </div>
   );
 }


### PR DESCRIPTION

## Description
I added a confirmation modal/alert dialog step for resetting adjustments since some users mentioned in #321 that they were accidentally performing this destructive action and losing their work

## Type of Change
- [x] UI/UX improvement

## Changes Made
Added a reusable `promptResetAdjustments()` function to request a confirmation before performing the action.

## Screenshots/Videos
<img width="1422" height="852" alt="image" src="https://github.com/user-attachments/assets/b9b093e8-4a52-4002-a37a-1a6bfb687033" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** (e.g. Windows 11, macOS Sonoma, Ubuntu 24.04)
- **Hardware:** (e.g. Intel i7, Apple M2, Nvidia RTX 3060)

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)