### PR TITLE
Fix: clippy action warning

### DIFF
--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -1730,9 +1730,9 @@ pub fn apply_cpu_agx_tonemap(image: &mut DynamicImage) {
 
     const LUT_SIZE: usize = 4096;
     let mut curve_lut = [0.0f32; LUT_SIZE];
-    for i in 0..LUT_SIZE {
+    for (i, slot) in curve_lut.iter_mut().enumerate() {
         let x = i as f32 / (LUT_SIZE - 1) as f32;
-        curve_lut[i] = agx_curve_channel(x).max(0.0).powf(AGX_GAMMA);
+        *slot = agx_curve_channel(x).max(0.0).powf(AGX_GAMMA);
     }
 
     let (pipe_to_rendering, rendering_to_pipe) = calculate_agx_matrices_glam();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1955,6 +1955,7 @@ fn apply_export_resize_and_watermark(
     Ok(image)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_image_for_export_pipeline(
     path: &str,
     base_image: &DynamicImage,
@@ -2079,6 +2080,7 @@ fn mime_type_for_extension(extension: &str) -> &'static str {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn process_image_for_export(
     path: &str,
     base_image: &DynamicImage,


### PR DESCRIPTION
CI's cargo clippy --all-targets --all-features -- -D warnings currently fails on main, blocking every open PR. 

image_processing.rs:1733 — needless_range_loop in the AgX tonemap LUT init
lib.rs:1958 — too_many_arguments (8/7) on process_image_for_export_pipeline after app_handle
lib.rs:2084 — same on process_image_for_export

Changes:
Switched the LUT loop to iter_mut().enumerate()
Added #[allow(clippy::too_many_arguments)] on both export functions, matching the existing pattern used elsewhere in lib.rs
No behavior chang