### PR TITLE
Add rounded macOS Tauri window corners

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "ndarray",
  "ndk-context",
  "num_cpus",
+ "objc",
  "once_cell",
  "ort",
  "os_info",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -75,6 +75,9 @@ trash = "5.2.5"
 tauri-plugin-single-instance = "2.4.0"
 reqwest = { version = "0.13", default-features = false, features = ["json", "multipart", "rustls"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2"
+
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-context = "0.1"
 jni = "0.21"

--- a/src-tauri/src/window_customizer.rs
+++ b/src-tauri/src/window_customizer.rs
@@ -2,6 +2,45 @@ use tauri::{Runtime, Webview, plugin::Plugin};
 
 pub struct PinchZoomDisablePlugin;
 
+#[cfg(target_os = "macos")]
+const MACOS_WINDOW_RADIUS: f64 = 14.0;
+
+#[cfg(target_os = "macos")]
+unsafe fn apply_macos_window_rounding(ns_view: *mut objc::runtime::Object) {
+    use objc::{msg_send, sel, sel_impl};
+
+    if ns_view.is_null() {
+        return;
+    }
+
+    let ns_window: *mut objc::runtime::Object = msg_send![ns_view, window];
+    if ns_window.is_null() {
+        return;
+    }
+
+    let () = msg_send![ns_window, setOpaque: false];
+    let () = msg_send![ns_window, setHasShadow: true];
+
+    let content_view: *mut objc::runtime::Object = msg_send![ns_window, contentView];
+    if !content_view.is_null() {
+        let () = msg_send![content_view, setWantsLayer: true];
+        let content_layer: *mut objc::runtime::Object = msg_send![content_view, layer];
+        if !content_layer.is_null() {
+            let () = msg_send![content_layer, setCornerRadius: MACOS_WINDOW_RADIUS];
+            let () = msg_send![content_layer, setMasksToBounds: true];
+        }
+    }
+
+    let () = msg_send![ns_view, setWantsLayer: true];
+    let webview_layer: *mut objc::runtime::Object = msg_send![ns_view, layer];
+    if !webview_layer.is_null() {
+        let () = msg_send![webview_layer, setCornerRadius: MACOS_WINDOW_RADIUS];
+        let () = msg_send![webview_layer, setMasksToBounds: true];
+    }
+
+    let () = msg_send![ns_window, invalidateShadow];
+}
+
 impl Default for PinchZoomDisablePlugin {
     fn default() -> Self {
         Self
@@ -15,6 +54,11 @@ impl<R: Runtime> Plugin<R> for PinchZoomDisablePlugin {
 
     fn webview_created(&mut self, webview: Webview<R>) {
         let _ = webview.with_webview(|_webview| {
+            #[cfg(target_os = "macos")]
+            unsafe {
+                apply_macos_window_rounding(_webview.inner().cast());
+            }
+
             #[cfg(target_os = "linux")]
             unsafe {
                 use gtk::GestureZoom;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5609,6 +5609,8 @@ function App() {
 
   const shouldHideFolderTree = isAndroid;
   const isWgpuActive = appSettings?.useWgpuRenderer !== false && selectedImage?.isReady && hasRenderedFirstFrame;
+  const useMacWindowShell =
+    osPlatform === 'macos' && !appSettings?.decorations && !isWindowFullScreen && !isFullScreen;
 
   useEffect(() => {
     if (selectedImage?.path && selectedImage.isReady && (finalPreviewUrl || isWgpuActive)) {
@@ -5641,6 +5643,7 @@ function App() {
     <div
       className={clsx(
         'flex flex-col h-screen font-sans text-text-primary overflow-hidden select-none',
+        useMacWindowShell && 'macos-window-shell',
         isWgpuActive ? 'bg-transparent' : 'bg-bg-primary',
       )}
     >

--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,13 @@
   html {
     background-color: transparent;
   }
+
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+
   body {
     background-color: transparent;
     @apply text-text-primary font-sans;
@@ -118,6 +125,11 @@
   }
   ::-webkit-scrollbar-thumb:hover {
     background-color: theme('colors.hover-color');
+  }
+
+  .macos-window-shell {
+    border-radius: 14px;
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
## Description
Fix the macOS frameless window so it uses rounded corners like native Mac apps instead of rendering as a square transparent window. The change applies macOS-native window/webview layer corner rounding and adds a matching renderer-side clip to keep the UI content aligned with the window shape.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [x] Build/CI or Dependency update

## Changes Made
- Add macOS-only native window rounding in [window_customizer.rs](/Users/camerongustavson/CodeProjects/RapidRaw/src-tauri/src/window_customizer.rs:1)
- Apply corner radius and masking to the `NSWindow` content view and webview layer for frameless transparent windows
- Add a macOS-only renderer shell class in [App.tsx](/Users/camerongustavson/CodeProjects/RapidRaw/src/App.tsx:5609) and [styles.css](/Users/camerongustavson/CodeProjects/RapidRaw/src/styles.css:86) so web content does not bleed into square bounds
- Add the macOS `objc` dependency in [Cargo.toml](/Users/camerongustavson/CodeProjects/RapidRaw/src-tauri/Cargo.toml:78) to support the AppKit calls

## Screenshots/Videos
After
<img width="554" height="324" alt="image" src="https://github.com/user-attachments/assets/2bc3c8f0-fc4e-4eb0-81bc-8d2f0ec84f69" />
Before
<img width="538" height="326" alt="image" src="https://github.com/user-attachments/assets/e2d2247b-eddc-4477-822b-963632e5cb47" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** macOS
- **Hardware:** Apple Silicon Mac

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
This only affects macOS. The native AppKit layer rounding is the actual fix; the renderer-side clipping is there to keep the web content visually consistent with the native window shape for transparent/custom-decorated rendering.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)