### PR TITLE
feat: Add parametric curve improvements

### DIFF
--- a/src-tauri/src/shaders/shader.wgsl
+++ b/src-tauri/src/shaders/shader.wgsl
@@ -1020,16 +1020,24 @@ fn no_tonemap(c: vec3<f32>) -> vec3<f32> {
 }
 
 fn is_default_curve(points: array<Point, 16>, count: u32) -> bool {
-    if (count != 2u) {
+    if (count < 2u) {
         return false;
     }
+    
+    var is_identity = true;
+    for (var i = 0u; i < count; i = i + 1u) {
+        if (abs(points[i].x - points[i].y) > 0.5) {
+            is_identity = false;
+            break;
+        }
+    }
+    
     let p0 = points[0];
-    let p1 = points[1];
-
+    let p_last = points[count - 1u];
     let p0_is_origin = abs(p0.x - 0.0) < 0.1 && abs(p0.y - 0.0) < 0.1;
-    let p1_is_end = abs(p1.x - 255.0) < 0.1 && abs(p1.y - 255.0) < 0.1;
-
-    return p0_is_origin && p1_is_end;
+    let p_last_is_end = abs(p_last.x - 255.0) < 0.1 && abs(p_last.y - 255.0) < 0.1;
+    
+    return is_identity && p0_is_origin && p_last_is_end;
 }
 
 fn apply_all_curves(color: vec3<f32>, luma_curve: array<Point, 16>, luma_curve_count: u32, red_curve: array<Point, 16>, red_curve_count: u32, green_curve: array<Point, 16>, green_curve_count: u32, blue_curve: array<Point, 16>, blue_curve_count: u32) -> vec3<f32> {

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -41,6 +41,8 @@ const DEFAULT_PARAMETRIC_CURVE_SETTINGS: ParametricCurveSettings = {
   split1: 25,
   split2: 50,
   split3: 75,
+  whiteLevel: 0,
+  blackLevel: 0,
 };
 
 const DEFAULT_PARAMETRIC_CURVE = {
@@ -69,11 +71,29 @@ const DEFAULT_POINT_CURVES = {
   ],
 };
 
+function getSplitterGradient(channel: ActiveChannel) {
+  switch(channel) {
+    case ActiveChannel.Luma:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)';
+    case ActiveChannel.Red:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 0, 0, 0.8) 25%, rgba(105, 50, 50, 0.8) 50%, rgba(158, 100, 100, 0.8) 75%, rgba(255, 107, 107, 0.8) 100%)';
+    case ActiveChannel.Green:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(0, 64, 0, 0.8) 25%, rgba(50, 105, 50, 0.8) 50%, rgba(100, 158, 100, 0.8) 75%, rgba(107, 203, 119, 0.8) 100%)';
+    case ActiveChannel.Blue:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 64, 0.8) 25%, rgba(50, 50, 105, 0.8) 50%, rgba(100, 100, 158, 0.8) 75%, rgba(77, 150, 255, 0.8) 100%)';
+    default:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)';
+  }
+}
+
 function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> {
   const vH = settings.highlights / 100;
   const vL = settings.lights / 100;
   const vD = settings.darks / 100;
   const vS = settings.shadows / 100;
+
+  const whiteYOffset = settings.whiteLevel;
+  const blackYOffset = settings.blackLevel;
 
   const s1 = settings.split1 / 100;
   const s2 = settings.split2 / 100;
@@ -105,10 +125,19 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
 
   const clamp = (v: number) => Math.max(0, Math.min(1, v));
 
-  return xs.map((x, i) => ({
+  let points = xs.map((x, i) => ({
     x: x * 255,
     y: clamp(ys[i]) * 255,
   }));
+
+  if (points.length >= 2) {
+    points[0].y = Math.max(0, Math.min(255, points[0].y + whiteYOffset));
+
+    const lastIndex = points.length - 1;
+    points[lastIndex].y = Math.max(0, Math.min(255, points[lastIndex].y + blackYOffset));
+  }
+  
+  return points;
 }
 
 function getCurvePath(points: Array<Coord>) {
@@ -222,7 +251,9 @@ function isDefaultParametricCurve(settings: ParametricCurveSettings | undefined)
     settings.highlights === DEFAULT_PARAMETRIC_CURVE_SETTINGS.highlights &&
     settings.split1 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split1 &&
     settings.split2 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split2 &&
-    settings.split3 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split3
+    settings.split3 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split3 &&
+    settings.whiteLevel === DEFAULT_PARAMETRIC_CURVE_SETTINGS.whiteLevel &&
+    settings.blackLevel === DEFAULT_PARAMETRIC_CURVE_SETTINGS.blackLevel
   );
 }
 
@@ -312,6 +343,11 @@ export default function CurveGraph({
       };
     });
   };
