### PR TITLE
[Android] Fix FS operations, enable all supported formats import, enable library backup, fix LUT

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -587,8 +587,7 @@ pub fn parse_virtual_path(virtual_path: &str) -> (PathBuf, PathBuf) {
     (source_path, sidecar_path)
 }
 
-#[cfg(target_os = "android")]
-fn is_android_content_uri(path: &str) -> bool {
+pub fn is_android_content_uri(path: &str) -> bool {
     path.starts_with("content://")
 }
 
@@ -670,7 +669,7 @@ fn parse_android_uri<'local>(
 }
 
 #[cfg(target_os = "android")]
-fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
+pub fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
     let vm = unsafe { JavaVM::from_raw(android_context().vm().cast()) }
         .map_err(|e| format!("Failed to access Android JVM: {}", e))?;
     let mut env = vm
@@ -772,7 +771,7 @@ fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
 }
 
 #[cfg(target_os = "android")]
-fn read_android_content_uri(uri_str: &str) -> Result<Vec<u8>, String> {
+pub fn read_android_content_uri(uri_str: &str) -> Result<Vec<u8>, String> {
     let vm = unsafe { JavaVM::from_raw(android_context().vm().cast()) }
         .map_err(|e| format!("Failed to access Android JVM: {}", e))?;
     let mut env = vm

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -714,106 +714,113 @@ fn parse_android_uri<'local>(
     Ok(uri)
 }
 
-#[cfg(target_os = "android")]
-fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
-    let vm = unsafe { JavaVM::from_raw(android_context().vm().cast()) }
-        .map_err(|e| format!("Failed to access Android JVM: {}", e))?;
-    let mut env = vm
-        .attach_current_thread()
-        .map_err(|e| format!("Failed to attach current thread to Android JVM: {}", e))?;
+#[tauri::command]
+pub fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
+    #[cfg(target_os = "android")]
+    {
+        let vm = unsafe { JavaVM::from_raw(android_context().vm().cast()) }
+            .map_err(|e| format!("Failed to access Android JVM: {}", e))?;
+        let mut env = vm
+            .attach_current_thread()
+            .map_err(|e| format!("Failed to attach current thread to Android JVM: {}", e))?;
 
-    let resolver = get_android_content_resolver(&mut env)?;
-    let uri = parse_android_uri(&mut env, uri_str)?;
-    let null_obj = JObject::null();
+        let resolver = get_android_content_resolver(&mut env)?;
+        let uri = parse_android_uri(&mut env, uri_str)?;
+        let null_obj = JObject::null();
 
-    let cursor = env
-        .call_method(
-            &resolver,
-            "query",
-            "(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;",
-            &[
-                (&uri).into(),
-                (&null_obj).into(),
-                (&null_obj).into(),
-                (&null_obj).into(),
-                (&null_obj).into(),
-            ],
-        )
-        .and_then(|value| value.l())
-        .map_err(|e| map_android_jni_error(&mut env, e))?;
+        let cursor = env
+            .call_method(
+                &resolver,
+                "query",
+                "(Landroid/net/Uri;[Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;)Landroid/database/Cursor;",
+                &[
+                    (&uri).into(),
+                    (&null_obj).into(),
+                    (&null_obj).into(),
+                    (&null_obj).into(),
+                    (&null_obj).into(),
+                ],
+            )
+            .and_then(|value| value.l())
+            .map_err(|e| map_android_jni_error(&mut env, e))?;
 
-    if cursor.is_null() {
-        return Err(format!(
-            "ContentResolver query returned no cursor for URI: {}",
-            uri_str
-        ));
+        if cursor.is_null() {
+            return Err(format!(
+                "ContentResolver query returned no cursor for URI: {}",
+                uri_str
+            ));
+        }
+
+        let result = (|| -> Result<String, String> {
+            let moved = env
+                .call_method(&cursor, "moveToFirst", "()Z", &[])
+                .and_then(|value| value.z())
+                .map_err(|e| map_android_jni_error(&mut env, e))?;
+
+            if !moved {
+                return Err(format!(
+                    "No metadata rows found for content URI: {}",
+                    uri_str
+                ));
+            }
+
+            let display_name_column = env
+                .get_static_field(
+                    "android/provider/OpenableColumns",
+                    "DISPLAY_NAME",
+                    "Ljava/lang/String;",
+                )
+                .and_then(|value| value.l())
+                .map_err(|e| map_android_jni_error(&mut env, e))?;
+            let column_index = env
+                .call_method(
+                    &cursor,
+                    "getColumnIndex",
+                    "(Ljava/lang/String;)I",
+                    &[(&display_name_column).into()],
+                )
+                .and_then(|value| value.i())
+                .map_err(|e| map_android_jni_error(&mut env, e))?;
+
+            if column_index < 0 {
+                return Err(format!(
+                    "DISPLAY_NAME column was unavailable for content URI: {}",
+                    uri_str
+                ));
+            }
+
+            let display_name_obj = env
+                .call_method(
+                    &cursor,
+                    "getString",
+                    "(I)Ljava/lang/String;",
+                    &[JValue::from(column_index)],
+                )
+                .and_then(|value| value.l())
+                .map_err(|e| map_android_jni_error(&mut env, e))?;
+
+            if display_name_obj.is_null() {
+                return Err(format!(
+                    "Display name was null for content URI: {}",
+                    uri_str
+                ));
+            }
+
+            let display_name_java = JString::from(display_name_obj);
+            let display_name = env
+                .get_string(&display_name_java)
+                .map_err(|e| map_android_jni_error(&mut env, e))?;
+
+            Ok(display_name.into())
+        })();
+
+        close_android_closeable(&mut env, &cursor);
+        result
     }
-
-    let result = (|| -> Result<String, String> {
-        let moved = env
-            .call_method(&cursor, "moveToFirst", "()Z", &[])
-            .and_then(|value| value.z())
-            .map_err(|e| map_android_jni_error(&mut env, e))?;
-
-        if !moved {
-            return Err(format!(
-                "No metadata rows found for content URI: {}",
-                uri_str
-            ));
-        }
-
-        let display_name_column = env
-            .get_static_field(
-                "android/provider/OpenableColumns",
-                "DISPLAY_NAME",
-                "Ljava/lang/String;",
-            )
-            .and_then(|value| value.l())
-            .map_err(|e| map_android_jni_error(&mut env, e))?;
-        let column_index = env
-            .call_method(
-                &cursor,
-                "getColumnIndex",
-                "(Ljava/lang/String;)I",
-                &[(&display_name_column).into()],
-            )
-            .and_then(|value| value.i())
-            .map_err(|e| map_android_jni_error(&mut env, e))?;
-
-        if column_index < 0 {
-            return Err(format!(
-                "DISPLAY_NAME column was unavailable for content URI: {}",
-                uri_str
-            ));
-        }
-
-        let display_name_obj = env
-            .call_method(
-                &cursor,
-                "getString",
-                "(I)Ljava/lang/String;",
-                &[JValue::from(column_index)],
-            )
-            .and_then(|value| value.l())
-            .map_err(|e| map_android_jni_error(&mut env, e))?;
-
-        if display_name_obj.is_null() {
-            return Err(format!(
-                "Display name was null for content URI: {}",
-                uri_str
-            ));
-        }
-
-        let display_name_java = JString::from(display_name_obj);
-        let display_name = env
-            .get_string(&display_name_java)
-            .map_err(|e| map_android_jni_error(&mut env, e))?;
-
-        Ok(display_name.into())
-    })();
-
-    close_android_closeable(&mut env, &cursor);
-    result
+    #[cfg(not(target_os = "android"))]
+    {
+        Ok(uri_str.to_string())
+    }
 }
 
 #[cfg(target_os = "android")]

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -618,6 +618,52 @@ fn close_android_closeable(env: &mut JNIEnv<'_>, closeable: &JObject<'_>) {
 }
 
 #[cfg(target_os = "android")]
+pub fn get_android_cached_lut_path(uri: &str, extension: &str) -> anyhow::Result<PathBuf> {
+    let vm = unsafe { jni::JavaVM::from_raw(ndk_context::android_context().vm().cast()) }
+        .map_err(|e| anyhow::anyhow!("Failed to access Android JVM: {}", e))?;
+    let mut env = vm.attach_current_thread()
+        .map_err(|e| anyhow::anyhow!("Failed to attach current thread: {}", e))?;
+    
+    let context = env.new_local_ref(unsafe { jni::objects::JObject::from_raw(ndk_context::android_context().context().cast()) })
+        .map_err(|e| anyhow::anyhow!(map_android_jni_error(&mut env, e)))?;
+
+    let dirs_array_obj = env.call_method(
+        &context,
+        "getExternalMediaDirs",
+        "()[Ljava/io/File;",
+        &[],
+    ).and_then(|v| v.l()).map_err(|e| anyhow::anyhow!(map_android_jni_error(&mut env, e)))?;
+
+    if dirs_array_obj.is_null() {
+        return Err(anyhow::anyhow!("External media storage not available"));
+    }
+
+    let dirs_array: jni::objects::JObjectArray = dirs_array_obj.into();
+    let dir_file = env.get_object_array_element(&dirs_array, 0)
+        .map_err(|e| anyhow::anyhow!(map_android_jni_error(&mut env, e)))?;
+
+    let path_jstring = env.call_method(&dir_file, "getAbsolutePath", "()Ljava/lang/String;", &[])
+        .and_then(|v| v.l()).map_err(|e| anyhow::anyhow!(map_android_jni_error(&mut env, e)))?;
+    
+    let root_path_str: String = env.get_string(&path_jstring.into())
+        .map_err(|e| anyhow::anyhow!(map_android_jni_error(&mut env, e)))?.into();
+
+    let mut hasher = DefaultHasher::new();
+    uri.hash(&mut hasher);
+    let hash = hasher.finish();
+
+    let mut path = PathBuf::from(root_path_str);
+    path.push(".lut_cache"); 
+    
+    if !path.exists() {
+        fs::create_dir_all(&path)?;
+    }
+    
+    path.push(format!("{:x}.{}", hash, extension));
+    Ok(path)
+}
+
+#[cfg(target_os = "android")]
 fn get_android_content_resolver<'local>(
     env: &mut JNIEnv<'local>,
 ) -> Result<JObject<'local>, String> {
