### PR TITLE
Numpad controls (SP-3000 style)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,7 +92,7 @@ import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import GlobalTooltip from './components/ui/GlobalTooltip';
 import { THEMES, DEFAULT_THEME_ID, ThemeProps } from './utils/themes';
 import { SubMask, ToolType } from './components/panel/right/Masks';
-import { ExportState, IMPORT_TIMEOUT, ImportState, Status } from './components/ui/ExportImportProperties';
+import { ExportState, IMPORT_TIMEOUT, ImportState, Status, ExportSettings, FILE_FORMATS } from './components/ui/ExportImportProperties';
 import {
   AppSettings,
   BrushSettings,
@@ -3172,6 +3172,60 @@ function App() {
     }
   }, [selectedImage]);
 
+  const handleInstantExport = useCallback(async (): Promise<boolean> => {
+    if (!selectedImage) return false;
+
+    const numpadSettings = appSettings?.numpadSettings;
+    if (!numpadSettings?.defaultExportPresetId || !numpadSettings?.defaultExportPath) {
+      toast.error('Please configure default export preset and path in settings');
+      return false;
+    }
+
+    const preset = appSettings?.exportPresets?.find((p) => p.id === numpadSettings.defaultExportPresetId);
+    if (!preset) {
+      toast.error('Selected export preset not found');
+      return false;
+    }
+
+    try {
+      const exportSettings: ExportSettings = {
+        filenameTemplate: preset.filenameTemplate,
+        jpegQuality: preset.jpegQuality,
+        keepMetadata: preset.keepMetadata,
+        preserveTimestamps: preset.preserveTimestamps,
+        resize: preset.enableResize ? { mode: preset.resizeMode, value: preset.resizeValue, dontEnlarge: preset.dontEnlarge } : null,
+        stripGps: preset.stripGps,
+        exportMasks: preset.exportMasks ?? false,
+        watermark:
+          preset.enableWatermark && preset.watermarkPath
+            ? {
+                path: preset.watermarkPath,
+                anchor: preset.watermarkAnchor as any,
+                scale: preset.watermarkScale,
+                spacing: preset.watermarkSpacing,
+                opacity: preset.watermarkOpacity,
+              }
+            : null,
+        preserveFolders: preset.preserveFolders ?? false,
+      };
+
+      await invoke(Invokes.BatchExportImages, {
+        exportSettings,
+        outputFolder: numpadSettings.defaultExportPath,
+        outputFormat: FILE_FORMATS.find((f: any) => f.id === preset.fileFormat)?.extensions[0],
+        paths: [selectedImage.path],
+        baseOriginFolder: rootPath,
+      });
+
+      toast.success('Export successful');
+      return true;
+    } catch (error) {
+      console.error('Error exporting image:', error);
+      toast.error(typeof error === 'string' ? error : 'Export failed');
+      return false;
+    }
+  }, [selectedImage, appSettings, rootPath]);
+
   useKeyboardShortcuts({
     isModalOpen: isAnyModalOpen,
     osPlatform,
@@ -3225,6 +3279,7 @@ function App() {
     numpadSettings: appSettings?.numpadSettings,
     setNumpadSettings: (settings) => handleSettingsChange({ ...appSettings, numpadSettings: settings }),
     handleExportCurrent: handleNumpadExport,
+    handleInstantExport,
     adjustments,
     setAdjustments,
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3165,6 +3165,13 @@ function App() {
     denoiseModalState.isOpen ||
     negativeModalState.isOpen;
 
+  const handleNumpadExport = useCallback(() => {
+    if (selectedImage) {
+      setMultiSelectedPaths([selectedImage.path]);
+      setIsLibraryExportPanelVisible(true);
+    }
+  }, [selectedImage]);
+
   useKeyboardShortcuts({
     isModalOpen: isAnyModalOpen,
     osPlatform,
@@ -3215,6 +3222,11 @@ function App() {
     originalSize,
     brushSettings: brushSettings,
     setBrushSettings: setBrushSettings,
+    numpadSettings: appSettings?.numpadSettings,
+    setNumpadSettings: (settings) => handleSettingsChange({ ...appSettings, numpadSettings: settings }),
+    handleExportCurrent: handleNumpadExport,
+    adjustments,
+    setAdjustments,
   });
 
   useEffect(() => {

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1993,7 +1993,7 @@ export default function SettingsPanel({
                           <Text variant={TextVariants.heading}>Step Sizes</Text>
 
                           <SettingItem
-                            label="Exposure (Density)"
+                            label={numpadSettings.mode === 'digital' ? 'Exposure' : 'Exposure (Density)'}
                             description="Adjustment amount per key press (stops)"
                           >
                             <Slider

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1877,7 +1877,7 @@ export default function SettingsPanel({
                     Numpad
                   </Text>
                   <Text className="mb-6">
-                    Enable numpad shortcuts for rapid color and density adjustments, inspired by traditional film scanner workflows.
+                    Enable numpad shortcuts for rapid color and density adjustments, inspired by the Fuji Frontier SP-3000 scanner workflow.
                   </Text>
 
                   <div className="space-y-6">
@@ -1937,6 +1937,14 @@ export default function SettingsPanel({
                             ))}
                           </div>
                         </SettingItem>
+
+                        {numpadSettings.mode === 'film' && (
+                          <div className="mt-2 p-3 bg-yellow-500/10 border border-yellow-500/30 rounded-md">
+                            <Text variant={TextVariants.body} className="text-yellow-500">
+                              ⚠️ Film mode is experimental. RGB/CMY color offsets are not yet applied to image rendering. Use Digital mode for full functionality.
+                            </Text>
+                          </div>
+                        )}
 
                         <SettingItem
                           label="Enter Key Behavior"
@@ -2060,7 +2068,7 @@ export default function SettingsPanel({
                             <KeybindItem keys={['8', '5']} description="Magenta / Green balance" />
                             <KeybindItem
                               keys={['9', '6']}
-                              description="Cyan / Red balance (Film mode only)"
+                              description="Cyan / Red balance (Film mode only - Experimental)"
                             />
                             <KeybindItem keys={['1', '.']} description="Density (Exposure ± Blacks)" />
                             <KeybindItem keys={['2', '3']} description="Contrast (Soften / Harden)" />

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -29,7 +29,7 @@ import Switch from '../ui/Switch';
 import Input from '../ui/Input';
 import Slider from '../ui/Slider';
 import { ThemeProps, THEMES, DEFAULT_THEME_ID } from '../../utils/themes';
-import { Invokes } from '../ui/AppProperties';
+import { Invokes, NumpadSettings } from '../ui/AppProperties';
 import Text from '../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../types/typography';
 import { useOsPlatform } from '../../hooks/useOsPlatform';
@@ -333,6 +333,19 @@ export default function SettingsPanel({
   const [lensModels, setLensModels] = useState<string[]>([]);
   const [tempLensMaker, setTempLensMaker] = useState<string>('');
   const [tempLensModel, setTempLensModel] = useState<string>('');
+
+  const [numpadSettings, setNumpadSettings] = useState<NumpadSettings>(
+    appSettings?.numpadSettings || {
+      enabled: false,
+      mode: 'digital',
+      enterKeyMode: 'next',
+      stepSizes: {
+        exposure: 0.1,
+        contrast: 2,
+        rgbCmy: 1,
+      },
+    }
+  );
 
   const osPlatform = useOsPlatform();
   const [processingSettings, setProcessingSettings] = useState({
@@ -1856,6 +1869,207 @@ export default function SettingsPanel({
                         <KeybindItem keys={['Click']} description="Quick Zoom (Toggle Fit/2x)" />
                       </div>
                     </div>
+                  </div>
+                </div>
+
+                <div className="p-6 bg-surface rounded-xl shadow-md">
+                  <Text variant={TextVariants.title} color={TextColors.accent} className="mb-8">
+                    Numpad
+                  </Text>
+                  <Text className="mb-6">
+                    Enable numpad shortcuts for rapid color and density adjustments, inspired by traditional film scanner workflows.
+                  </Text>
+
+                  <div className="space-y-6">
+                    <SettingItem
+                      label="Enable Numpad Shortcuts"
+                      description="Enable numpad keys for rapid adjustments"
+                    >
+                      <Switch
+                        checked={numpadSettings.enabled}
+                        id="numpad-enabled-toggle"
+                        label="Enable Numpad"
+                        onChange={(checked) => {
+                          const newSettings = { ...numpadSettings, enabled: checked };
+                          setNumpadSettings(newSettings);
+                          onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                        }}
+                      />
+                    </SettingItem>
+
+                    {numpadSettings.enabled && (
+                      <>
+                        <SettingItem
+                          label="Adjustment Mode"
+                          description="Digital: Temperature/Tint. Film: Full RGB/CMY control with density-rich shadows."
+                        >
+                          <div className="relative flex w-full p-1 bg-bg-primary rounded-md border border-border-color">
+                            {[
+                              { id: 'digital', label: 'Digital' },
+                              { id: 'film', label: 'Film' },
+                            ].map((mode) => (
+                              <button
+                                key={mode.id}
+                                onClick={() => {
+                                  const newSettings = { ...numpadSettings, mode: mode.id as 'digital' | 'film' };
+                                  setNumpadSettings(newSettings);
+                                  onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                                }}
+                                className={clsx(
+                                  'relative flex-1 flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
+                                  {
+                                    'text-text-primary hover:bg-surface': numpadSettings.mode !== mode.id,
+                                    'text-button-text': numpadSettings.mode === mode.id,
+                                  },
+                                )}
+                                style={{ WebkitTapHighlightColor: 'transparent' }}
+                              >
+                                {numpadSettings.mode === mode.id && (
+                                  <motion.span
+                                    layoutId="numpad-mode-switch-bubble"
+                                    className="absolute inset-0 z-0 bg-accent"
+                                    style={{ borderRadius: 6 }}
+                                    transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
+                                  />
+                                )}
+                                <span className="relative z-10">{mode.label}</span>
+                              </button>
+                            ))}
+                          </div>
+                        </SettingItem>
+
+                        <SettingItem
+                          label="Enter Key Behavior"
+                          description="Action when pressing Enter on numpad"
+                        >
+                          <div className="relative flex w-full p-1 bg-bg-primary rounded-md border border-border-color">
+                            {[
+                              { id: 'next', label: 'Next Image' },
+                              { id: 'instant-export', label: 'Instant Export' },
+                              { id: 'skip-move', label: 'Skip & Move' },
+                            ].map((enterMode) => (
+                              <button
+                                key={enterMode.id}
+                                onClick={() => {
+                                  const newSettings = {
+                                    ...numpadSettings,
+                                    enterKeyMode: enterMode.id as 'next' | 'instant-export' | 'skip-move',
+                                  };
+                                  setNumpadSettings(newSettings);
+                                  onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                                }}
+                                className={clsx(
+                                  'relative flex-1 flex items-center justify-center gap-2 px-3 py-1.5 text-xs font-medium rounded-md transition-colors',
+                                  {
+                                    'text-text-primary hover:bg-surface': numpadSettings.enterKeyMode !== enterMode.id,
+                                    'text-button-text': numpadSettings.enterKeyMode === enterMode.id,
+                                  },
+                                )}
+                                style={{ WebkitTapHighlightColor: 'transparent' }}
+                              >
+                                {numpadSettings.enterKeyMode === enterMode.id && (
+                                  <motion.span
+                                    layoutId="numpad-enter-mode-switch-bubble"
+                                    className="absolute inset-0 z-0 bg-accent"
+                                    style={{ borderRadius: 6 }}
+                                    transition={{ type: 'spring', bounce: 0.2, duration: 0.6 }}
+                                  />
+                                )}
+                                <span className="relative z-10">{enterMode.label}</span>
+                              </button>
+                            ))}
+                          </div>
+                        </SettingItem>
+
+                        <div className="space-y-4 pt-4">
+                          <Text variant={TextVariants.heading}>Step Sizes</Text>
+
+                          <SettingItem
+                            label="Exposure (Density)"
+                            description="Adjustment amount per key press (stops)"
+                          >
+                            <Slider
+                              defaultValue={0.1}
+                              label=""
+                              max={0.5}
+                              min={0.01}
+                              onChange={(e: any) => {
+                                const newSettings = {
+                                  ...numpadSettings,
+                                  stepSizes: { ...numpadSettings.stepSizes, exposure: parseFloat(e.target.value) },
+                                };
+                                setNumpadSettings(newSettings);
+                                onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                              }}
+                              step={0.01}
+                              value={numpadSettings.stepSizes.exposure}
+                            />
+                          </SettingItem>
+
+                          <SettingItem
+                            label="Contrast"
+                            description="Adjustment amount per key press (units)"
+                          >
+                            <Slider
+                              defaultValue={2}
+                              label=""
+                              max={10}
+                              min={0.5}
+                              onChange={(e: any) => {
+                                const newSettings = {
+                                  ...numpadSettings,
+                                  stepSizes: { ...numpadSettings.stepSizes, contrast: parseFloat(e.target.value) },
+                                };
+                                setNumpadSettings(newSettings);
+                                onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                              }}
+                              step={0.5}
+                              value={numpadSettings.stepSizes.contrast}
+                            />
+                          </SettingItem>
+
+                          <SettingItem
+                            label="RGB / CMY"
+                            description="Color adjustment amount per key press (units)"
+                          >
+                            <Slider
+                              defaultValue={1}
+                              label=""
+                              max={5}
+                              min={0.1}
+                              onChange={(e: any) => {
+                                const newSettings = {
+                                  ...numpadSettings,
+                                  stepSizes: { ...numpadSettings.stepSizes, rgbCmy: parseFloat(e.target.value) },
+                                };
+                                setNumpadSettings(newSettings);
+                                onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                              }}
+                              step={0.1}
+                              value={numpadSettings.stepSizes.rgbCmy}
+                            />
+                          </SettingItem>
+                        </div>
+
+                        <div className="pt-4">
+                          <Text variant={TextVariants.heading} className="mb-3">
+                            Key Mapping
+                          </Text>
+                          <div className="divide-y divide-border-color">
+                            <KeybindItem keys={['7', '4']} description="Yellow / Blue balance" />
+                            <KeybindItem keys={['8', '5']} description="Magenta / Green balance" />
+                            <KeybindItem
+                              keys={['9', '6']}
+                              description="Cyan / Red balance (Film mode only)"
+                            />
+                            <KeybindItem keys={['1', '.']} description="Density (Exposure ± Blacks)" />
+                            <KeybindItem keys={['2', '3']} description="Contrast (Soften / Harden)" />
+                            <KeybindItem keys={['0']} description="Reset Film offsets" />
+                            <KeybindItem keys={['Enter']} description="Next / Export / Skip (based on mode)" />
+                          </div>
+                        </div>
+                      </>
+                    )}
                   </div>
                 </div>
               </motion.div>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -2036,27 +2036,29 @@ export default function SettingsPanel({
                             />
                           </SettingItem>
 
-                          <SettingItem
-                            label="RGB / CMY"
-                            description="Color adjustment amount per key press (units)"
-                          >
-                            <Slider
-                              defaultValue={1}
-                              label=""
-                              max={5}
-                              min={0.1}
-                              onChange={(e: any) => {
-                                const newSettings = {
-                                  ...numpadSettings,
-                                  stepSizes: { ...numpadSettings.stepSizes, rgbCmy: parseFloat(e.target.value) },
-                                };
-                                setNumpadSettings(newSettings);
-                                onSettingsChange({ ...appSettings, numpadSettings: newSettings });
-                              }}
-                              step={0.1}
-                              value={numpadSettings.stepSizes.rgbCmy}
-                            />
-                          </SettingItem>
+                          {numpadSettings.mode === 'film' && (
+                            <SettingItem
+                              label="RGB / CMY"
+                              description="Color adjustment amount per key press (units)"
+                            >
+                              <Slider
+                                defaultValue={1}
+                                label=""
+                                max={5}
+                                min={0.1}
+                                onChange={(e: any) => {
+                                  const newSettings = {
+                                    ...numpadSettings,
+                                    stepSizes: { ...numpadSettings.stepSizes, rgbCmy: parseFloat(e.target.value) },
+                                  };
+                                  setNumpadSettings(newSettings);
+                                  onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                                }}
+                                step={0.1}
+                                value={numpadSettings.stepSizes.rgbCmy}
+                              />
+                            </SettingItem>
+                          )}
                         </div>
 
                         <div className="pt-4">
@@ -2064,15 +2066,17 @@ export default function SettingsPanel({
                             Key Mapping
                           </Text>
                           <div className="divide-y divide-border-color">
-                            <KeybindItem keys={['7', '4']} description="Yellow / Blue balance" />
-                            <KeybindItem keys={['8', '5']} description="Magenta / Green balance" />
-                            <KeybindItem
-                              keys={['9', '6']}
-                              description="Cyan / Red balance (Film mode only - Experimental)"
-                            />
-                            <KeybindItem keys={['1', '.']} description="Density (Exposure ± Blacks)" />
+                            {numpadSettings.mode === 'film' && <KeybindItem keys={['7', '4']} description="Yellow / Blue balance" />}
+                            {numpadSettings.mode === 'film' && <KeybindItem keys={['8', '5']} description="Magenta / Green balance" />}
+                            {numpadSettings.mode === 'film' && (
+                              <KeybindItem
+                                keys={['9', '6']}
+                                description="Cyan / Red balance (Film mode only - Experimental)"
+                              />
+                            )}
+                            <KeybindItem keys={['1', '.']} description={numpadSettings.mode === 'digital' ? 'Density (Exposure)' : 'Density (Exposure ± Blacks)'} />
                             <KeybindItem keys={['2', '3']} description="Contrast (Soften / Harden)" />
-                            <KeybindItem keys={['0']} description="Reset Film offsets" />
+                            <KeybindItem keys={['0']} description={numpadSettings.mode === 'digital' ? 'Reset color adjustments' : 'Reset Film offsets'} />
                             <KeybindItem keys={['Enter']} description="Next / Export / Skip (based on mode)" />
                           </div>
                         </div>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -30,6 +30,7 @@ import Input from '../ui/Input';
 import Slider from '../ui/Slider';
 import { ThemeProps, THEMES, DEFAULT_THEME_ID } from '../../utils/themes';
 import { Invokes, NumpadSettings } from '../ui/AppProperties';
+import { ExportPreset } from '../ui/ExportImportProperties';
 import Text from '../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../types/typography';
 import { useOsPlatform } from '../../hooks/useOsPlatform';
@@ -1989,6 +1990,71 @@ export default function SettingsPanel({
                             ))}
                           </div>
                         </SettingItem>
+
+                        {numpadSettings.enterKeyMode === 'instant-export' && (
+                          <>
+                            <SettingItem
+                              label="Default Export Preset"
+                              description="Export preset to use for instant export"
+                            >
+                              <div className="relative flex w-full p-1 bg-bg-primary rounded-md border border-border-color">
+                                <select
+                                  value={numpadSettings.defaultExportPresetId || ''}
+                                  onChange={(e) => {
+                                    const newSettings = {
+                                      ...numpadSettings,
+                                      defaultExportPresetId: e.target.value || undefined,
+                                    };
+                                    setNumpadSettings(newSettings);
+                                    onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                                  }}
+                                  className="w-full bg-bg-primary text-text-primary text-sm outline-none px-2 py-1"
+                                >
+                                  <option value="" className="bg-bg-primary text-text-primary">None</option>
+                                  {(appSettings?.exportPresets || [])
+                                    .filter((p: ExportPreset) => p.id !== '__last_used__')
+                                    .map((preset: ExportPreset) => (
+                                      <option key={preset.id} value={preset.id} className="bg-bg-primary text-text-primary">
+                                        {preset.name}
+                                      </option>
+                                    ))}
+                                </select>
+                              </div>
+                            </SettingItem>
+
+                            <SettingItem
+                              label="Default Export Path"
+                              description="Folder where instant exports will be saved"
+                            >
+                              <div className="flex gap-2">
+                                <div className="flex-1 text-sm text-text-primary truncate">
+                                  {numpadSettings.defaultExportPath || 'Not set'}
+                                </div>
+                                <Button
+                                  variant="secondary"
+                                  size="sm"
+                                  onClick={async () => {
+                                    const { open } = await import('@tauri-apps/plugin-dialog');
+                                    const selected = await open({
+                                      directory: true,
+                                      title: 'Select Default Export Folder',
+                                    });
+                                    if (selected) {
+                                      const newSettings = {
+                                        ...numpadSettings,
+                                        defaultExportPath: selected as string,
+                                      };
+                                      setNumpadSettings(newSettings);
+                                      onSettingsChange({ ...appSettings, numpadSettings: newSettings });
+                                    }
+                                  }}
+                                >
+                                  Browse
+                                </Button>
+                              </div>
+                            </SettingItem>
+                          </>
+                        )}
 
                         <div className="space-y-4 pt-4">
                           <Text variant={TextVariants.heading}>Step Sizes</Text>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1878,6 +1878,7 @@ export default function SettingsPanel({
                   </Text>
                   <Text className="mb-6">
                     Enable numpad shortcuts for rapid color and density adjustments, inspired by the Fuji Frontier SP-3000 scanner workflow.
+                    {numpadSettings.mode === 'film' && ' Film mode provides RGB/CMY color control similar to traditional film scanners.'}
                   </Text>
 
                   <div className="space-y-6">
@@ -1901,7 +1902,7 @@ export default function SettingsPanel({
                       <>
                         <SettingItem
                           label="Adjustment Mode"
-                          description="Digital: Temperature/Tint. Film: Full RGB/CMY control with density-rich shadows."
+                          description={numpadSettings.mode === 'digital' ? 'Digital: Temperature/Tint adjustments' : 'Film: Full RGB/CMY control with density-rich shadows'}
                         >
                           <div className="relative flex w-full p-1 bg-bg-primary rounded-md border border-border-color">
                             {[

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -154,6 +154,8 @@ export interface NumpadSettings {
     contrast: number;
     rgbCmy: number;
   };
+  defaultExportPresetId?: string;
+  defaultExportPath?: string;
 }
 
 export interface AppSettings {

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -145,6 +145,17 @@ export enum ThumbnailAspectRatio {
   Contain = 'contain',
 }
 
+export interface NumpadSettings {
+  enabled: boolean;
+  mode: 'digital' | 'film';
+  enterKeyMode: 'next' | 'instant-export' | 'skip-move';
+  stepSizes: {
+    exposure: number;
+    contrast: number;
+    rgbCmy: number;
+  };
+}
+
 export interface AppSettings {
   aiConnectorAddress?: string;
   decorations?: any;
@@ -181,6 +192,7 @@ export interface AppSettings {
   waveformHeight?: number;
   activeWaveformChannel?: string;
   useWgpuRenderer?: boolean;
+  numpadSettings?: NumpadSettings;
 }
 
 export interface BrushSettings {

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -57,6 +57,7 @@ interface KeyboardShortcutsProps {
   numpadSettings?: NumpadSettings;
   setNumpadSettings?: (settings: NumpadSettings) => void;
   handleExportCurrent?: () => void;
+  handleInstantExport?: () => Promise<boolean>;
   adjustments: Adjustments;
   setAdjustments: (adjustments: Partial<Adjustments> | ((prev: Adjustments) => Adjustments)) => void;
 }
@@ -115,6 +116,7 @@ export const useKeyboardShortcuts = ({
   numpadSettings,
   setNumpadSettings,
   handleExportCurrent,
+  handleInstantExport,
   adjustments,
   setAdjustments,
 }: KeyboardShortcutsProps) => {
@@ -556,22 +558,27 @@ export const useKeyboardShortcuts = ({
                   }
                   break;
                 case 'instant-export':
-                  // Export and move to next
-                  if (handleExportCurrent) {
-                    handleExportCurrent();
-                    const currentIndex = sortedImageList.findIndex(
-                      (img: ImageFile) => img.path === selectedImage.path
-                    );
-                    if (currentIndex !== -1) {
-                      let newIndex = currentIndex + 1;
-                      if (newIndex >= sortedImageList.length) {
-                        newIndex = 0;
+                  // Export and move to next after completion
+                  if (handleInstantExport) {
+                    (async () => {
+                      const exportSuccess = await handleInstantExport();
+                      if (exportSuccess) {
+                        const currentIndex = sortedImageList.findIndex(
+                          (img: ImageFile) => img.path === selectedImage.path
+                        );
+                        if (currentIndex !== -1) {
+                          let newIndex = currentIndex + 1;
+                          if (newIndex >= sortedImageList.length) {
+                            newIndex = 0;
+                          }
+                          const nextImage = sortedImageList[newIndex];
+                          if (nextImage) {
+                            handleImageSelect(nextImage.path);
+                          }
+                        }
                       }
-                      const nextImage = sortedImageList[newIndex];
-                      if (nextImage) {
-                        handleImageSelect(nextImage.path);
-                      }
-                    }
+                      // If export failed, stay on current image (error shown in handleInstantExport)
+                    })();
                   }
                   break;
                 case 'skip-move':

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { ImageFile, Panel, SelectedImage, NumpadSettings } from '../components/ui/AppProperties';
 import { BrushSettings } from '../components/ui/AppProperties';
-import { Adjustments, INITIAL_SP3000_OFFSETS } from '../utils/adjustments';
+import { Adjustments, INITIAL_FILM_OFFSETS } from '../utils/adjustments';
 
 interface KeyboardShortcutsProps {
   activeAiPatchContainerId?: string | null;
@@ -253,7 +253,7 @@ export const useKeyboardShortcuts = ({
           }
         }
       } else {
-        if ((key === 'enter' || key === ' ') && !isCtrl) {
+        if ((key === 'enter' || key === ' ') && !isCtrl && code !== 'NumpadEnter') {
           event.preventDefault();
           if (libraryActivePath) {
             handleImageSelect(libraryActivePath);
@@ -325,7 +325,7 @@ export const useKeyboardShortcuts = ({
         }
       }
 
-      if (code.startsWith('Digit') && !isCtrl) {
+      if (code.startsWith('Digit') && !isCtrl && !code.startsWith('Numpad')) {
         event.preventDefault();
         const keyNum = parseInt(code.replace('Digit', ''), 10);
 
@@ -341,7 +341,7 @@ export const useKeyboardShortcuts = ({
             handleRate(keyNum);
           }
         }
-      } else if (['0', '1', '2', '3', '4', '5'].includes(key) && !isCtrl) {
+      } else if (['0', '1', '2', '3', '4', '5'].includes(key) && !isCtrl && !code.startsWith('Numpad')) {
         event.preventDefault();
         handleRate(parseInt(key, 10));
       }
@@ -375,7 +375,7 @@ export const useKeyboardShortcuts = ({
         }
       }
 
-      // Numpad shortcuts for SP-3000 style adjustments
+      // Numpad shortcuts for film-style adjustments
       if (numpadSettings?.enabled && selectedImage) {
         const stepSizes = numpadSettings.stepSizes;
         const mode = numpadSettings.mode;
@@ -395,9 +395,9 @@ export const useKeyboardShortcuts = ({
               } else {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  sp3000ColorOffsets: {
-                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
-                    yellowBlue: (prev.sp3000ColorOffsets?.yellowBlue || 0) - stepSizes.rgbCmy,
+                  filmColorOffsets: {
+                    ...(prev.filmColorOffsets || INITIAL_FILM_OFFSETS),
+                    yellowBlue: (prev.filmColorOffsets?.yellowBlue || 0) - stepSizes.rgbCmy,
                   },
                 }));
               }
@@ -412,9 +412,9 @@ export const useKeyboardShortcuts = ({
               } else {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  sp3000ColorOffsets: {
-                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
-                    yellowBlue: (prev.sp3000ColorOffsets?.yellowBlue || 0) + stepSizes.rgbCmy,
+                  filmColorOffsets: {
+                    ...(prev.filmColorOffsets || INITIAL_FILM_OFFSETS),
+                    yellowBlue: (prev.filmColorOffsets?.yellowBlue || 0) + stepSizes.rgbCmy,
                   },
                 }));
               }
@@ -429,9 +429,9 @@ export const useKeyboardShortcuts = ({
               } else {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  sp3000ColorOffsets: {
-                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
-                    magentaGreen: (prev.sp3000ColorOffsets?.magentaGreen || 0) - stepSizes.rgbCmy,
+                  filmColorOffsets: {
+                    ...(prev.filmColorOffsets || INITIAL_FILM_OFFSETS),
+                    magentaGreen: (prev.filmColorOffsets?.magentaGreen || 0) - stepSizes.rgbCmy,
                   },
                 }));
               }
@@ -446,9 +446,9 @@ export const useKeyboardShortcuts = ({
               } else {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  sp3000ColorOffsets: {
-                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
-                    magentaGreen: (prev.sp3000ColorOffsets?.magentaGreen || 0) + stepSizes.rgbCmy,
+                  filmColorOffsets: {
+                    ...(prev.filmColorOffsets || INITIAL_FILM_OFFSETS),
+                    magentaGreen: (prev.filmColorOffsets?.magentaGreen || 0) + stepSizes.rgbCmy,
                   },
                 }));
               }
@@ -458,9 +458,9 @@ export const useKeyboardShortcuts = ({
               if (mode === 'film') {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  sp3000ColorOffsets: {
-                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
-                    cyanRed: (prev.sp3000ColorOffsets?.cyanRed || 0) - stepSizes.rgbCmy,
+                  filmColorOffsets: {
+                    ...(prev.filmColorOffsets || INITIAL_FILM_OFFSETS),
+                    cyanRed: (prev.filmColorOffsets?.cyanRed || 0) - stepSizes.rgbCmy,
                   },
                 }));
               }
@@ -470,9 +470,9 @@ export const useKeyboardShortcuts = ({
               if (mode === 'film') {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  sp3000ColorOffsets: {
-                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
-                    cyanRed: (prev.sp3000ColorOffsets?.cyanRed || 0) + stepSizes.rgbCmy,
+                  filmColorOffsets: {
+                    ...(prev.filmColorOffsets || INITIAL_FILM_OFFSETS),
+                    cyanRed: (prev.filmColorOffsets?.cyanRed || 0) + stepSizes.rgbCmy,
                   },
                 }));
               }
@@ -482,12 +482,12 @@ export const useKeyboardShortcuts = ({
               if (mode === 'digital') {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  exposure: (prev.exposure || 0) + stepSizes.exposure,
+                  exposure: Math.max(-5, Math.min(5, (prev.exposure || 0) + stepSizes.exposure)),
                 }));
               } else {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  exposure: (prev.exposure || 0) + stepSizes.exposure,
+                  exposure: Math.max(-5, Math.min(5, (prev.exposure || 0) + stepSizes.exposure)),
                   blacks: (prev.blacks || 0) + 2,
                 }));
               }
@@ -497,12 +497,12 @@ export const useKeyboardShortcuts = ({
               if (mode === 'digital') {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  exposure: (prev.exposure || 0) - stepSizes.exposure,
+                  exposure: Math.max(-5, Math.min(5, (prev.exposure || 0) - stepSizes.exposure)),
                 }));
               } else {
                 setAdjustments((prev: Adjustments) => ({
                   ...prev,
-                  exposure: (prev.exposure || 0) - stepSizes.exposure,
+                  exposure: Math.max(-5, Math.min(5, (prev.exposure || 0) - stepSizes.exposure)),
                   blacks: (prev.blacks || 0) - 2,
                 }));
               }
@@ -511,22 +511,30 @@ export const useKeyboardShortcuts = ({
               // - Contrast (soften)
               setAdjustments((prev: Adjustments) => ({
                 ...prev,
-                contrast: (prev.contrast || 0) - stepSizes.contrast,
+                contrast: Math.max(-100, Math.min(100, (prev.contrast || 0) - stepSizes.contrast)),
               }));
               break;
             case 'Numpad3':
               // + Contrast (harden)
               setAdjustments((prev: Adjustments) => ({
                 ...prev,
-                contrast: (prev.contrast || 0) + stepSizes.contrast,
+                contrast: Math.max(-100, Math.min(100, (prev.contrast || 0) + stepSizes.contrast)),
               }));
               break;
             case 'Numpad0':
-              // Reset SP-3000 offsets
-              setAdjustments((prev: Adjustments) => ({
-                ...prev,
-                sp3000ColorOffsets: { ...INITIAL_SP3000_OFFSETS },
-              }));
+              // Reset color adjustments
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  temperature: 0,
+                  tint: 0,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  filmColorOffsets: { ...INITIAL_FILM_OFFSETS },
+                }));
+              }
               break;
             case 'NumpadEnter':
               // Handle based on enterKeyMode
@@ -551,11 +559,11 @@ export const useKeyboardShortcuts = ({
                   // Export and move to next
                   if (handleExportCurrent) {
                     handleExportCurrent();
-                    const exportIndex = sortedImageList.findIndex(
+                    const currentIndex = sortedImageList.findIndex(
                       (img: ImageFile) => img.path === selectedImage.path
                     );
-                    if (exportIndex !== -1) {
-                      let newIndex = exportIndex + 1;
+                    if (currentIndex !== -1) {
+                      let newIndex = currentIndex + 1;
                       if (newIndex >= sortedImageList.length) {
                         newIndex = 0;
                       }

--- a/src/hooks/useKeyboardShortcuts.tsx
+++ b/src/hooks/useKeyboardShortcuts.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
-import { ImageFile, Panel, SelectedImage } from '../components/ui/AppProperties';
+import { ImageFile, Panel, SelectedImage, NumpadSettings } from '../components/ui/AppProperties';
 import { BrushSettings } from '../components/ui/AppProperties';
+import { Adjustments, INITIAL_SP3000_OFFSETS } from '../utils/adjustments';
 
 interface KeyboardShortcutsProps {
   activeAiPatchContainerId?: string | null;
@@ -51,8 +52,13 @@ interface KeyboardShortcutsProps {
   displaySize?: { width: number; height: number };
   baseRenderSize?: { width: number; height: number };
   originalSize?: { width: number; height: number };
-  brushSettings: BrushSettings | null;  
-  setBrushSettings: (settings: BrushSettings) => void;  
+  brushSettings: BrushSettings | null;
+  setBrushSettings: (settings: BrushSettings) => void;
+  numpadSettings?: NumpadSettings;
+  setNumpadSettings?: (settings: NumpadSettings) => void;
+  handleExportCurrent?: () => void;
+  adjustments: Adjustments;
+  setAdjustments: (adjustments: Partial<Adjustments> | ((prev: Adjustments) => Adjustments)) => void;
 }
 
 export const useKeyboardShortcuts = ({
@@ -104,8 +110,13 @@ export const useKeyboardShortcuts = ({
   displaySize,
   baseRenderSize,
   originalSize,
-  brushSettings,  
-  setBrushSettings,  
+  brushSettings,
+  setBrushSettings,
+  numpadSettings,
+  setNumpadSettings,
+  handleExportCurrent,
+  adjustments,
+  setAdjustments,
 }: KeyboardShortcutsProps) => {
   useEffect(() => {
     const handleKeyDown = (event: any) => {
@@ -364,6 +375,221 @@ export const useKeyboardShortcuts = ({
         }
       }
 
+      // Numpad shortcuts for SP-3000 style adjustments
+      if (numpadSettings?.enabled && selectedImage) {
+        const stepSizes = numpadSettings.stepSizes;
+        const mode = numpadSettings.mode;
+
+        // Handle numpad keys
+        if (code.startsWith('Numpad') && !isCtrl) {
+          event.preventDefault();
+
+          switch (code) {
+            case 'Numpad7':
+              // - Yellow / + Blue
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  temperature: (prev.temperature || 0) - stepSizes.rgbCmy,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  sp3000ColorOffsets: {
+                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
+                    yellowBlue: (prev.sp3000ColorOffsets?.yellowBlue || 0) - stepSizes.rgbCmy,
+                  },
+                }));
+              }
+              break;
+            case 'Numpad4':
+              // + Yellow / - Blue
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  temperature: (prev.temperature || 0) + stepSizes.rgbCmy,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  sp3000ColorOffsets: {
+                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
+                    yellowBlue: (prev.sp3000ColorOffsets?.yellowBlue || 0) + stepSizes.rgbCmy,
+                  },
+                }));
+              }
+              break;
+            case 'Numpad8':
+              // - Magenta / + Green
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  tint: (prev.tint || 0) - stepSizes.rgbCmy,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  sp3000ColorOffsets: {
+                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
+                    magentaGreen: (prev.sp3000ColorOffsets?.magentaGreen || 0) - stepSizes.rgbCmy,
+                  },
+                }));
+              }
+              break;
+            case 'Numpad5':
+              // + Magenta / - Green
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  tint: (prev.tint || 0) + stepSizes.rgbCmy,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  sp3000ColorOffsets: {
+                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
+                    magentaGreen: (prev.sp3000ColorOffsets?.magentaGreen || 0) + stepSizes.rgbCmy,
+                  },
+                }));
+              }
+              break;
+            case 'Numpad9':
+              // - Cyan / + Red (Film mode only)
+              if (mode === 'film') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  sp3000ColorOffsets: {
+                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
+                    cyanRed: (prev.sp3000ColorOffsets?.cyanRed || 0) - stepSizes.rgbCmy,
+                  },
+                }));
+              }
+              break;
+            case 'Numpad6':
+              // + Cyan / - Red (Film mode only)
+              if (mode === 'film') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  sp3000ColorOffsets: {
+                    ...(prev.sp3000ColorOffsets || INITIAL_SP3000_OFFSETS),
+                    cyanRed: (prev.sp3000ColorOffsets?.cyanRed || 0) + stepSizes.rgbCmy,
+                  },
+                }));
+              }
+              break;
+            case 'Numpad1':
+              // - Density (brighten)
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  exposure: (prev.exposure || 0) + stepSizes.exposure,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  exposure: (prev.exposure || 0) + stepSizes.exposure,
+                  blacks: (prev.blacks || 0) + 2,
+                }));
+              }
+              break;
+            case 'NumpadDecimal':
+              // + Density (darken)
+              if (mode === 'digital') {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  exposure: (prev.exposure || 0) - stepSizes.exposure,
+                }));
+              } else {
+                setAdjustments((prev: Adjustments) => ({
+                  ...prev,
+                  exposure: (prev.exposure || 0) - stepSizes.exposure,
+                  blacks: (prev.blacks || 0) - 2,
+                }));
+              }
+              break;
+            case 'Numpad2':
+              // - Contrast (soften)
+              setAdjustments((prev: Adjustments) => ({
+                ...prev,
+                contrast: (prev.contrast || 0) - stepSizes.contrast,
+              }));
+              break;
+            case 'Numpad3':
+              // + Contrast (harden)
+              setAdjustments((prev: Adjustments) => ({
+                ...prev,
+                contrast: (prev.contrast || 0) + stepSizes.contrast,
+              }));
+              break;
+            case 'Numpad0':
+              // Reset SP-3000 offsets
+              setAdjustments((prev: Adjustments) => ({
+                ...prev,
+                sp3000ColorOffsets: { ...INITIAL_SP3000_OFFSETS },
+              }));
+              break;
+            case 'NumpadEnter':
+              // Handle based on enterKeyMode
+              switch (numpadSettings.enterKeyMode) {
+                case 'next':
+                  // Move to next image
+                  const nextIndex = sortedImageList.findIndex(
+                    (img: ImageFile) => img.path === selectedImage.path
+                  );
+                  if (nextIndex !== -1) {
+                    let newIndex = nextIndex + 1;
+                    if (newIndex >= sortedImageList.length) {
+                      newIndex = 0;
+                    }
+                    const nextImage = sortedImageList[newIndex];
+                    if (nextImage) {
+                      handleImageSelect(nextImage.path);
+                    }
+                  }
+                  break;
+                case 'instant-export':
+                  // Export and move to next
+                  if (handleExportCurrent) {
+                    handleExportCurrent();
+                    const exportIndex = sortedImageList.findIndex(
+                      (img: ImageFile) => img.path === selectedImage.path
+                    );
+                    if (exportIndex !== -1) {
+                      let newIndex = exportIndex + 1;
+                      if (newIndex >= sortedImageList.length) {
+                        newIndex = 0;
+                      }
+                      const nextImage = sortedImageList[newIndex];
+                      if (nextImage) {
+                        handleImageSelect(nextImage.path);
+                      }
+                    }
+                  }
+                  break;
+                case 'skip-move':
+                  // Just move to next (revert metadata changes)
+                  const skipIndex = sortedImageList.findIndex(
+                    (img: ImageFile) => img.path === selectedImage.path
+                  );
+                  if (skipIndex !== -1) {
+                    let newIndex = skipIndex + 1;
+                    if (newIndex >= sortedImageList.length) {
+                      newIndex = 0;
+                    }
+                    const nextImage = sortedImageList[newIndex];
+                    if (nextImage) {
+                      handleImageSelect(nextImage.path);
+                    }
+                  }
+                  break;
+              }
+              break;
+            default:
+              break;
+          }
+        }
+      }
+
       if (isCtrl) {
         const dpr = typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1;
         const currentPercent =
@@ -502,7 +728,12 @@ export const useKeyboardShortcuts = ({
     displaySize,
     baseRenderSize,
     originalSize,
-    brushSettings,  
-    setBrushSettings,  
+    brushSettings,
+    setBrushSettings,
+    numpadSettings,
+    setNumpadSettings,
+    handleExportCurrent,
+    adjustments,
+    setAdjustments,
   ]);
 };

--- a/src/utils/adjustments.tsx
+++ b/src/utils/adjustments.tsx
@@ -124,6 +124,12 @@ export interface ColorCalibration {
   blueSaturation: number;
 }
 
+export interface Sp3000ColorOffsets {
+  cyanRed: number;
+  magentaGreen: number;
+  yellowBlue: number;
+}
+
 export interface Adjustments {
   [index: string]: any;
   aiPatches: Array<AiPatch>;
@@ -185,6 +191,7 @@ export interface Adjustments {
   shadows: number;
   sharpness: number;
   showClipping: boolean;
+  sp3000ColorOffsets?: Sp3000ColorOffsets;
   structure: number;
   temperature: number;
   tint: number;
@@ -346,6 +353,12 @@ const INITIAL_COLOR_CALIBRATION: ColorCalibration = {
   blueSaturation: 0,
 };
 
+export const INITIAL_SP3000_OFFSETS: Sp3000ColorOffsets = {
+  cyanRed: 0,
+  magentaGreen: 0,
+  yellowBlue: 0,
+};
+
 export const INITIAL_MASK_ADJUSTMENTS: MaskAdjustments = {
   blacks: 0,
   brightness: 0,
@@ -496,6 +509,7 @@ export const INITIAL_ADJUSTMENTS: Adjustments = {
   shadows: 0,
   sharpness: 0,
   showClipping: false,
+  sp3000ColorOffsets: { ...INITIAL_SP3000_OFFSETS },
   structure: 0,
   temperature: 0,
   tint: 0,
@@ -590,6 +604,7 @@ export const normalizeLoadedAdjustments = (loadedAdjustments: Adjustments): any 
     colorGrading: { ...INITIAL_ADJUSTMENTS.colorGrading, ...(loadedAdjustments.colorGrading || {}) },
     hsl: { ...INITIAL_ADJUSTMENTS.hsl, ...(loadedAdjustments.hsl || {}) },
     curves: { ...INITIAL_ADJUSTMENTS.curves, ...(loadedAdjustments.curves || {}) },
+    sp3000ColorOffsets: { ...INITIAL_ADJUSTMENTS.sp3000ColorOffsets, ...(loadedAdjustments.sp3000ColorOffsets || {}) },
     masks: normalizedMasks,
     aiPatches: normalizedAiPatches,
     sectionVisibility: {

--- a/src/utils/adjustments.tsx
+++ b/src/utils/adjustments.tsx
@@ -124,7 +124,7 @@ export interface ColorCalibration {
   blueSaturation: number;
 }
 
-export interface Sp3000ColorOffsets {
+export interface FilmColorOffsets {
   cyanRed: number;
   magentaGreen: number;
   yellowBlue: number;
@@ -191,7 +191,7 @@ export interface Adjustments {
   shadows: number;
   sharpness: number;
   showClipping: boolean;
-  sp3000ColorOffsets?: Sp3000ColorOffsets;
+  filmColorOffsets?: FilmColorOffsets;
   structure: number;
   temperature: number;
   tint: number;
@@ -353,7 +353,7 @@ const INITIAL_COLOR_CALIBRATION: ColorCalibration = {
   blueSaturation: 0,
 };
 
-export const INITIAL_SP3000_OFFSETS: Sp3000ColorOffsets = {
+export const INITIAL_FILM_OFFSETS: FilmColorOffsets = {
   cyanRed: 0,
   magentaGreen: 0,
   yellowBlue: 0,
@@ -509,7 +509,7 @@ export const INITIAL_ADJUSTMENTS: Adjustments = {
   shadows: 0,
   sharpness: 0,
   showClipping: false,
-  sp3000ColorOffsets: { ...INITIAL_SP3000_OFFSETS },
+  filmColorOffsets: { ...INITIAL_FILM_OFFSETS },
   structure: 0,
   temperature: 0,
   tint: 0,
@@ -604,7 +604,7 @@ export const normalizeLoadedAdjustments = (loadedAdjustments: Adjustments): any 
     colorGrading: { ...INITIAL_ADJUSTMENTS.colorGrading, ...(loadedAdjustments.colorGrading || {}) },
     hsl: { ...INITIAL_ADJUSTMENTS.hsl, ...(loadedAdjustments.hsl || {}) },
     curves: { ...INITIAL_ADJUSTMENTS.curves, ...(loadedAdjustments.curves || {}) },
-    sp3000ColorOffsets: { ...INITIAL_ADJUSTMENTS.sp3000ColorOffsets, ...(loadedAdjustments.sp3000ColorOffsets || {}) },
+    filmColorOffsets: { ...INITIAL_ADJUSTMENTS.filmColorOffsets, ...(loadedAdjustments.filmColorOffsets || {}) },
     masks: normalizedMasks,
     aiPatches: normalizedAiPatches,
     sectionVisibility: {


### PR DESCRIPTION
## Description
Implemented numpad hotkeys for rapid image adjustments, inspired by traditional film scanner workflows. Users can now adjust RGB/CMY color channels, contrast, and density using the numpad keys, with configurable step sizes and two adjustment modes.

This was requested in https://github.com/CyberTimon/RapidRAW/issues/96

## Type of Change
- [x] New feature

## Changes Made
- Added settings interface for numpad configuration with mode (digital/film), enter key behavior, and configurable step sizes
- Extended adjustments interface with color offsets for film-style color grading
- Updated keyboard shortcuts hook to handle all numpad keys with:
  - Digital mode: Temperature/Tint adjustments
  - Film mode: Full RGB/CMY color offsets with density-rich shadows
  - Contrast adjustments
  - Reset function
  - Enter key modes: Next, Instant Export, Skip & Move
- Created settings panel section with:
  - Enable/disable toggle
  - Mode switch (Digital/Film)
  - Enter key behavior selector
  - Adjustable step sizes for exposure, contrast, and RGB/CMY
  - Key mapping reference table
- Integrated with main app to pass numpad settings and adjustments to the keyboard hook

## Screenshots/Videos
<img width="1274" height="1357" alt="image" src="https://github.com/user-attachments/assets/70456613-b57f-4e19-b155-7d0635ffc8d2" />
<img width="1272" height="1372" alt="image" src="https://github.com/user-attachments/assets/2d54c2d0-2c72-4d95-aa13-a538c47261f7" />
<img width="1259" height="1341" alt="image" src="https://github.com/user-attachments/assets/52ad7641-ccd3-47ed-ab81-60e4b1bb4595" />
<img width="1205" height="442" alt="image" src="https://github.com/user-attachments/assets/7c504c5d-f0cf-42f4-9e06-d2a8f6399755" />

## Critical Issue: Film Mode Not Integrated with Backend

The Film mode (RGB/CMY color offsets) is currently **not functional** because it lacks backend integration.

### Problem
- Frontend stores `filmColorOffsets` (cyanRed, magentaGreen, yellowBlue) in the adjustments state
- Numpad shortcuts successfully modify these values in the frontend
- However, the Rust backend ([GlobalAdjustments](cci:2://file:///c:/Users/fil/Documents/GitHub/RapidRAW/src-tauri/src/image_processing.rs:1191:0-1273:1) struct in [image_processing.rs](cci:7://file:///c:/Users/fil/Documents/GitHub/RapidRAW/src-tauri/src/image_processing.rs:0:0-0:0)) and WGSL shader do not include these fields
- No shader logic exists to apply these color offsets to the rendered image

### Impact
- Film mode adjustments are saved but **do not affect image rendering**
- Digital mode works fully (uses existing temperature/tint which are already in the backend)
- Users will see no visual change when using Film mode numpad keys

### Resolution Required
To make Film mode functional, backend changes are needed:
1. Add `cyan_red`, `magenta_green`, `yellow_blue` fields to Rust [GlobalAdjustments](cci:2://file:///c:/Users/fil/Documents/GitHub/RapidRAW/src-tauri/src/image_processing.rs:1191:0-1273:1) struct
2. Add same fields to WGSL shader [GlobalAdjustments](cci:2://file:///c:/Users/fil/Documents/GitHub/RapidRAW/src-tauri/src/image_processing.rs:1191:0-1273:1) struct  
3. Add shader logic to apply these color offsets in the color grading section
4. Update JSON-to-struct conversion in [image_processing.rs](cci:7://file:///c:/Users/fil/Documents/GitHub/RapidRAW/src-tauri/src/image_processing.rs:0:0-0:0)

### Current Status
- Film mode is documented as experimental in the UI with a warning banner
- Digital mode is fully functional and recommended for use

### Optional future addition
Color Panel could be updated to display film color offsets for visual feedback

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 11
- **Hardware:** i9-9900 RX9070

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
- [x] This PR is AI-generated but guided by a human