### PR TITLE
Vertical Screens + Android fixes

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -505,6 +505,9 @@ impl Default for AppSettings {
             tagging_shortcuts: default_tagging_shortcuts_option(),
             custom_ai_tags: Some(Vec::new()),
             ai_tag_count: Some(10),
+            #[cfg(target_os = "android")]
+            thumbnail_size: Some("small".to_string()),
+            #[cfg(not(target_os = "android"))]
             thumbnail_size: Some("medium".to_string()),
             thumbnail_aspect_ratio: Some("cover".to_string()),
             ai_provider: Some("cpu".to_string()),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,6 +289,7 @@ function App() {
       return '';
     }
   });
+  const defaultThumbnailSize = osPlatform === 'android' ? ThumbnailSize.Small : ThumbnailSize.Medium;
   const [activeView, setActiveView] = useState('library');
   const [isWindowFullScreen, setIsWindowFullScreen] = useState(false);
   const [isInstantTransition, setIsInstantTransition] = useState(false);
@@ -401,7 +402,7 @@ function App() {
   const [compactEditorPanelHeightOverride, setCompactEditorPanelHeightOverride] = useState<number | null>(null);
   const [activeTreeSection, setActiveTreeSection] = useState<string | null>('current');
   const [isResizing, setIsResizing] = useState(false);
-  const [thumbnailSize, setThumbnailSize] = useState(ThumbnailSize.Medium);
+  const [thumbnailSize, setThumbnailSize] = useState(defaultThumbnailSize);
   const [thumbnailAspectRatio, setThumbnailAspectRatio] = useState(ThumbnailAspectRatio.Cover);
   const [copiedAdjustments, setCopiedAdjustments] = useState<Adjustments | null>(null);
   const [isStraightenActive, setIsStraightenActive] = useState(false);
@@ -1912,9 +1913,7 @@ function App() {
         if (settings?.libraryViewMode) {
           setLibraryViewMode(settings.libraryViewMode);
         }
-        if (settings?.thumbnailSize) {
-          setThumbnailSize(settings.thumbnailSize);
-        }
+        setThumbnailSize(settings?.thumbnailSize ?? defaultThumbnailSize);
         if (settings?.thumbnailAspectRatio) {
           setThumbnailAspectRatio(settings.thumbnailAspectRatio);
         }
@@ -1968,7 +1967,7 @@ function App() {
       })
       .catch((err) => {
         console.error('Failed to load settings:', err);
-        setAppSettings({ lastRootPath: null, theme: DEFAULT_THEME_ID });
+        setAppSettings({ lastRootPath: null, theme: DEFAULT_THEME_ID, thumbnailSize: defaultThumbnailSize });
       })
       .finally(() => {
         isInitialMount.current = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5266,6 +5266,7 @@ function App() {
           canUndo={canUndo}
           finalPreviewUrl={finalPreviewUrl}
           interactivePatch={interactivePatch}
+          isAndroid={isAndroid}
           isFullScreen={isFullScreen}
           isLoading={isViewLoading}
           isSliderDragging={isSliderDragging}

--- a/src/components/modals/CollageModal.tsx
+++ b/src/components/modals/CollageModal.tsx
@@ -594,7 +594,7 @@ export default function CollageModal({ isOpen, onClose, onSave, sourceImages }: 
   }, [panningImage, thumbnailDrag, activeLayout, previewSize, spacing, loadedImages, imageStates, hoveredCellIndex]);
 
   const renderControls = () => (
-    <div className="w-80 shrink-0 bg-bg-secondary p-4 flex flex-col gap-8 overflow-y-auto border-l border-surface h-full">
+    <div className="modal-adjustments-pane w-80 shrink-0 bg-bg-secondary p-4 flex flex-col gap-8 overflow-y-auto border-l border-surface h-full">
       {loadedImages.length > 1 && (
         <div>
           <Text variant={TextVariants.heading} className="mb-2 flex items-center justify-between">
@@ -772,7 +772,7 @@ export default function CollageModal({ isOpen, onClose, onSave, sourceImages }: 
     }
 
     return (
-      <div className="flex flex-row h-full w-full">
+      <div className="modal-preview-adjustments flex flex-row h-full w-full">
         <AnimatePresence>
           {thumbnailDrag && (
             <motion.div
@@ -794,7 +794,7 @@ export default function CollageModal({ isOpen, onClose, onSave, sourceImages }: 
           )}
         </AnimatePresence>
 
-        <div className="grow flex flex-col min-w-0 h-full bg-bg-secondary">
+        <div className="modal-preview-pane grow flex flex-col min-w-0 h-full bg-bg-secondary">
           <div ref={previewContainerRef} className="grow flex items-center justify-center p-4 relative min-h-0">
             {isLoading && (
               <div className="absolute inset-0 flex items-center justify-center bg-black/20 z-10">

--- a/src/components/modals/LensCorrectionModal.tsx
+++ b/src/components/modals/LensCorrectionModal.tsx
@@ -536,7 +536,7 @@ export default function LensCorrectionModal({
   };
 
   const renderControls = () => (
-    <div className="w-80 shrink-0 bg-bg-secondary flex flex-col border-l border-surface h-full z-10">
+    <div className="modal-adjustments-pane w-80 shrink-0 bg-bg-secondary flex flex-col border-l border-surface h-full z-10">
       <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
         <Text variant={TextVariants.title}>Lens Correction</Text>
         <button
@@ -797,8 +797,8 @@ export default function LensCorrectionModal({
   );
 
   const renderContent = () => (
-    <div className="flex flex-row h-full w-full overflow-hidden">
-      <div className="grow flex flex-col relative min-h-0 bg-[#0f0f0f] overflow-hidden">
+    <div className="modal-preview-adjustments flex flex-row h-full w-full overflow-hidden">
+      <div className="modal-preview-pane grow flex flex-col relative min-h-0 bg-[#0f0f0f] overflow-hidden">
         <div
           ref={containerRef}
           className="flex-1 relative overflow-hidden cursor-grab active:cursor-grabbing select-none"

--- a/src/components/modals/NegativeConversionModal.tsx
+++ b/src/components/modals/NegativeConversionModal.tsx
@@ -196,7 +196,7 @@ export default function NegativeConversionModal({
   };
 
   const renderControls = () => (
-    <div className="w-80 shrink-0 bg-bg-secondary flex flex-col border-l border-surface h-full z-10">
+    <div className="modal-adjustments-pane w-80 shrink-0 bg-bg-secondary flex flex-col border-l border-surface h-full z-10">
       <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
         <Text variant={TextVariants.title}>Negative Conversion</Text>
         <button
@@ -319,8 +319,8 @@ export default function NegativeConversionModal({
   );
 
   const renderContent = () => (
-    <div className="flex flex-row h-full w-full overflow-hidden">
-      <div className="grow flex flex-col relative min-h-0 bg-[#0f0f0f] overflow-hidden">
+    <div className="modal-preview-adjustments flex flex-row h-full w-full overflow-hidden">
+      <div className="modal-preview-pane grow flex flex-col relative min-h-0 bg-[#0f0f0f] overflow-hidden">
         <div
           ref={containerRef}
           className="flex-1 relative overflow-hidden cursor-grab active:cursor-grabbing select-none"

--- a/src/components/modals/TransformModal.tsx
+++ b/src/components/modals/TransformModal.tsx
@@ -324,7 +324,7 @@ export default function TransformModal({ isOpen, onClose, onApply, currentAdjust
   };
 
   const renderControls = () => (
-    <div className="w-80 shrink-0 bg-bg-secondary flex flex-col border-l border-surface h-full z-10">
+    <div className="modal-adjustments-pane w-80 shrink-0 bg-bg-secondary flex flex-col border-l border-surface h-full z-10">
       <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
         <Text variant={TextVariants.title}>Transform</Text>
         <button
@@ -466,8 +466,8 @@ export default function TransformModal({ isOpen, onClose, onApply, currentAdjust
   };
 
   const renderContent = () => (
-    <div className="flex flex-row h-full w-full overflow-hidden">
-      <div className="grow flex flex-col relative min-h-0 bg-[#0f0f0f] overflow-hidden">
+    <div className="modal-preview-adjustments flex flex-row h-full w-full overflow-hidden">
+      <div className="modal-preview-pane grow flex flex-col relative min-h-0 bg-[#0f0f0f] overflow-hidden">
         <div
           ref={containerRef}
           className="flex-1 relative overflow-hidden cursor-grab active:cursor-grabbing select-none"

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -76,6 +76,7 @@ interface EditorProps {
   canUndo: boolean;
   finalPreviewUrl: string | null;
   interactivePatch?: { url: string; normX: number; normY: number; normW: number; normH: number } | null;
+  isAndroid: boolean;
   isFullScreen: boolean;
   isLoading: boolean;
   isSliderDragging: boolean;
@@ -131,6 +132,7 @@ export default function Editor({
   canUndo,
   finalPreviewUrl,
   interactivePatch,
+  isAndroid,
   isFullScreen,
   isLoading,
   isSliderDragging,
@@ -1782,6 +1784,7 @@ export default function Editor({
         <EditorToolbar
           canRedo={canRedo}
           canUndo={canUndo}
+          isAndroid={isAndroid}
           isLoading={isLoading}
           onBackToLibrary={onBackToLibrary}
           onRedo={onRedo}

--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -2113,20 +2113,24 @@ export default function MainLibrary({
             thumbnailSize={thumbnailSize}
             thumbnailAspectRatio={thumbnailAspectRatio}
           />
-          <Button
-            className="h-12 w-12 bg-surface text-text-primary shadow-none p-0 flex items-center justify-center"
-            onClick={onNavigateToCommunity}
-            data-tooltip="Community Presets"
-          >
-            <Users className="w-8 h-8" />
-          </Button>
-          <Button
-            className="h-12 w-12 bg-surface text-text-primary shadow-none p-0 flex items-center justify-center"
-            onClick={onOpenFolder}
-            data-tooltip="Open another folder"
-          >
-            <Folder className="w-8 h-8" />
-          </Button>
+          {!isAndroid && (
+            <>
+              <Button
+                className="h-12 w-12 bg-surface text-text-primary shadow-none p-0 flex items-center justify-center"
+                onClick={onNavigateToCommunity}
+                data-tooltip="Community Presets"
+              >
+                <Users className="w-8 h-8" />
+              </Button>
+              <Button
+                className="h-12 w-12 bg-surface text-text-primary shadow-none p-0 flex items-center justify-center"
+                onClick={onOpenFolder}
+                data-tooltip="Open another folder"
+              >
+                <Folder className="w-8 h-8" />
+              </Button>
+            </>
+          )}
           <Button
             className="h-12 w-12 bg-surface text-text-primary shadow-none p-0 flex items-center justify-center"
             onClick={onGoHome}

--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -2047,31 +2047,33 @@ export default function MainLibrary({
       >
         <div className="min-w-0">
           <Text variant={TextVariants.headline}>Library</Text>
-          <div className="flex items-center gap-2">
-            {currentFolderPath ? (
-              <Text className="truncate">{currentFolderPath}</Text>
-            ) : (
-              <p className="text-sm invisible select-none pointer-events-none h-5 overflow-hidden"></p>
-            )}
-            <div
-              className={`flex items-center gap-2 overflow-hidden transition-all duration-300 whitespace-nowrap ${
-                isBusyDelayed ? 'max-w-xs opacity-100' : 'max-w-0 opacity-0'
-              }`}
-            >
-              <Loader2 size={14} className="animate-spin text-text-secondary shrink-0" />
+          {!isAndroid && (
+            <div className="flex items-center gap-2">
+              {currentFolderPath ? (
+                <Text className="truncate">{currentFolderPath}</Text>
+              ) : (
+                <p className="text-sm invisible select-none pointer-events-none h-5 overflow-hidden"></p>
+              )}
               <div
-                className={`flex items-center transition-all duration-300 ease-out overflow-hidden ${
-                  isProgressHovered && isBusyDelayed && (thumbnailProgress?.total ?? 0) > 0
-                    ? 'max-w-xs opacity-100'
-                    : 'max-w-0 opacity-0'
+                className={`flex items-center gap-2 overflow-hidden transition-all duration-300 whitespace-nowrap ${
+                  isBusyDelayed ? 'max-w-xs opacity-100' : 'max-w-0 opacity-0'
                 }`}
               >
-                <Text variant={TextVariants.small} color={TextColors.secondary} className="whitespace-nowrap">
-                  ({thumbnailProgress?.current ?? 0}/{thumbnailProgress?.total ?? 0})
-                </Text>
+                <Loader2 size={14} className="animate-spin text-text-secondary shrink-0" />
+                <div
+                  className={`flex items-center transition-all duration-300 ease-out overflow-hidden ${
+                    isProgressHovered && isBusyDelayed && (thumbnailProgress?.total ?? 0) > 0
+                      ? 'max-w-xs opacity-100'
+                      : 'max-w-0 opacity-0'
+                  }`}
+                >
+                  <Text variant={TextVariants.small} color={TextColors.secondary} className="whitespace-nowrap">
+                    ({thumbnailProgress?.current ?? 0}/{thumbnailProgress?.total ?? 0})
+                  </Text>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
         <div className="flex items-center gap-3 shrink-0">
           {importState.status === Status.Importing && (

--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -959,10 +959,10 @@ function ViewOptionsDropdown({
         </>
       }
       buttonTitle="View Options"
-      contentClassName="w-[720px]"
+      contentClassName="library-view-options-menu w-[720px]"
     >
-      <div className="flex">
-        <div className="w-1/4 p-2 border-r border-border-color">
+      <div className="library-view-options-content flex">
+        <div className="library-view-options-section w-1/4 p-2 border-r border-border-color">
           <ThumbnailSizeOptions selectedSize={thumbnailSize} onSelectSize={onSelectSize} />
           <div className="pt-2">
             <ThumbnailAspectRatioOptions
@@ -974,10 +974,10 @@ function ViewOptionsDropdown({
             <ViewModeOptions mode={libraryViewMode} setMode={setLibraryViewMode} />
           </div>
         </div>
-        <div className="w-2/4 p-2 border-r border-border-color">
+        <div className="library-view-options-section w-2/4 p-2 border-r border-border-color">
           <FilterOptions filterCriteria={filterCriteria} setFilterCriteria={setFilterCriteria} />
         </div>
-        <div className="w-1/4 p-2">
+        <div className="library-view-options-section w-1/4 p-2">
           <SortOptions sortCriteria={sortCriteria} setSortCriteria={setSortCriteria} sortOptions={sortOptions} />
         </div>
       </div>

--- a/src/components/panel/editor/EditorToolbar.tsx
+++ b/src/components/panel/editor/EditorToolbar.tsx
@@ -10,6 +10,7 @@ import { TextColors, TextVariants, TextWeights } from '../../../types/typography
 interface EditorToolbarProps {
   canRedo: boolean;
   canUndo: boolean;
+  isAndroid: boolean;
   isLoading: boolean;
   onBackToLibrary(): void;
   onRedo(): void;
@@ -29,6 +30,7 @@ const EditorToolbar = memo(
   ({
     canRedo,
     canUndo,
+    isAndroid,
     isLoading,
     onBackToLibrary,
     onRedo,
@@ -54,7 +56,7 @@ const EditorToolbar = memo(
     const historyContainerRef = useRef<HTMLDivElement>(null);
     const historyButtonRef = useRef<HTMLDivElement>(null);
 
-    const showResolution = selectedImage.width > 0 && selectedImage.height > 0;
+    const showResolution = !isAndroid && selectedImage.width > 0 && selectedImage.height > 0;
     const [displayedResolution, setDisplayedResolution] = useState('');
 
     const { baseName, isVirtualCopy, vcId, exifData, hasExif } = useMemo(() => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -233,6 +233,29 @@
   }
 }
 
+@media (orientation: portrait) {
+  .modal-preview-adjustments {
+    flex-direction: column;
+  }
+
+  .modal-preview-adjustments > .modal-preview-pane {
+    flex: 1 1 58%;
+    width: 100%;
+    min-height: 0;
+  }
+
+  .modal-preview-adjustments > .modal-adjustments-pane {
+    width: 100%;
+    max-width: none;
+    height: auto;
+    flex: 0 1 42%;
+    min-height: 14rem;
+    max-height: 46%;
+    border-left-width: 0;
+    border-top-width: 1px;
+  }
+}
+
 .cg-hue-gradient {
   background: linear-gradient(
     to right,

--- a/src/styles.css
+++ b/src/styles.css
@@ -254,6 +254,31 @@
     border-left-width: 0;
     border-top-width: 1px;
   }
+
+  .library-view-options-menu {
+    position: fixed;
+    top: 5rem;
+    left: 1rem;
+    right: 1rem;
+    width: auto;
+    max-height: calc(100dvh - 6rem);
+    overflow-y: auto;
+    transform-origin: top right;
+  }
+
+  .library-view-options-content {
+    flex-direction: column;
+  }
+
+  .library-view-options-content > .library-view-options-section {
+    width: 100%;
+    border-right-width: 0;
+    border-bottom-width: 1px;
+  }
+
+  .library-view-options-content > .library-view-options-section:last-child {
+    border-bottom-width: 0;
+  }
 }
 
 .cg-hue-gradient {


### PR DESCRIPTION
## Description
Fixes some things for vertical screens and android.

## Type of Change
- [x] UI/UX improvement

## Changes Made
- Adjusted most Modals to work on vertical Screens
- Hide "community preset" and "open another folder" buttons on android in the gallery view
- Remove Library subtitle "Path" on Android an center Library title
- Fixed the sorting dropdown in the Library for vertical screens

## Screenshots/Videos

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/3d8f3750-9587-4883-866d-85309112a34d" height="300" /> | <img src="https://github.com/user-attachments/assets/df6619cc-56da-4227-a3b0-7902de8943bc" height="300" /> |
| <img alt="Screenshot_20260429-161857" src="https://github.com/user-attachments/assets/c4c8ffa2-f5c1-432e-8b65-d59f5b109559" height="300"/> | <img alt="Screenshot_20260429-162103" src="https://github.com/user-attachments/assets/c9609c51-2e97-42a1-8553-54de45e54f48" height="300" /> |
| <img alt="Screenshot_20260429-161926" src="https://github.com/user-attachments/assets/624c074d-d0dc-4fb5-8f77-ab2a010867a8" height="300"/> | <img alt="Screenshot_20260429-162120" src="https://github.com/user-attachments/assets/91560f4b-d2d9-4e49-a553-d0a78f65a924" height="300" /> |
| <img alt="Screenshot_20260429-162001" src="https://github.com/user-attachments/assets/d19da378-5c41-4852-8208-2304b4153327" height="300"/>| <img alt="Screenshot_20260429-162201" src="https://github.com/user-attachments/assets/33fc4ba5-dcfa-4b2c-ab31-5fddc890767b" height="300"/> |

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)