### PR TITLE
fix(linux): gpu - skip surface creation on Linux

### DIFF
--- a/src-tauri/src/gpu_processing.rs
+++ b/src-tauri/src/gpu_processing.rs
@@ -153,7 +153,7 @@ pub fn get_or_init_gpu_context(
 
     let instance = wgpu::Instance::new(&instance_desc);
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_os = "linux")))]
     let surface_opt = {
         let window = app_handle
             .get_webview_window("main")
@@ -165,7 +165,7 @@ pub fn get_or_init_gpu_context(
         )
     };
 
-    #[cfg(target_os = "android")]
+    #[cfg(any(target_os = "android", target_os = "linux"))]
     let surface_opt: Option<wgpu::Surface> = None;
 
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -209,7 +209,7 @@ pub fn get_or_init_gpu_context(
         let _ = std::fs::remove_file(p);
     }
 
-    #[cfg(not(target_os = "android"))]
+    #[cfg(not(any(target_os = "android", target_os = "linux")))]
     let display_opt = {
         let surface = surface_opt.unwrap();
         let window = app_handle
@@ -442,6 +442,9 @@ pub fn get_or_init_gpu_context(
             current_bind_group: None,
         })
     };
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    let display_opt = None;
 
     #[cfg(target_os = "android")]
     let display_opt = None;


### PR DESCRIPTION
## Description

After the direct wgpu renderer implementation 5edd9fb some issues occurred on the Linux platform.

One was on startup coming from #1048:

`[WARN] GPU pre-initialization failed (editing and thumbnails may be degraded): No surface available`

I was not able to fix this, even when delaying gpu-initialization.

More critically, for the vulkan backends, thumbnail generation failed and the app crashed immediately. This seems to be related to the fact that a surface cannot be created from the child processes used for thumbnail generation.

Since direct wgpu seems to be broken on Linux anyway (#1060), a simple fix is to set `surface_opt` to `None` and following display_opt to None, as done for Android.

Maybe a flag for a kind of "headless" mode would also be possible in `get_or_init_gpu_context`.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Do not create wgpu surface on linux

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:**  Windows 11, Ubuntu 24.04
- **Hardware:** AMD AI 370

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [ ] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

