### PR TITLE
Changed AllAdjustments from uniform buffer to storage buffer to increase GPU compatibility

### DIFF
--- a/src-tauri/src/gpu_processing.rs
+++ b/src-tauri/src/gpu_processing.rs
@@ -847,7 +847,7 @@ impl GpuProcessor {
                 binding: 2,
                 visibility: wgpu::ShaderStages::COMPUTE,
                 ty: wgpu::BindingType::Buffer {
-                    ty: wgpu::BufferBindingType::Uniform,
+                    ty: wgpu::BufferBindingType::Storage { read_only: true },
                     has_dynamic_offset: false,
                     min_binding_size: None,
                 },
@@ -964,7 +964,7 @@ impl GpuProcessor {
         let adjustments_buffer = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("Adjustments Buffer"),
             size: std::mem::size_of::<AllAdjustments>() as u64,
-            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 

--- a/src-tauri/src/shaders/shader.wgsl
+++ b/src-tauri/src/shaders/shader.wgsl
@@ -193,7 +193,7 @@ const HSL_RANGES: array<HslRange, 8> = array<HslRange, 8>(
 
 @group(0) @binding(0) var input_texture: texture_2d<f32>;
 @group(0) @binding(1) var output_texture: texture_storage_2d<rgba8unorm, write>;
-@group(0) @binding(2) var<uniform> adjustments: AllAdjustments;
+@group(0) @binding(2) var<storage, read> adjustments: AllAdjustments;
 
 @group(0) @binding(3) var mask_textures: texture_2d_array<f32>;
 


### PR DESCRIPTION
## Description
WebGPU spec mandates support for at minimum 64 KB uniform buffers. The buffer is suspected to be larger than this. The limit seems to be enforced by the Adreno 732 GPU leading to a crash. Further, dynamic array indexing seems only to be guaranteed to work in WGSL if the buffer is a storage buffer. This change should have negligible performance penalty and no compatibility issues on other systems.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Changed AllAdjustments from Uniform Buffer to Storage buffer to increase GPU compatibility


## Screenshots/Videos
No UI changes

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Android 16
- **Hardware:** Adreno 732

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
-

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