+
+const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
+  const value = parseFloat(e.target.value);
+  updateParametricValue(key, value);
+};
 
   useEffect(() => {
     activeChannelRef.current = activeChannel;
@@ -812,6 +848,27 @@ export default function CurveGraph({
 
             <path d={getCurvePath(activePoints)} fill="none" stroke={color} strokeWidth="2.5" />
 
+            {isParametricMode && activePoints.length >= 2 && (
+              <>
+                <circle
+                  cx={activePoints[0]?.x || 0}
+                  cy={255 - (activePoints[0]?.y || 0)}
+                  fill={color}
+                  r="6"
+                  stroke="#1e1e1e"
+                  strokeWidth="2"
+                />
+                <circle
+                  cx={activePoints[activePoints.length - 1]?.x || 255}
+                  cy={255 - (activePoints[activePoints.length - 1]?.y || 255)}
+                  fill={color}
+                  r="6"
+                  stroke="#1e1e1e"
+                  strokeWidth="2"
+                />
+              </>
+            )}
+
             {!isParametricMode &&
               activePoints.map((p: Coord, i: number) => (
                 <circle
@@ -848,7 +905,7 @@ export default function CurveGraph({
                     <div
                       className="absolute inset-0"
                       style={{
-                        background: `linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)`,
+                        background: getSplitterGradient(activeChannel),
                       }}
                     />
                     {splitPositions.map(({ key, value }) => (
@@ -885,13 +942,23 @@ export default function CurveGraph({
 
               <div className="flex flex-col gap-2">
                 <Slider
+                  label="White Level"
+                  min={0}
+                  max={100}
+                  step={1}
+                  defaultValue={0}
+                  value={activeParametricSettings.whiteLevel}
+                  onChange={(e: any) => handleSliderChange('whiteLevel', e)}
+                  onDragStateChange={onDragStateChange}
+                />
+                <Slider
                   label="Highlights"
                   min={-100}
                   max={100}
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.highlights}
-                  onChange={(e: any) => updateParametricValue('highlights', parseFloat(e.target.value))}
+                  onChange={(e: any) => handleSliderChange('highlights', e)}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -901,7 +968,7 @@ export default function CurveGraph({
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.lights}
-                  onChange={(e: any) => updateParametricValue('lights', parseFloat(e.target.value))}
+                  onChange={(e: any) => handleSliderChange('lights', e)}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -911,7 +978,7 @@ export default function CurveGraph({
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.darks}
-                  onChange={(e: any) => updateParametricValue('darks', parseFloat(e.target.value))}
+                  onChange={(e: any) => handleSliderChange('darks', e)}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -921,7 +988,17 @@ export default function CurveGraph({
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.shadows}
-                  onChange={(e: any) => updateParametricValue('shadows', parseFloat(e.target.value))}
+                  onChange={(e: any) => handleSliderChange('shadows', e)}
+                  onDragStateChange={onDragStateChange}
+                />
+                <Slider
+                  label="Black Level"
+                  min={-100}
+                  max={0}
+                  step={1}
+                  defaultValue={0}
+                  value={activeParametricSettings.blackLevel}
+                  onChange={(e: any) => handleSliderChange('blackLevel', e)}
                   onDragStateChange={onDragStateChange}
                 />
               </div>

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -484,6 +484,16 @@ export default function CurveGraph({
     ? buildParametricPoints(activeParametricSettings)
     : (localPoints ?? adjustments?.curves?.[activeChannel]);
 
+  useEffect(() => {
+    if (adjustments?.curves?.[activeChannel]) {
+      console.log(`[${curveMode.toUpperCase()}] ${activeChannel} curve points:`, 
+        adjustments.curves[activeChannel].map((p: Coord) => `(${p.x.toFixed(1)}, ${p.y.toFixed(1)})`).join(', '),
+        `count: ${adjustments.curves[activeChannel].length}`
+      );
+      console.log(`[${curveMode.toUpperCase()}] ALL counts - luma:${adjustments.curves?.luma?.length}, red:${adjustments.curves?.red?.length}, green:${adjustments.curves?.green?.length}, blue:${adjustments.curves?.blue?.length}`);
+    }
+  }, [adjustments?.curves?.[activeChannel], curveMode, activeChannel]);
+
   const { color, data: histogramData } = channelConfig[activeChannel];
 
   if (!activePoints) {
@@ -679,6 +689,11 @@ export default function CurveGraph({
     const handlePasteFromParametric = () => {
       if (!parametricClipboard) return;
       const newPoints = convertParametricToPoints(parametricClipboard);
+      console.log('Pasting from parametric:', 
+        newPoints.map((p: Coord) => `(${p.x.toFixed(1)}, ${p.y.toFixed(1)})`).join(', '),
+        `count: ${newPoints.length}`
+      );
+      console.log('Parametric clipboard settings:', parametricClipboard);
       setLocalPoints(newPoints);
       localPointsRef.current = newPoints;
       setAdjustments((prev: any) => ({ ...prev, curves: { ...prev.curves, [activeChannel]: newPoints } }));

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -92,8 +92,8 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
   const vD = settings.darks / 100;
   const vS = settings.shadows / 100;
 
-  const whiteYOffset = settings.whiteLevel;
   const blackYOffset = settings.blackLevel;
+  const whiteYOffset = settings.whiteLevel;
 
   const s1 = settings.split1 / 100;
   const s2 = settings.split2 / 100;
@@ -131,10 +131,10 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
   }));
 
   if (points.length >= 2) {
-    points[0].y = Math.max(0, Math.min(255, points[0].y + whiteYOffset));
+    points[0].y = Math.max(0, Math.min(255, points[0].y + blackYOffset));
 
     const lastIndex = points.length - 1;
-    points[lastIndex].y = Math.max(0, Math.min(255, points[lastIndex].y + blackYOffset));
+    points[lastIndex].y = Math.max(0, Math.min(255, points[lastIndex].y + whiteYOffset));
   }
   
   return points;
@@ -938,8 +938,8 @@ export default function CurveGraph({
               <div className="flex flex-col gap-2">
                 <Slider
                   label="White Level"
-                  min={0}
-                  max={100}
+                  min={-100}
+                  max={0}
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.whiteLevel}
@@ -988,8 +988,8 @@ export default function CurveGraph({
                 />
                 <Slider
                   label="Black Level"
-                  min={-100}
-                  max={0}
+                  min={0}
+                  max={100}
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.blackLevel}

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -92,9 +92,6 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
   const vD = settings.darks / 100;
   const vS = settings.shadows / 100;
 
-  const blackYOffset = settings.blackLevel;
-  const whiteYOffset = settings.whiteLevel;
-
   const s1 = settings.split1 / 100;
   const s2 = settings.split2 / 100;
   const s3 = settings.split3 / 100;
@@ -130,11 +127,20 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
     y: clamp(ys[i]) * 255,
   }));
 
-  if (points.length >= 2) {
-    points[0].y = Math.max(0, Math.min(255, points[0].y + blackYOffset));
+  const blackFactor = settings.blackLevel / 100;
+  if (blackFactor > 0) {
+    points = points.map(point => ({
+      x: point.x,
+      y: Math.max(0, Math.min(255, point.y + (255 - point.y) * blackFactor * 0.39))
+    }));
+  }
 
-    const lastIndex = points.length - 1;
-    points[lastIndex].y = Math.max(0, Math.min(255, points[lastIndex].y + whiteYOffset));
+  const whiteFactor = Math.abs(settings.whiteLevel) / 100;
+  if (whiteFactor > 0) {
+    points = points.map(point => ({
+      x: point.x,
+      y: Math.max(0, Math.min(255, point.y * (1 - whiteFactor * 0.39)))
+    }));
   }
   
   return points;

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -92,6 +92,9 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
   const vD = settings.darks / 100;
   const vS = settings.shadows / 100;
 
+  const blackYOffset = settings.blackLevel;
+  const whiteYOffset = settings.whiteLevel;
+
   const s1 = settings.split1 / 100;
   const s2 = settings.split2 / 100;
   const s3 = settings.split3 / 100;
@@ -127,20 +130,11 @@ function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> 
     y: clamp(ys[i]) * 255,
   }));
 
-  const blackFactor = settings.blackLevel / 100;
-  if (blackFactor > 0) {
-    points = points.map(point => ({
-      x: point.x,
-      y: Math.max(0, Math.min(255, point.y + (255 - point.y) * blackFactor * 0.39))
-    }));
-  }
+  if (points.length >= 2) {
+    points[0].y = Math.max(0, Math.min(255, points[0].y + blackYOffset));
 
-  const whiteFactor = Math.abs(settings.whiteLevel) / 100;
-  if (whiteFactor > 0) {
-    points = points.map(point => ({
-      x: point.x,
-      y: Math.max(0, Math.min(255, point.y * (1 - whiteFactor * 0.39)))
-    }));
+    const lastIndex = points.length - 1;
+    points[lastIndex].y = Math.max(0, Math.min(255, points[lastIndex].y + whiteYOffset));
   }
   
   return points;
@@ -348,6 +342,19 @@ export default function CurveGraph({
         },
       };
     });
+  };
+
+  const pasteParametricToPointCurve = () => {
+    if (!parametricClipboard) return;
+
+    const convertedPoints = buildParametricPoints(parametricClipboard);
+    
+    setLocalPoints(convertedPoints);
+    localPointsRef.current = convertedPoints;
+    setAdjustments((prev: any) => ({
+      ...prev,
+      curves: { ...prev.curves, [activeChannel]: convertedPoints },
+    }));
   };
 
   useEffect(() => {
@@ -720,6 +727,12 @@ export default function CurveGraph({
         icon: ClipboardPaste,
         onClick: handlePaste,
         disabled: !curveClipboard,
+      },
+      {
+        label: `Paste from Parametric Curve`,
+        icon: Settings2,
+        onClick: pasteParametricToPointCurve,
+        disabled: !parametricClipboard,
       },
       { type: OPTION_SEPARATOR },
       { label: `Reset ${channelName} Point Curve`, icon: RotateCcw, onClick: handleReset },

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -344,11 +344,6 @@ export default function CurveGraph({
     });
   };
 
-const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
-  const value = parseFloat(e.target.value);
-  updateParametricValue(key, value);
-};
-
   useEffect(() => {
     activeChannelRef.current = activeChannel;
     setLocalPoints(null);
@@ -948,7 +943,7 @@ const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.whiteLevel}
-                  onChange={(e: any) => handleSliderChange('whiteLevel', e)}
+                  onChange={(e: any) => updateParametricValue('whiteLevel', parseFloat(e.target.value))}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -958,7 +953,7 @@ const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.highlights}
-                  onChange={(e: any) => handleSliderChange('highlights', e)}
+                  onChange={(e: any) => updateParametricValue('highlights', parseFloat(e.target.value))}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -968,7 +963,7 @@ const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.lights}
-                  onChange={(e: any) => handleSliderChange('lights', e)}
+                  onChange={(e: any) => updateParametricValue('lights', parseFloat(e.target.value))}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -978,7 +973,7 @@ const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.darks}
-                  onChange={(e: any) => handleSliderChange('darks', e)}
+                  onChange={(e: any) => updateParametricValue('darks', parseFloat(e.target.value))}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -988,7 +983,7 @@ const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.shadows}
-                  onChange={(e: any) => handleSliderChange('shadows', e)}
+                  onChange={(e: any) => updateParametricValue('shadows', parseFloat(e.target.value))}
                   onDragStateChange={onDragStateChange}
                 />
                 <Slider
@@ -998,7 +993,7 @@ const handleSliderChange = (key: keyof ParametricCurveSettings, e: any) => {
                   step={1}
                   defaultValue={0}
                   value={activeParametricSettings.blackLevel}
-                  onChange={(e: any) => handleSliderChange('blackLevel', e)}
+                  onChange={(e: any) => updateParametricValue('blackLevel', parseFloat(e.target.value))}
                   onDragStateChange={onDragStateChange}
                 />
               </div>

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -484,16 +484,6 @@ export default function CurveGraph({
     ? buildParametricPoints(activeParametricSettings)
     : (localPoints ?? adjustments?.curves?.[activeChannel]);
 
-  useEffect(() => {
-    if (adjustments?.curves?.[activeChannel]) {
-      console.log(`[${curveMode.toUpperCase()}] ${activeChannel} curve points:`, 
-        adjustments.curves[activeChannel].map((p: Coord) => `(${p.x.toFixed(1)}, ${p.y.toFixed(1)})`).join(', '),
-        `count: ${adjustments.curves[activeChannel].length}`
-      );
-      console.log(`[${curveMode.toUpperCase()}] ALL counts - luma:${adjustments.curves?.luma?.length}, red:${adjustments.curves?.red?.length}, green:${adjustments.curves?.green?.length}, blue:${adjustments.curves?.blue?.length}`);
-    }
-  }, [adjustments?.curves?.[activeChannel], curveMode, activeChannel]);
-
   const { color, data: histogramData } = channelConfig[activeChannel];
 
   if (!activePoints) {
@@ -689,11 +679,6 @@ export default function CurveGraph({
     const handlePasteFromParametric = () => {
       if (!parametricClipboard) return;
       const newPoints = convertParametricToPoints(parametricClipboard);
-      console.log('Pasting from parametric:', 
-        newPoints.map((p: Coord) => `(${p.x.toFixed(1)}, ${p.y.toFixed(1)})`).join(', '),
-        `count: ${newPoints.length}`
-      );
-      console.log('Parametric clipboard settings:', parametricClipboard);
       setLocalPoints(newPoints);
       localPointsRef.current = newPoints;
       setAdjustments((prev: any) => ({ ...prev, curves: { ...prev.curves, [activeChannel]: newPoints } }));

--- a/src/components/adjustments/Curves.tsx
+++ b/src/components/adjustments/Curves.tsx
@@ -38,11 +38,11 @@ const DEFAULT_PARAMETRIC_CURVE_SETTINGS: ParametricCurveSettings = {
   shadows: 0,
   highlights: 0,
   lights: 0,
+  whiteLevel: 0,
+  blackLevel: 0,
   split1: 25,
   split2: 50,
   split3: 75,
-  whiteLevel: 0,
-  blackLevel: 0,
 };
 
 const DEFAULT_PARAMETRIC_CURVE = {
@@ -70,21 +70,6 @@ const DEFAULT_POINT_CURVES = {
     { x: 255, y: 255 },
   ],
 };
-
-function getSplitterGradient(channel: ActiveChannel) {
-  switch(channel) {
-    case ActiveChannel.Luma:
-      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)';
-    case ActiveChannel.Red:
-      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 0, 0, 0.8) 25%, rgba(105, 50, 50, 0.8) 50%, rgba(158, 100, 100, 0.8) 75%, rgba(255, 107, 107, 0.8) 100%)';
-    case ActiveChannel.Green:
-      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(0, 64, 0, 0.8) 25%, rgba(50, 105, 50, 0.8) 50%, rgba(100, 158, 100, 0.8) 75%, rgba(107, 203, 119, 0.8) 100%)';
-    case ActiveChannel.Blue:
-      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 64, 0.8) 25%, rgba(50, 50, 105, 0.8) 50%, rgba(100, 100, 158, 0.8) 75%, rgba(77, 150, 255, 0.8) 100%)';
-    default:
-      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)';
-  }
-}
 
 function buildParametricPoints(settings: ParametricCurveSettings): Array<Coord> {
   const vH = settings.highlights / 100;
@@ -249,12 +234,31 @@ function isDefaultParametricCurve(settings: ParametricCurveSettings | undefined)
     settings.shadows === DEFAULT_PARAMETRIC_CURVE_SETTINGS.shadows &&
     settings.lights === DEFAULT_PARAMETRIC_CURVE_SETTINGS.lights &&
     settings.highlights === DEFAULT_PARAMETRIC_CURVE_SETTINGS.highlights &&
+    settings.whiteLevel === DEFAULT_PARAMETRIC_CURVE_SETTINGS.whiteLevel &&
+    settings.blackLevel === DEFAULT_PARAMETRIC_CURVE_SETTINGS.blackLevel &&
     settings.split1 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split1 &&
     settings.split2 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split2 &&
-    settings.split3 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split3 &&
-    settings.whiteLevel === DEFAULT_PARAMETRIC_CURVE_SETTINGS.whiteLevel &&
-    settings.blackLevel === DEFAULT_PARAMETRIC_CURVE_SETTINGS.blackLevel
+    settings.split3 === DEFAULT_PARAMETRIC_CURVE_SETTINGS.split3
   );
+}
+
+function getSplitterGradient(channel: ActiveChannel) {
+  switch(channel) {
+    case ActiveChannel.Luma:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)';
+    case ActiveChannel.Red:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 0, 0, 0.8) 25%, rgba(105, 50, 50, 0.8) 50%, rgba(158, 100, 100, 0.8) 75%, rgba(255, 107, 107, 0.8) 100%)';
+    case ActiveChannel.Green:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(0, 64, 0, 0.8) 25%, rgba(50, 105, 50, 0.8) 50%, rgba(100, 158, 100, 0.8) 75%, rgba(107, 203, 119, 0.8) 100%)';
+    case ActiveChannel.Blue:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 64, 0.8) 25%, rgba(50, 50, 105, 0.8) 50%, rgba(100, 100, 158, 0.8) 75%, rgba(77, 150, 255, 0.8) 100%)';
+    default:
+      return 'linear-gradient(to right, rgba(0, 0, 0, 0.8) 0%, rgba(64, 64, 64, 0.8) 25%, rgba(105, 101, 101, 0.8) 50%, rgba(158, 154, 154, 0.8) 75%, rgba(198, 195, 197, 0.8) 100%)';
+  }
+}
+
+function convertParametricToPoints(settings: ParametricCurveSettings): Array<Coord> {
+  return buildParametricPoints(settings);
 }
 
 export default function CurveGraph({
@@ -342,19 +346,6 @@ export default function CurveGraph({
         },
       };
     });
-  };
-
-  const pasteParametricToPointCurve = () => {
-    if (!parametricClipboard) return;
-
-    const convertedPoints = buildParametricPoints(parametricClipboard);
-    
-    setLocalPoints(convertedPoints);
-    localPointsRef.current = convertedPoints;
-    setAdjustments((prev: any) => ({
-      ...prev,
-      curves: { ...prev.curves, [activeChannel]: convertedPoints },
-    }));
   };
 
   useEffect(() => {
@@ -685,6 +676,14 @@ export default function CurveGraph({
       setAdjustments((prev: any) => ({ ...prev, curves: { ...prev.curves, [activeChannel]: newPoints } }));
     };
 
+    const handlePasteFromParametric = () => {
+      if (!parametricClipboard) return;
+      const newPoints = convertParametricToPoints(parametricClipboard);
+      setLocalPoints(newPoints);
+      localPointsRef.current = newPoints;
+      setAdjustments((prev: any) => ({ ...prev, curves: { ...prev.curves, [activeChannel]: newPoints } }));
+    };
+
     const handleReset = () => {
       const defaultPoints = [
         { x: 0, y: 0 },
@@ -729,9 +728,9 @@ export default function CurveGraph({
         disabled: !curveClipboard,
       },
       {
-        label: `Paste from Parametric Curve`,
-        icon: Settings2,
-        onClick: pasteParametricToPointCurve,
+        label: 'Paste from Parametric Curve',
+        icon: ClipboardPaste,
+        onClick: handlePasteFromParametric,
         disabled: !parametricClipboard,
       },
       { type: OPTION_SEPARATOR },

--- a/src/utils/adjustments.tsx
+++ b/src/utils/adjustments.tsx
@@ -132,6 +132,8 @@ export interface ParametricCurveSettings {
   split1: number;
   split2: number;
   split3: number;
+  whiteLevel: number;
+  blackLevel: number
 }
 
 export interface ParametricCurve {
@@ -378,6 +380,8 @@ export const DEFAULT_PARAMETRIC_CURVE_SETTINGS: ParametricCurveSettings = {
   split1: 25,
   split2: 50,
   split3: 75,
+  whiteLevel: 0,
+  blackLevel: 0,
 };
 
 export const getDefaultParametricCurve = (): ParametricCurve => ({

--- a/src/utils/adjustments.tsx
+++ b/src/utils/adjustments.tsx
@@ -129,11 +129,11 @@ export interface ParametricCurveSettings {
   shadows: number;
   highlights: number;
   lights: number;
+  whiteLevel: number;
+  blackLevel: number;
   split1: number;
   split2: number;
   split3: number;
-  whiteLevel: number;
-  blackLevel: number
 }
 
 export interface ParametricCurve {
@@ -377,11 +377,11 @@ export const DEFAULT_PARAMETRIC_CURVE_SETTINGS: ParametricCurveSettings = {
   shadows: 0,
   highlights: 0,
   lights: 0,
+  whiteLevel: 0,
+  blackLevel: 0,
   split1: 25,
   split2: 50,
   split3: 75,
-  whiteLevel: 0,
-  blackLevel: 0,
 };
 
 export const getDefaultParametricCurve = (): ParametricCurve => ({


### PR DESCRIPTION
## Description
Adds White Level and Black Level controls to parametric curve mode, enabling filmic rolloff and endpoint adjustments. Also adds channel-specific gradients to the splitter visualization and endpoint circles on the curve graph for better visual feedback.

This PR addresses the user feedback from issue #951: https://github.com/CyberTimon/RapidRAW/issues/951#issuecomment-4343521650

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Added White Level slider (-100 to 0) to control the Y-axis of the 255,255 point
- Added Black Level slider (0 to 100) to control the Y-axis of the 0,0 point
- Added channel-specific gradient colors to the splitter area (RGB channels now show red/green/blue gradients instead of grayscale)
- Added non-draggable endpoint circles at (0,0) and (255,255) in parametric mode for visual reference
- Updated `ParametricCurveSettings` interface with whiteLevel and blackLevel properties
- Updated default values to 0 for both new controls

## Screenshots/Videos
_No Screenshots/Videos_

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 10
- **Hardware:** Intel i5

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
_No Additional Notes_

## AI Disclaimer:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)