@@ -669,7 +715,7 @@ fn parse_android_uri<'local>(
 }
 
 #[cfg(target_os = "android")]
-pub fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
+fn resolve_android_content_uri_name(uri_str: &str) -> Result<String, String> {
     let vm = unsafe { JavaVM::from_raw(android_context().vm().cast()) }
         .map_err(|e| format!("Failed to access Android JVM: {}", e))?;
     let mut env = vm

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -648,9 +648,7 @@ pub fn get_android_cached_lut_path(uri: &str, extension: &str) -> anyhow::Result
     let root_path_str: String = env.get_string(&path_jstring.into())
         .map_err(|e| anyhow::anyhow!(map_android_jni_error(&mut env, e)))?.into();
 
-    let mut hasher = DefaultHasher::new();
-    uri.hash(&mut hasher);
-    let hash = hasher.finish();
+    let hash = blake3::hash(uri.as_bytes());
 
     let mut path = PathBuf::from(root_path_str);
     path.push(".lut_cache"); 
@@ -659,7 +657,7 @@ pub fn get_android_cached_lut_path(uri: &str, extension: &str) -> anyhow::Result
         fs::create_dir_all(&path)?;
     }
     
-    path.push(format!("{:x}.{}", hash, extension));
+    path.push(format!("{}.{}", &hash.to_hex()[..16], extension));
     Ok(path)
 }
 

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -2707,17 +2707,64 @@ fn get_settings_path(app_handle: &AppHandle) -> Result<std::path::PathBuf, Strin
 }
 
 fn get_internal_library_root_path(app_handle: &AppHandle) -> Result<std::path::PathBuf, String> {
-    let library_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| e.to_string())?
-        .join("library");
+    #[cfg(not(target_os = "android"))]
+    {
+        let library_dir = app_handle
+            .path()
+            .app_data_dir()
+            .map_err(|e| e.to_string())?
+            .join("library");
 
-    if !library_dir.exists() {
-        fs::create_dir_all(&library_dir).map_err(|e| e.to_string())?;
+        if !library_dir.exists() {
+            fs::create_dir_all(&library_dir).map_err(|e| e.to_string())?;
+        }
+        Ok(library_dir)
     }
+    #[cfg(target_os = "android")]
+    {
+        let vm = unsafe { JavaVM::from_raw(android_context().vm().cast()) }
+            .map_err(|e| format!("Failed to access Android JVM: {}", e))?;
+        let mut env = vm.attach_current_thread()
+            .map_err(|e| format!("Failed to attach current thread: {}", e))?;
+        
+        let context = env.new_local_ref(unsafe { JObject::from_raw(android_context().context().cast()) })
+            .map_err(|e| map_android_jni_error(&mut env, e))?;
 
-    Ok(library_dir)
+        let dirs_array_obj = env.call_method(
+            &context,
+            "getExternalMediaDirs",
+            "()[Ljava/io/File;",
+            &[],
+        ).and_then(|v| v.l()).map_err(|e| map_android_jni_error(&mut env, e))?;
+
+        if dirs_array_obj.is_null() {
+            return Err("External media storage not available".to_string());
+        }
+
+        let dirs_array: jni::objects::JObjectArray = dirs_array_obj.into();
+        
+        let dir_file = env.get_object_array_element(&dirs_array, 0)
+            .map_err(|e| map_android_jni_error(&mut env, e))?;
+
+        if dir_file.is_null() {
+            return Err("Primary external media storage is null".to_string());
+        }
+
+        let path_jstring = env.call_method(&dir_file, "getAbsolutePath", "()Ljava/lang/String;", &[])
+            .and_then(|v| v.l()).map_err(|e| map_android_jni_error(&mut env, e))?;
+        
+        let path: String = env.get_string(&path_jstring.into())
+            .map_err(|e| map_android_jni_error(&mut env, e))?.into();
+        
+        let media_path = PathBuf::from(path);
+        let library_dir = media_path.join(".library");
+        
+        if !library_dir.exists() {
+            fs::create_dir_all(&library_dir).map_err(|e| e.to_string())?;
+        }
+        Ok(library_dir)
+    }
+    
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5206,6 +5206,7 @@ pub fn run() {
             file_management::set_rating_for_paths,
             file_management::import_files,
             file_management::create_virtual_copy,
+            file_management::resolve_android_content_uri_name,
             tagging::start_background_indexing,
             tagging::clear_ai_tags,
             tagging::clear_all_tags,

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -3,9 +3,11 @@ use image::{DynamicImage, GenericImageView, Rgb, Rgb32FImage};
 use std::fs::File;
 use std::io::{BufRead, BufReader, Cursor};
 use std::path::Path;
+#[cfg(target_os = "android")]
+use std::fs;
 use crate::file_management::{is_android_content_uri};
 #[cfg(target_os = "android")]
-use crate::file_management::{resolve_android_content_uri_name, read_android_content_uri};
+use crate::file_management::{read_android_content_uri, get_android_cached_lut_path};
 
 #[derive(Debug, Clone)]
 pub struct Lut {
@@ -184,17 +186,33 @@ pub fn parse_lut_file(path_str: &str) -> Result<Lut> {
     let (extension, bytes): (String, Option<Vec<u8>>) = if cfg!(target_os = "android") && is_android_content_uri(path_str) {
         #[cfg(target_os = "android")]
         {
-            let name = resolve_android_content_uri_name(path_str).map_err(|e| anyhow!(e))?;
-            let ext = Path::new(&name)
-                .extension()
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_lowercase();
-            let b = Some(read_android_content_uri(path_str).map_err(|e| anyhow!(e))?);
-            (ext, b)
+            let ext = path_str
+                .rsplit_once('.')
+                .map(|(_, e)| e.to_lowercase())
+                .unwrap_or_else(|| "".to_string());
+
+            let cache_path = get_android_cached_lut_path(path_str, &ext)?;
+            
+            let data = if cache_path.exists() {
+                fs::read(&cache_path).ok()
+            } else {
+                None
+            };
+
+            let actual_data = match data {
+                Some(d) => d,
+                None => {
+                    let uri_bytes = read_android_content_uri(path_str).map_err(|e| anyhow!(e))?;
+                    let _ = fs::write(&cache_path, &uri_bytes);
+                    uri_bytes
+                }
+            };
+            (ext, Some(actual_data))
         }
         #[cfg(not(target_os = "android"))]
-        { (String::new(), None) }
+        { 
+            (String::new(), None)
+        }
     } else {
         let ext = Path::new(path_str)
             .extension()

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -1,8 +1,11 @@
 use anyhow::{Result, anyhow};
 use image::{DynamicImage, GenericImageView, Rgb, Rgb32FImage};
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, Cursor};
 use std::path::Path;
+use crate::file_management::{is_android_content_uri};
+#[cfg(target_os = "android")]
+use crate::file_management::{resolve_android_content_uri_name, read_android_content_uri};
 
 #[derive(Debug, Clone)]
 pub struct Lut {
@@ -10,10 +13,7 @@ pub struct Lut {
     pub data: Vec<f32>,
 }
 
-fn parse_cube(path: &Path) -> Result<Lut> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-
+fn parse_cube(reader: impl BufRead) -> Result<Lut> {
     let mut size: Option<u32> = None;
     let mut data: Vec<f32> = Vec::new();
     let mut line_num = 0;
@@ -111,9 +111,7 @@ fn parse_cube(path: &Path) -> Result<Lut> {
     })
 }
 
-fn parse_3dl(path: &Path) -> Result<Lut> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
+fn parse_3dl(reader: impl BufRead) -> Result<Lut> {
     let mut data: Vec<f32> = Vec::new();
 
     for line in reader.lines() {
@@ -183,18 +181,52 @@ fn parse_hald(image: DynamicImage) -> Result<Lut> {
 }
 
 pub fn parse_lut_file(path_str: &str) -> Result<Lut> {
-    let path = Path::new(path_str);
-    let extension = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .unwrap_or("")
-        .to_lowercase();
+    let (extension, bytes): (String, Option<Vec<u8>>) = if cfg!(target_os = "android") && is_android_content_uri(path_str) {
+        #[cfg(target_os = "android")]
+        {
+            let name = resolve_android_content_uri_name(path_str).map_err(|e| anyhow!(e))?;
+            let ext = Path::new(&name)
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+            let b = Some(read_android_content_uri(path_str).map_err(|e| anyhow!(e))?);
+            (ext, b)
+        }
+        #[cfg(not(target_os = "android"))]
+        { (String::new(), None) }
+    } else {
+        let ext = Path::new(path_str)
+            .extension()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+        (ext, None)
+    };
 
     match extension.as_str() {
-        "cube" => parse_cube(path),
-        "3dl" => parse_3dl(path),
+        "cube" => {
+            if let Some(b) = bytes {
+                parse_cube(BufReader::new(Cursor::new(b)))
+            } else {
+                let file = File::open(path_str)?;
+                parse_cube(BufReader::new(file))
+            }
+        }
+        "3dl" => {
+            if let Some(b) = bytes {
+                parse_3dl(BufReader::new(Cursor::new(b)))
+            } else {
+                let file = File::open(path_str)?;
+                parse_3dl(BufReader::new(file))
+            }
+        }
         "png" | "jpg" | "jpeg" | "tiff" => {
-            let img = image::open(path)?;
+            let img = if let Some(b) = bytes {
+                image::load_from_memory(&b)?
+            } else {
+                image::open(path_str)?
+            };
             parse_hald(img)
         }
         _ => Err(anyhow!("Unsupported LUT file format: {}", extension)),

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -5,9 +5,11 @@ use std::io::{BufRead, BufReader, Cursor};
 use std::path::Path;
 #[cfg(target_os = "android")]
 use std::fs;
+#[cfg(target_os = "android")]
+use std::hash::{Hash, DefaultHasher, Hasher};
 use crate::file_management::{is_android_content_uri};
 #[cfg(target_os = "android")]
-use crate::file_management::{read_android_content_uri, get_android_cached_lut_path};
+use crate::file_management::{read_android_content_uri, get_android_cached_lut_path, resolve_android_content_uri_name};
 
 #[derive(Debug, Clone)]
 pub struct Lut {
@@ -185,29 +187,54 @@ fn parse_hald(image: DynamicImage) -> Result<Lut> {
 pub fn parse_lut_file(path_str: &str) -> Result<Lut> {
     let (extension, bytes): (String, Option<Vec<u8>>) = if cfg!(target_os = "android") && is_android_content_uri(path_str) {
         #[cfg(target_os = "android")]
+        #[cfg(target_os = "android")]
         {
-            let ext = path_str
-                .rsplit_once('.')
-                .map(|(_, e)| e.to_lowercase())
-                .unwrap_or_else(|| "".to_string());
-
-            let cache_path = get_android_cached_lut_path(path_str, &ext)?;
-            
-            let data = if cache_path.exists() {
-                fs::read(&cache_path).ok()
-            } else {
-                None
-            };
-
-            let actual_data = match data {
-                Some(d) => d,
-                None => {
+            match resolve_android_content_uri_name(path_str) {
+                Ok(resolved_name) => {
+                    let ext = Path::new(&resolved_name)
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("cube")
+                        .to_lowercase();
+                    
                     let uri_bytes = read_android_content_uri(path_str).map_err(|e| anyhow!(e))?;
-                    let _ = fs::write(&cache_path, &uri_bytes);
-                    uri_bytes
+                    
+                    if let Ok(cache_path) = get_android_cached_lut_path(path_str, &ext) {
+                        let _ = fs::write(cache_path, &uri_bytes);
+                    }
+                    
+                    (ext, Some(uri_bytes))
                 }
-            };
-            (ext, Some(actual_data))
+                Err(_) => {
+                    let mut hasher = DefaultHasher::new();
+                    path_str.hash(&mut hasher);
+                    let hash_prefix = format!("{:x}.", hasher.finish());
+
+                    let cache_dir = get_android_cached_lut_path(path_str, "tmp")?
+                        .parent()
+                        .ok_or_else(|| anyhow!("Invalid cache path"))?
+                        .to_path_buf();
+
+                    let mut found = None;
+                    if let Ok(entries) = fs::read_dir(cache_dir) {
+                        for entry in entries.flatten() {
+                            let fname = entry.file_name().to_string_lossy().into_owned();
+                            if fname.starts_with(&hash_prefix) {
+                                let ext = Path::new(&fname)
+                                    .extension()
+                                    .and_then(|s| s.to_str())
+                                    .unwrap_or("cube")
+                                    .to_string();
+                                if let Ok(bytes) = fs::read(entry.path()) {
+                                    found = Some((ext, Some(bytes)));
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    found.ok_or_else(|| anyhow!("LUT not found in cache and permission denied for URI"))?
+                }
+            }
         }
         #[cfg(not(target_os = "android"))]
         { 

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -5,8 +5,6 @@ use std::io::{BufRead, BufReader, Cursor};
 use std::path::Path;
 #[cfg(target_os = "android")]
 use std::fs;
-#[cfg(target_os = "android")]
-use std::hash::{Hash, DefaultHasher, Hasher};
 use crate::file_management::{is_android_content_uri};
 #[cfg(target_os = "android")]
 use crate::file_management::{read_android_content_uri, get_android_cached_lut_path, resolve_android_content_uri_name};
@@ -187,7 +185,6 @@ fn parse_hald(image: DynamicImage) -> Result<Lut> {
 pub fn parse_lut_file(path_str: &str) -> Result<Lut> {
     let (extension, bytes): (String, Option<Vec<u8>>) = if cfg!(target_os = "android") && is_android_content_uri(path_str) {
         #[cfg(target_os = "android")]
-        #[cfg(target_os = "android")]
         {
             match resolve_android_content_uri_name(path_str) {
                 Ok(resolved_name) => {
@@ -206,9 +203,7 @@ pub fn parse_lut_file(path_str: &str) -> Result<Lut> {
                     (ext, Some(uri_bytes))
                 }
                 Err(_) => {
-                    let mut hasher = DefaultHasher::new();
-                    path_str.hash(&mut hasher);
-                    let hash_prefix = format!("{:x}.", hasher.finish());
+                    let hash_prefix = format!("{}.", &blake3::hash(path_str.as_bytes()).to_hex()[..16]);
 
                     let cache_dir = get_android_cached_lut_path(path_str, "tmp")?
                         .parent()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1734,10 +1734,10 @@ function App() {
       try {
         const result: LutData = await invoke('load_and_parse_lut', { path });
         let name = 'LUT';
-        if (isAndroid && path.startsWith('content://')) {
-          const decodedPath = decodeURIComponent(path);
-          
-          name = decodedPath.split(/[:/]/).pop() || 'LUT';
+        if (isAndroid) {
+          name = await invoke<string>('resolve_android_content_uri_name', { 
+              uriStr: path
+            });
         } else {
           name = path.split(/[\\/]/).pop() || 'LUT';
         }
@@ -4208,8 +4208,23 @@ function App() {
         if (Array.isArray(selected) && selected.length > 0) {
           const invalidExtensions = new Set<string>();
           const allowedExtensions = new Set(allImageExtensions.map(e => e.toLowerCase()));
-          const validFiles = selected.filter((path) => {
-            const ext = path.split('.').pop()?.toLowerCase() || 'unknown';
+          const resolvedFiles = await Promise.all(
+            selected.map(async (path) => {
+              if (isAndroid) {
+                try {
+                  return await invoke<string>('resolve_android_content_uri_name', { uriStr: path });
+                } catch (e) {
+                  console.error("Failed to resolve URI:", e);
+                  return path;
+                }
+              }
+              return path;
+            })
+          );
+          const validFiles = selected.filter((originalPath, index) => {
+            const resolvedName = resolvedFiles[index];
+            const ext = resolvedName.split('.').pop()?.toLowerCase() || 'unknown';
+            
             if (!allowedExtensions.has(ext)) {
               invalidExtensions.add(`.${ext}`);
               return false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1733,7 +1733,14 @@ function App() {
     async (path: string) => {
       try {
         const result: LutData = await invoke('load_and_parse_lut', { path });
-        const name = path.split(/[\\/]/).pop() || 'LUT';
+        let name = 'LUT';
+        if (isAndroid && path.startsWith('content://')) {
+          const decodedPath = decodeURIComponent(path);
+          
+          name = decodedPath.split(/[:/]/).pop() || 'LUT';
+        } else {
+          name = path.split(/[\\/]/).pop() || 'LUT';
+        }
         setAdjustments((prev: Partial<Adjustments>) => ({
           ...prev,
           lutPath: path,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4171,9 +4171,10 @@ function App() {
         const processedNonRaw = expandExtensions(nonRaw);
         const processedRaw = expandExtensions(raw);
         const allImageExtensions = [...processedNonRaw, ...processedRaw];
-
-        const selected = await open({
-          filters: [
+        
+        const typeFilters = isAndroid
+        ? [ ] 
+        : [
             {
               name: 'All Supported Images',
               extensions: allImageExtensions,
@@ -4190,13 +4191,32 @@ function App() {
               name: 'All Files',
               extensions: ['*'],
             },
-          ],
+          ];
+        const selected = await open({
+          filters: typeFilters,
           multiple: true,
           title: 'Select files to import',
         });
 
         if (Array.isArray(selected) && selected.length > 0) {
-          setImportSourcePaths(selected);
+          const invalidExtensions = new Set<string>();
+          const allowedExtensions = new Set(allImageExtensions.map(e => e.toLowerCase()));
+          const validFiles = selected.filter((path) => {
+            const ext = path.split('.').pop()?.toLowerCase() || 'unknown';
+            if (!allowedExtensions.has(ext)) {
+              invalidExtensions.add(`.${ext}`);
+              return false;
+            }
+            return true;
+          });
+
+          if (invalidExtensions.size > 0) {
+            const extList = Array.from(invalidExtensions).join(', ');
+            toast.error(`Unsupported file format(s) detected: ${extList}`);
+            return;
+          }
+
+          setImportSourcePaths(validFiles);
           setImportTargetFolder(targetPath);
           setIsImportModalOpen(true);
         }
@@ -4204,7 +4224,7 @@ function App() {
         console.error('Failed to open file dialog for import:', err);
       }
     },
-    [supportedTypes],
+    [supportedTypes, isAndroid],
   );
 
   const handleEditorContextMenu = (event: any) => {

--- a/src/components/ui/LUTControl.tsx
+++ b/src/components/ui/LUTControl.tsx
@@ -1,6 +1,8 @@
 import { open } from '@tauri-apps/plugin-dialog';
 import { X } from 'lucide-react';
 import Slider from './Slider';
+import { useOsPlatform } from '../../hooks/useOsPlatform';
+import { toast } from 'react-toastify';
 
 interface LUTControlProps {
   lutName: string | null;
@@ -19,18 +21,36 @@ export default function LUTControl({
   onClear,
   onDragStateChange,
 }: LUTControlProps) {
+  const osPlatform = useOsPlatform(); 
+  const isAndroid = osPlatform === 'android';
+
   const handleSelectFile = async () => {
     try {
+      const LutExtensions = ['cube', '3dl', 'png', 'jpg', 'jpeg', 'tiff'];
+      const expandExtensions = (exts: string[]) => {
+          return Array.from(new Set(exts.flatMap((ext) => [ext.toLowerCase(), ext.toUpperCase()])));
+        };
+      const allLutExtensions = expandExtensions(LutExtensions);
+      const typeFilters = isAndroid
+        ? [ ] 
+        : [
+            {
+              name: 'LUT Files',
+              extensions: allLutExtensions,
+            },
+          ];
       const selected = await open({
         multiple: false,
-        filters: [
-          {
-            name: 'LUT Files',
-            extensions: ['cube', '3dl', 'png', 'jpg', 'jpeg', 'tiff'],
-          },
-        ],
+        filters: typeFilters,
       });
       if (typeof selected === 'string') {
+        const allowedExtensions = new Set(allLutExtensions.map(e => e.toLowerCase()));
+        const ext = selected.split('.').pop()?.toLowerCase() || 'unknown';
+        if (!allowedExtensions.has(ext)) {
+          toast.error(`Unsupported file format(s) detected: ${ext}`);
+          return;
+        }
+ 
         onLutSelect(selected);
       }
     } catch (err) {

--- a/src/components/ui/LUTControl.tsx
+++ b/src/components/ui/LUTControl.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react';
 import Slider from './Slider';
 import { useOsPlatform } from '../../hooks/useOsPlatform';
 import { toast } from 'react-toastify';
+import { invoke } from '@tauri-apps/api/core';
 
 interface LUTControlProps {
   lutName: string | null;
@@ -44,10 +45,20 @@ export default function LUTControl({
         filters: typeFilters,
       });
       if (typeof selected === 'string') {
+        let fileName = selected;
+        if (isAndroid) {
+          try {
+            fileName = await invoke<string>('resolve_android_content_uri_name', { 
+              uriStr: selected 
+            });
+          } catch (e) {
+            console.error('Failed to resolve Android URI:', e);
+          }
+        }
         const allowedExtensions = new Set(allLutExtensions.map(e => e.toLowerCase()));
-        const ext = selected.split('.').pop()?.toLowerCase() || 'unknown';
+        const ext = fileName.split('.').pop()?.toLowerCase() || 'unknown';
         if (!allowedExtensions.has(ext)) {
-          toast.error(`Unsupported file format(s) detected: ${ext}`);
+          toast.error(`Unsupported file format(s) detected: .${ext}`);
           return;
         }
  


### PR DESCRIPTION
## Description
- moved library path to /sdcard/Android/media
- Android library import can now handle all supported RAW formats
- Android LUT file picker fixed

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Android library now lives in  /sdcard/Android/media/io.github.CyberTimon.RapidRAW/.library. This allows backup of the library with non-root file managers
- Import file picker on Android does not use file extension filters as Android expects MIMI types, but not all supported RAW file types have a consistent Android MIME type, therefore the frontend checks the file type of the selected files and displays an error toast if the file is unsupported
- LUT file picker uses the same approach as import file picker on Android. While fixing this, I also discovered that we only supported lower-case LUT extensions until now, fixed that as well
- LUT files get cached on Android in  /sdcard/Android/media/io.github.CyberTimon.RapidRAW/.lut_cache. This is necessary, because with the current minimal permission set the app is only allowed to access the LUT file when the user actually selects it from the file picker. With the caching any later attempt to read the file again will be done from the app-owned .lut_cache folder which does not have the strict file access permission issues

## Screenshots/Videos


## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:**  Ubuntu 24.04, Android 16
- **Hardware:** Intel i5, Xiaomi Pad 7 

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
- we must use hidden folders in favor of .nomedia files because hidden folders don't trigger the android media scanner. With normal folders and .nomedia files the media scanner locks access to any .jpeg/png etc. files it finds in the folders even if they are not shown in the gallery. 
- The code implements a few workarounds to make sure that we don't need higher file access permissions on Android. This is a bit messy in some places. It should be discussed whether we want to request the external storage access permission in future so that we don't have to cache all files coming from outside the app

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
