### PR TITLE
Feat dynamic sliders for color mixer panel

### DIFF
--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Pipette, Sliders } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import Slider from '../ui/Slider';
@@ -397,6 +397,35 @@ export default function ColorPanel({
   const [activeColor, setActiveColor] = useState('reds');
   const adjustmentVisibility = appSettings?.adjustmentVisibility || {};
 
+  const colorHueMap: Record<string, number> = {
+    reds: 0,
+    oranges: 30,
+    yellows: 60,
+    greens: 120,
+    aquas: 180,
+    blues: 240,
+    purples: 300,
+    magentas: 340,
+  };
+
+  const currentHsl = adjustments?.hsl?.[activeColor] || { hue: 0, saturation: 0, luminance: 0 };
+  const baseHue = colorHueMap[activeColor] || 0;
+  const effectiveHue = baseHue + (currentHsl.hue || 0);
+
+  useEffect(() => {
+    const normalizedHue = ((effectiveHue % 360) + 360) % 360;
+    const effectiveSaturation = (currentHsl.saturation + 100) / 2;
+
+    document.documentElement.style.setProperty(
+      `--hsl-mixer-hue-${activeColor}`,
+      normalizedHue.toString()
+    );
+    document.documentElement.style.setProperty(
+      `--hsl-mixer-sat-${activeColor}`,
+      `${effectiveSaturation}%`
+    );
+  }, [effectiveHue, currentHsl.saturation, activeColor]);
+
   const handleGlobalChange = (key: ColorAdjustment, value: string) => {
     setAdjustments((prev: Partial<Adjustments>) => ({ ...prev, [key]: parseFloat(value) }));
   };
@@ -417,8 +446,6 @@ export default function ColorPanel({
   const hue_slider = `hue-slider-${activeColor}`;
   const saturation_slider = `sat-slider-${activeColor}`;
   const luminance_slider = `lum-slider-${activeColor}`;
-
-  const currentHsl = adjustments?.hsl?.[activeColor] || { hue: 0, saturation: 0, luminance: 0 };
 
   return (
     <div className="space-y-4">

--- a/src/styles.css
+++ b/src/styles.css
@@ -153,83 +153,83 @@
   }
 
   .hue-slider-reds {
-    background: linear-gradient(to right, hsl(260, 60%, 45%), hsl(0, 60%, 45%), hsl(100, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(260, 50%, 50%), hsl(0, 50%, 50%), hsl(100, 50%, 50%)) !important;
   }
   .sat-slider-reds {
-    background: linear-gradient(to right, hsl(0, 0%, 45%), hsl(0, 60%, 45%), hsl(0, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-reds, 0), 0%, 50%), hsl(var(--hsl-mixer-hue-reds, 0), 100%, 50%)) !important;
   }
   .lum-slider-reds {
-    background: linear-gradient(to right, hsl(0, 60%, 0%), hsl(0, 60%, 45%), hsl(0, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-reds, 0), var(--hsl-mixer-sat-reds, 0%), 0%), hsl(var(--hsl-mixer-hue-reds, 0), var(--hsl-mixer-sat-reds, 0%), 50%), hsl(var(--hsl-mixer-hue-reds, 0), var(--hsl-mixer-sat-reds, 0%), 100%)) !important;
   }
 
   .hue-slider-oranges {
-    background: linear-gradient(to right, hsl(290, 60%, 45%), hsl(30, 60%, 45%), hsl(130, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(290, 50%, 50%), hsl(30, 50%, 50%), hsl(130, 50%, 50%)) !important;
   }
   .sat-slider-oranges {
-    background: linear-gradient(to right, hsl(30, 0%, 45%), hsl(30, 60%, 45%), hsl(30, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-oranges, 30), 0%, 50%), hsl(var(--hsl-mixer-hue-oranges, 30), 100%, 50%)) !important;
   }
   .lum-slider-oranges {
-    background: linear-gradient(to right, hsl(30, 60%, 0%), hsl(30, 60%, 45%), hsl(30, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-oranges, 30), var(--hsl-mixer-sat-oranges, 0%), 0%), hsl(var(--hsl-mixer-hue-oranges, 30), var(--hsl-mixer-sat-oranges, 0%), 50%), hsl(var(--hsl-mixer-hue-oranges, 30), var(--hsl-mixer-sat-oranges, 0%), 100%)) !important;
   }
 
   .hue-slider-yellows {
-    background: linear-gradient(to right, hsl(320, 60%, 50%), hsl(60, 60%, 50%), hsl(160, 60%, 50%)) !important;
+    background: linear-gradient(to right, hsl(320, 50%, 50%), hsl(60, 50%, 50%), hsl(160, 50%, 50%)) !important;
   }
   .sat-slider-yellows {
-    background: linear-gradient(to right, hsl(60, 0%, 45%), hsl(60, 60%, 45%), hsl(60, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-yellows, 60), 0%, 50%), hsl(var(--hsl-mixer-hue-yellows, 60), 100%, 50%)) !important;
   }
   .lum-slider-yellows {
-    background: linear-gradient(to right, hsl(60, 60%, 0%), hsl(60, 60%, 45%), hsl(60, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-yellows, 60), var(--hsl-mixer-sat-yellows, 0%), 0%), hsl(var(--hsl-mixer-hue-yellows, 60), var(--hsl-mixer-sat-yellows, 0%), 50%), hsl(var(--hsl-mixer-hue-yellows, 60), var(--hsl-mixer-sat-yellows, 0%), 100%)) !important;
   }
 
   .hue-slider-greens {
-    background: linear-gradient(to right, hsl(20, 60%, 45%), hsl(120, 60%, 45%), hsl(220, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(20, 50%, 50%), hsl(120, 50%, 50%), hsl(220, 50%, 50%)) !important;
   }
   .sat-slider-greens {
-    background: linear-gradient(to right, hsl(120, 0%, 45%), hsl(120, 60%, 45%), hsl(120, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-greens, 120), 0%, 50%), hsl(var(--hsl-mixer-hue-greens, 120), 100%, 50%)) !important;
   }
   .lum-slider-greens {
-    background: linear-gradient(to right, hsl(120, 60%, 0%), hsl(120, 60%, 45%), hsl(120, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-greens, 120), var(--hsl-mixer-sat-greens, 0%), 0%), hsl(var(--hsl-mixer-hue-greens, 120), var(--hsl-mixer-sat-greens, 0%), 50%), hsl(var(--hsl-mixer-hue-greens, 120), var(--hsl-mixer-sat-greens, 0%), 100%)) !important;
   }
 
   .hue-slider-aquas {
-    background: linear-gradient(to right, hsl(80, 60%, 45%), hsl(180, 60%, 45%), hsl(280, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(80, 50%, 50%), hsl(180, 50%, 50%), hsl(280, 50%, 50%)) !important;
   }
   .sat-slider-aquas {
-    background: linear-gradient(to right, hsl(180, 0%, 45%), hsl(180, 60%, 45%), hsl(180, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-aquas, 180), 0%, 50%), hsl(var(--hsl-mixer-hue-aquas, 180), 100%, 50%)) !important;
   }
   .lum-slider-aquas {
-    background: linear-gradient(to right, hsl(180, 60%, 0%), hsl(180, 60%, 45%), hsl(180, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-aquas, 180), var(--hsl-mixer-sat-aquas, 0%), 0%), hsl(var(--hsl-mixer-hue-aquas, 180), var(--hsl-mixer-sat-aquas, 0%), 50%), hsl(var(--hsl-mixer-hue-aquas, 180), var(--hsl-mixer-sat-aquas, 0%), 100%)) !important;
   }
 
   .hue-slider-blues {
-    background: linear-gradient(to right, hsl(140, 60%, 45%), hsl(240, 60%, 45%), hsl(340, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(140, 50%, 50%), hsl(240, 50%, 50%), hsl(340, 50%, 50%)) !important;
   }
   .sat-slider-blues {
-    background: linear-gradient(to right, hsl(240, 0%, 45%), hsl(240, 60%, 45%), hsl(240, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-blues, 240), 0%, 50%), hsl(var(--hsl-mixer-hue-blues, 240), 100%, 50%)) !important;
   }
   .lum-slider-blues {
-    background: linear-gradient(to right, hsl(240, 60%, 0%), hsl(240, 60%, 45%), hsl(240, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-blues, 240), var(--hsl-mixer-sat-blues, 0%), 0%), hsl(var(--hsl-mixer-hue-blues, 240), var(--hsl-mixer-sat-blues, 0%), 50%), hsl(var(--hsl-mixer-hue-blues, 240), var(--hsl-mixer-sat-blues, 0%), 100%)) !important;
   }
 
   .hue-slider-purples {
-    background: linear-gradient(to right, hsl(200, 60%, 45%), hsl(300, 60%, 45%), hsl(40, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(200, 50%, 50%), hsl(300, 50%, 50%), hsl(40, 50%, 50%)) !important;
   }
   .sat-slider-purples {
-    background: linear-gradient(to right, hsl(300, 0%, 45%), hsl(300, 60%, 45%), hsl(300, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-purples, 300), 0%, 50%), hsl(var(--hsl-mixer-hue-purples, 300), 100%, 50%)) !important;
   }
   .lum-slider-purples {
-    background: linear-gradient(to right, hsl(300, 60%, 0%), hsl(300, 60%, 45%), hsl(300, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-purples, 300), var(--hsl-mixer-sat-purples, 0%), 0%), hsl(var(--hsl-mixer-hue-purples, 300), var(--hsl-mixer-sat-purples, 0%), 50%), hsl(var(--hsl-mixer-hue-purples, 300), var(--hsl-mixer-sat-purples, 0%), 100%)) !important;
   }
 
   .hue-slider-magentas {
-    background: linear-gradient(to right, hsl(240, 60%, 45%), hsl(340, 60%, 45%), hsl(80, 60%, 45%)) !important;
+    background: linear-gradient(to right, hsl(240, 50%, 50%), hsl(340, 50%, 50%), hsl(80, 50%, 50%)) !important;
   }
   .sat-slider-magentas {
-    background: linear-gradient(to right, hsl(340, 0%, 45%), hsl(340, 60%, 45%), hsl(340, 90%, 45%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-magentas, 340), 0%, 50%), hsl(var(--hsl-mixer-hue-magentas, 340), 100%, 50%)) !important;
   }
   .lum-slider-magentas {
-    background: linear-gradient(to right, hsl(340, 60%, 0%), hsl(340, 60%, 45%), hsl(340, 60%, 80%)) !important;
+    background: linear-gradient(to right, hsl(var(--hsl-mixer-hue-magentas, 340), var(--hsl-mixer-sat-magentas, 0%), 0%), hsl(var(--hsl-mixer-hue-magentas, 340), var(--hsl-mixer-sat-magentas, 0%), 50%), hsl(var(--hsl-mixer-hue-magentas, 340), var(--hsl-mixer-sat-magentas, 0%), 100%)) !important;
   }
 }
 


### PR DESCRIPTION
## Description
Dynamic gradient shades for Saturation and Luminance sliders in Color Mixer Panel.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Saturation slider now has a gradient fill of 0% saturated shade of selected hue to 100% saturated shade of selected hue. Updates dynamically when hue changes.
- Luminance slider now has a gradient fill of -100% light shade of selected hue to 100% light shade of selected hue and saturation. Updates dynamically when hue or saturation changes.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 10
- **Hardware:** Intel i5

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
- It will close this issue https://github.com/CyberTimon/RapidRAW/issues/936

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [x] This PR contains only blood, sweat, and coffee (AI-free)