### PR TITLE
Android Defaults, Auto scaling UI

### DIFF
--- a/src-tauri/gen/android/app/src/main/java/io/github/CyberTimon/RapidRAW/MainActivity.kt
+++ b/src-tauri/gen/android/app/src/main/java/io/github/CyberTimon/RapidRAW/MainActivity.kt
@@ -4,12 +4,15 @@ import android.graphics.Color
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 
 class MainActivity : TauriActivity() {
   private val safeMarginBackgroundColor = Color.rgb(24, 24, 24)
+  private var webView: WebView? = null
+  private var backCallback: OnBackPressedCallback? = null
 
   override fun onCreate(savedInstanceState: Bundle?) {
     enableEdgeToEdge()
@@ -43,7 +46,60 @@ class MainActivity : TauriActivity() {
   override fun onWebViewCreate(webView: WebView) {
     super.onWebViewCreate(webView)
 
+    this.webView = webView
     webView.setBackgroundColor(safeMarginBackgroundColor)
     webView.fitsSystemWindows = true
+
+    if (backCallback == null) {
+      val callback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+          dispatchBackToWebView(this)
+        }
+      }
+
+      backCallback = callback
+      onBackPressedDispatcher.addCallback(this, callback)
+    }
+  }
+
+  private fun dispatchBackToWebView(callback: OnBackPressedCallback) {
+    val currentWebView = webView
+    if (currentWebView == null) {
+      continueDefaultBack(callback)
+      return
+    }
+
+    currentWebView.evaluateJavascript(ANDROID_BACK_EVENT_SCRIPT) { result ->
+      if (result != "true") {
+        if (currentWebView.canGoBack()) {
+          currentWebView.goBack()
+        } else {
+          continueDefaultBack(callback)
+        }
+      }
+    }
+  }
+
+  private fun continueDefaultBack(callback: OnBackPressedCallback) {
+    callback.isEnabled = false
+    try {
+      onBackPressedDispatcher.onBackPressed()
+    } finally {
+      callback.isEnabled = true
+    }
+  }
+
+  companion object {
+    private const val ANDROID_BACK_EVENT_SCRIPT = """
+      (function () {
+        try {
+          var event = new CustomEvent('rapidraw:android-back', { cancelable: true });
+          window.dispatchEvent(event);
+          return event.defaultPrevented === true;
+        } catch (error) {
+          return false;
+        }
+      })();
+    """
   }
 }

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -46,6 +46,16 @@ use crate::mask_generation::MaskDefinition;
 use crate::preset_converter;
 use crate::tagging::COLOR_TAG_PREFIX;
 
+#[cfg(target_os = "android")]
+pub const DEFAULT_THUMBNAIL_WORKER_THREADS: u32 = 2;
+#[cfg(not(target_os = "android"))]
+pub const DEFAULT_THUMBNAIL_WORKER_THREADS: u32 = 4;
+
+#[cfg(target_os = "android")]
+pub const DEFAULT_IMAGE_CACHE_SIZE: u32 = 2;
+#[cfg(not(target_os = "android"))]
+pub const DEFAULT_IMAGE_CACHE_SIZE: u32 = 5;
+
 fn resolve_thumbnail_cache_dir(app_handle: &AppHandle) -> std::result::Result<PathBuf, String> {
     let cache_dir = app_handle
         .path()
@@ -379,6 +389,14 @@ fn default_tagging_shortcuts_option() -> Option<Vec<String>> {
     ])
 }
 
+fn default_thumbnail_worker_threads() -> Option<u32> {
+    Some(DEFAULT_THUMBNAIL_WORKER_THREADS)
+}
+
+fn default_image_cache_size() -> Option<u32> {
+    Some(DEFAULT_IMAGE_CACHE_SIZE)
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
@@ -460,9 +478,9 @@ pub struct AppSettings {
     pub zoom_speed_multiplier: Option<f32>,
     #[serde(default)]
     pub keybinds: HashMap<String, Vec<String>>,
-    #[serde(default)]
+    #[serde(default = "default_thumbnail_worker_threads")]
     pub thumbnail_worker_threads: Option<u32>,
-    #[serde(default)]
+    #[serde(default = "default_image_cache_size")]
     pub image_cache_size: Option<u32>,
 }
 
@@ -539,8 +557,8 @@ impl Default for AppSettings {
             canvas_input_mode: Some("mouse".to_string()),
             zoom_speed_multiplier: Some(1.0),
             keybinds: HashMap::new(),
-            thumbnail_worker_threads: Some(4),
-            image_cache_size: Some(5),
+            thumbnail_worker_threads: Some(DEFAULT_THUMBNAIL_WORKER_THREADS),
+            image_cache_size: Some(DEFAULT_IMAGE_CACHE_SIZE),
         }
     }
 }
@@ -1731,7 +1749,10 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
     let state = app_handle.state::<crate::AppState>();
     let manager = state.thumbnail_manager.clone();
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
-    let thread_count = settings.thumbnail_worker_threads.unwrap_or(4).clamp(1, 16);
+    let thread_count = settings
+        .thumbnail_worker_threads
+        .unwrap_or(DEFAULT_THUMBNAIL_WORKER_THREADS)
+        .clamp(1, 16);
 
     for _ in 0..thread_count {
         let app_clone = app_handle.clone();
@@ -2998,7 +3019,9 @@ pub fn save_settings(settings: AppSettings, app_handle: AppHandle) -> Result<(),
     let json_string = serde_json::to_string_pretty(&settings).map_err(|e| e.to_string())?;
     fs::write(path, json_string).map_err(|e| e.to_string())?;
     let state = app_handle.state::<AppState>();
-    let cache_size = settings.image_cache_size.unwrap_or(5) as usize;
+    let cache_size = settings
+        .image_cache_size
+        .unwrap_or(DEFAULT_IMAGE_CACHE_SIZE) as usize;
     state
         .decoded_image_cache
         .lock()

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -56,6 +56,31 @@ pub const DEFAULT_IMAGE_CACHE_SIZE: u32 = 2;
 #[cfg(not(target_os = "android"))]
 pub const DEFAULT_IMAGE_CACHE_SIZE: u32 = 5;
 
+#[cfg(target_os = "android")]
+const DEFAULT_THUMBNAIL_RESOLUTION: u32 = 640;
+#[cfg(not(target_os = "android"))]
+const DEFAULT_THUMBNAIL_RESOLUTION: u32 = 720;
+
+#[cfg(target_os = "android")]
+const DEFAULT_EDITOR_PREVIEW_RESOLUTION: u32 = 1280;
+#[cfg(not(target_os = "android"))]
+const DEFAULT_EDITOR_PREVIEW_RESOLUTION: u32 = 1920;
+
+#[cfg(target_os = "android")]
+const DEFAULT_ENABLE_ZOOM_HIFI: bool = false;
+#[cfg(not(target_os = "android"))]
+const DEFAULT_ENABLE_ZOOM_HIFI: bool = true;
+
+#[cfg(target_os = "android")]
+const DEFAULT_HIGH_RES_ZOOM_MULTIPLIER: f32 = 0.75;
+#[cfg(not(target_os = "android"))]
+const DEFAULT_HIGH_RES_ZOOM_MULTIPLIER: f32 = 1.0;
+
+#[cfg(target_os = "android")]
+const DEFAULT_LIVE_PREVIEW_QUALITY: &str = "performance";
+#[cfg(not(target_os = "android"))]
+const DEFAULT_LIVE_PREVIEW_QUALITY: &str = "high";
+
 fn resolve_thumbnail_cache_dir(app_handle: &AppHandle) -> std::result::Result<PathBuf, String> {
     let cache_dir = app_handle
         .path()
@@ -507,12 +532,12 @@ impl Default for AppSettings {
         Self {
             last_root_path: None,
             pinned_folders: Vec::new(),
-            thumbnail_resolution: Some(720),
-            editor_preview_resolution: Some(1920),
-            enable_zoom_hifi: Some(true),
+            thumbnail_resolution: Some(DEFAULT_THUMBNAIL_RESOLUTION),
+            editor_preview_resolution: Some(DEFAULT_EDITOR_PREVIEW_RESOLUTION),
+            enable_zoom_hifi: Some(DEFAULT_ENABLE_ZOOM_HIFI),
             use_full_dpi_rendering: Some(false),
             enable_live_previews: Some(true),
-            live_preview_quality: Some("high".to_string()),
+            live_preview_quality: Some(DEFAULT_LIVE_PREVIEW_QUALITY.to_string()),
             sort_criteria: None,
             filter_criteria: None,
             theme: Some("dark".to_string()),
@@ -548,7 +573,7 @@ impl Default for AppSettings {
             library_view_mode: Some("flat".to_string()),
             export_presets: default_export_presets(),
             my_lenses: Some(Vec::new()),
-            high_res_zoom_multiplier: Some(1.0),
+            high_res_zoom_multiplier: Some(DEFAULT_HIGH_RES_ZOOM_MULTIPLIER),
             enable_folder_image_counts: Some(false),
             linear_raw_mode: default_linear_raw_mode(),
             enable_xmp_sync: Some(true),
@@ -569,6 +594,43 @@ impl Default for AppSettings {
             default_raw_tonemapper: Some("agx".to_string()),
             default_non_raw_tonemapper: Some("basic".to_string()),
         }
+    }
+}
+
+impl AppSettings {
+    fn apply_missing_platform_defaults(&mut self) -> bool {
+        let mut modified = false;
+
+        if self.thumbnail_resolution.is_none() {
+            self.thumbnail_resolution = Some(DEFAULT_THUMBNAIL_RESOLUTION);
+            modified = true;
+        }
+        if self.editor_preview_resolution.is_none() {
+            self.editor_preview_resolution = Some(DEFAULT_EDITOR_PREVIEW_RESOLUTION);
+            modified = true;
+        }
+        if self.enable_zoom_hifi.is_none() {
+            self.enable_zoom_hifi = Some(DEFAULT_ENABLE_ZOOM_HIFI);
+            modified = true;
+        }
+        if self.use_full_dpi_rendering.is_none() {
+            self.use_full_dpi_rendering = Some(false);
+            modified = true;
+        }
+        if self.high_res_zoom_multiplier.is_none() {
+            self.high_res_zoom_multiplier = Some(DEFAULT_HIGH_RES_ZOOM_MULTIPLIER);
+            modified = true;
+        }
+        if self.enable_live_previews.is_none() {
+            self.enable_live_previews = Some(true);
+            modified = true;
+        }
+        if self.live_preview_quality.is_none() {
+            self.live_preview_quality = Some(DEFAULT_LIVE_PREVIEW_QUALITY.to_string());
+            modified = true;
+        }
+
+        modified
     }
 }
 
@@ -3109,6 +3171,10 @@ pub fn load_settings(app_handle: AppHandle) -> Result<AppSettings, String> {
     let all_current_keys = all_available_adjustments();
     let default_included = default_included_adjustments();
     let mut settings_modified = false;
+
+    if settings.apply_missing_platform_defaults() {
+        settings_modified = true;
+    }
 
     let is_first_migration = settings.copy_paste_settings.known_adjustments.is_empty();
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -75,8 +75,8 @@ use crate::ai_processing::{
 };
 use crate::exif_processing::{read_exposure_time_secs, read_iso};
 use crate::file_management::{
-    AppSettings, generate_filename_from_template, load_settings, parse_virtual_path,
-    read_file_mapped,
+    AppSettings, DEFAULT_IMAGE_CACHE_SIZE, generate_filename_from_template, load_settings,
+    parse_virtual_path, read_file_mapped,
 };
 use crate::formats::is_raw_file;
 use crate::image_loader::{
@@ -4926,7 +4926,7 @@ pub fn run() {
 
             {
                 let state = app.state::<AppState>();
-                let cache_size = settings.image_cache_size.unwrap_or(5) as usize;
+                let cache_size = settings.image_cache_size.unwrap_or(DEFAULT_IMAGE_CACHE_SIZE) as usize;
                 state.decoded_image_cache.lock().unwrap().set_capacity(cache_size);
             }
 
@@ -5180,7 +5180,7 @@ pub fn run() {
             load_image_generation: Arc::new(AtomicUsize::new(0)),
             full_warped_cache: Mutex::new(None),
             full_transformed_cache: Mutex::new(None),
-            decoded_image_cache: Mutex::new(DecodedImageCache::new(5)),
+            decoded_image_cache: Mutex::new(DecodedImageCache::new(DEFAULT_IMAGE_CACHE_SIZE as usize)),
             thumbnail_manager: ThumbnailManager::new(),
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2071,7 +2071,22 @@ function App() {
       })
       .catch((err) => {
         console.error('Failed to load settings:', err);
-        setAppSettings({ lastRootPath: null, theme: DEFAULT_THEME_ID, thumbnailSize: defaultThumbnailSize });
+        setAppSettings({
+          lastRootPath: null,
+          theme: DEFAULT_THEME_ID,
+          thumbnailSize: defaultThumbnailSize,
+          ...(isAndroid
+            ? {
+                editorPreviewResolution: 1280,
+                enableZoomHifi: false,
+                useFullDpiRendering: false,
+                enableLivePreviews: true,
+                livePreviewQuality: 'performance',
+                highResZoomMultiplier: 0.75,
+                thumbnailResolution: 640,
+              }
+            : {}),
+        });
       })
       .finally(() => {
         isInitialMount.current = false;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -401,7 +401,9 @@ function App() {
     effects: false,
   });
   const [isLibraryExportPanelVisible, setIsLibraryExportPanelVisible] = useState(false);
-  const [libraryViewMode, setLibraryViewMode] = useState<LibraryViewMode>(LibraryViewMode.Flat);
+  const [libraryViewMode, setLibraryViewMode] = useState<LibraryViewMode>(
+    osPlatform === 'android' ? LibraryViewMode.Recursive : LibraryViewMode.Flat,
+  );
   const [leftPanelWidth, setLeftPanelWidth] = useState<number>(256);
   const [rightPanelWidth, setRightPanelWidth] = useState<number>(320);
   const [bottomPanelHeight, setBottomPanelHeight] = useState<number>(144);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -484,7 +484,7 @@ function App() {
     isOpen: false,
     sourceImages: [],
   });
-  const [customEscapeHandler, setCustomEscapeHandler] = useState(null);
+  const [customEscapeHandler, setCustomEscapeHandler] = useState<(() => void) | null>(null);
   const [isGeneratingAiMask, setIsGeneratingAiMask] = useState(false);
   const [isAIConnectorConnected, setisAIConnectorConnected] = useState(false);
   const [isGeneratingAi, setIsGeneratingAi] = useState(false);
@@ -3350,6 +3350,51 @@ function App() {
     collageModalState.isOpen ||
     denoiseModalState.isOpen ||
     negativeModalState.isOpen;
+
+  const handleAndroidBackNavigation = useCallback(() => {
+    if (isAnyModalOpen) return false;
+
+    if (isFullScreen) {
+      handleToggleFullScreen();
+      return true;
+    }
+
+    if (selectedImage) {
+      handleBackToLibrary();
+      return true;
+    }
+
+    if (activeView !== 'library') {
+      setActiveView('library');
+      return true;
+    }
+
+    if (isLibraryExportPanelVisible) {
+      setIsLibraryExportPanelVisible(false);
+      return true;
+    }
+
+    return false;
+  }, [
+    activeView,
+    handleBackToLibrary,
+    handleToggleFullScreen,
+    isAnyModalOpen,
+    isFullScreen,
+    isLibraryExportPanelVisible,
+    selectedImage,
+  ]);
+
+  useEffect(() => {
+    const handleAndroidBack = (event: Event) => {
+      if (handleAndroidBackNavigation()) {
+        event.preventDefault();
+      }
+    };
+
+    window.addEventListener('rapidraw:android-back', handleAndroidBack);
+    return () => window.removeEventListener('rapidraw:android-back', handleAndroidBack);
+  }, [handleAndroidBackNavigation]);
 
   useKeyboardShortcuts({
     isModalOpen: isAnyModalOpen,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,11 +273,11 @@ const insertChildrenIntoTree = (node: any, targetPath: string, newChildren: any[
 
 function App() {
   const COMPACT_EDITOR_MAX_WIDTH = 900;
-  const COMPACT_EDITOR_PANEL_MIN_RATIO = 0.4;
+  const COMPACT_EDITOR_PANEL_MIN_RATIO = 0.52;
   const COMPACT_EDITOR_PANEL_MANUAL_MIN_HEIGHT = 220;
   const COMPACT_EDITOR_PREVIEW_MIN_HEIGHT = 220;
-  const COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT = 64;
-  const COMPACT_EDITOR_HORIZONTAL_INSET = 32;
+  const COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT = 80;
+  const COMPACT_EDITOR_HORIZONTAL_INSET = 16;
   const COMPACT_EDITOR_STACK_GAP = 8;
   const DEFAULT_IMPORT_SETTINGS: ImportSettings = {
     filenameTemplate: '{original_filename}',
@@ -406,6 +406,8 @@ function App() {
   const [rightPanelWidth, setRightPanelWidth] = useState<number>(320);
   const [bottomPanelHeight, setBottomPanelHeight] = useState<number>(144);
   const [compactEditorPanelHeightOverride, setCompactEditorPanelHeightOverride] = useState<number | null>(null);
+  const compactEditorStackRef = useRef<HTMLDivElement>(null);
+  const [compactEditorStackSize, setCompactEditorStackSize] = useState<ImageDimensions>({ width: 0, height: 0 });
   const [activeTreeSection, setActiveTreeSection] = useState<string | null>('current');
   const [isResizing, setIsResizing] = useState(false);
   const [thumbnailSize, setThumbnailSize] = useState(defaultThumbnailSize);
@@ -517,6 +519,8 @@ function App() {
   const isPortraitViewport = viewportSize.width > 0 && viewportSize.height > viewportSize.width;
   const isCompactPortrait =
     viewportSize.width > 0 && viewportSize.width <= COMPACT_EDITOR_MAX_WIDTH && isPortraitViewport;
+  const compactEditorStackWidth = compactEditorStackSize.width || viewportSize.width;
+  const compactEditorStackHeight = compactEditorStackSize.height || viewportSize.height;
 
   const compactEditorImageDimensions = useMemo(() => {
     if (!selectedImage?.width || !selectedImage?.height) {
@@ -537,42 +541,41 @@ function App() {
   }, [adjustments.crop, adjustments.orientationSteps, selectedImage?.height, selectedImage?.width]);
 
   const compactEditorPanelAutoMinHeight =
-    viewportSize.height > 0 ? Math.max(320, Math.round(viewportSize.height * COMPACT_EDITOR_PANEL_MIN_RATIO)) : 340;
+    compactEditorStackHeight > 0
+      ? Math.max(
+          COMPACT_EDITOR_PANEL_MANUAL_MIN_HEIGHT,
+          Math.round(compactEditorStackHeight * COMPACT_EDITOR_PANEL_MIN_RATIO),
+        )
+      : 340;
   const compactEditorPanelManualMinHeight = COMPACT_EDITOR_PANEL_MANUAL_MIN_HEIGHT;
   const compactEditorPreviewMaxHeight =
-    viewportSize.height > 0
-      ? Math.max(
-          COMPACT_EDITOR_PREVIEW_MIN_HEIGHT,
-          viewportSize.height - compactEditorPanelAutoMinHeight - COMPACT_EDITOR_STACK_GAP,
-        )
+    compactEditorStackHeight > 0
+      ? Math.max(0, compactEditorStackHeight - compactEditorPanelAutoMinHeight - COMPACT_EDITOR_STACK_GAP)
       : COMPACT_EDITOR_PREVIEW_MIN_HEIGHT;
   const compactEditorPreviewFitHeight =
-    compactEditorImageDimensions && viewportSize.width > 0
-      ? Math.round(
-          Math.max(
-            COMPACT_EDITOR_PREVIEW_MIN_HEIGHT,
-            Math.min(
-              (Math.max(0, viewportSize.width - COMPACT_EDITOR_HORIZONTAL_INSET) *
-                compactEditorImageDimensions.height) /
-                compactEditorImageDimensions.width +
-                COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT,
-              compactEditorPreviewMaxHeight,
-            ),
+    compactEditorImageDimensions && compactEditorStackWidth > 0
+      ? Math.min(
+          Math.ceil(
+            (Math.max(0, compactEditorStackWidth - COMPACT_EDITOR_HORIZONTAL_INSET) *
+              compactEditorImageDimensions.height) /
+              compactEditorImageDimensions.width +
+              COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT,
           ),
+          compactEditorPreviewMaxHeight,
         )
       : compactEditorPreviewMaxHeight;
   const compactEditorPanelDefaultHeight =
-    viewportSize.height > 0
+    compactEditorStackHeight > 0
       ? Math.max(
           compactEditorPanelAutoMinHeight,
-          viewportSize.height - compactEditorPreviewFitHeight - COMPACT_EDITOR_STACK_GAP,
+          compactEditorStackHeight - compactEditorPreviewFitHeight - COMPACT_EDITOR_STACK_GAP,
         )
       : compactEditorPanelAutoMinHeight;
   const compactEditorPanelMaxHeight =
-    viewportSize.height > 0
+    compactEditorStackHeight > 0
       ? Math.max(
           compactEditorPanelManualMinHeight,
-          viewportSize.height - COMPACT_EDITOR_PREVIEW_MIN_HEIGHT - COMPACT_EDITOR_STACK_GAP,
+          compactEditorStackHeight - COMPACT_EDITOR_PREVIEW_MIN_HEIGHT - COMPACT_EDITOR_STACK_GAP,
         )
       : 520;
   const compactEditorPanelResolvedMinHeight =
@@ -586,6 +589,37 @@ function App() {
 
   useEffect(() => {
     setCompactEditorPanelHeightOverride(null);
+  }, [isCompactPortrait, selectedImage?.path]);
+
+  useEffect(() => {
+    const node = compactEditorStackRef.current;
+    if (!isCompactPortrait || !node) {
+      setCompactEditorStackSize((prev) => (prev.width === 0 && prev.height === 0 ? prev : { width: 0, height: 0 }));
+      return;
+    }
+
+    const updateCompactEditorStackSize = () => {
+      const rect = node.getBoundingClientRect();
+      const nextSize = {
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+      };
+
+      setCompactEditorStackSize((prev) =>
+        prev.width === nextSize.width && prev.height === nextSize.height ? prev : nextSize,
+      );
+    };
+
+    updateCompactEditorStackSize();
+
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateCompactEditorStackSize);
+    observer.observe(node);
+
+    return () => observer.disconnect();
   }, [isCompactPortrait, selectedImage?.path]);
 
   useEffect(() => {
@@ -5582,7 +5616,10 @@ function App() {
       );
 
       return (
-        <div className={clsx('flex grow h-full min-h-0', isCompactPortrait ? 'flex-col gap-2' : 'flex-row')}>
+        <div
+          ref={isCompactPortrait ? compactEditorStackRef : undefined}
+          className={clsx('flex grow h-full min-h-0', isCompactPortrait ? 'flex-col gap-2' : 'flex-row')}
+        >
           <div className={clsx('flex-1 flex flex-col min-w-0', isCompactPortrait && 'min-h-0')}>
             {editorNode}
             {!isCompactPortrait && editorBottomBarNode}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,7 +273,8 @@ const insertChildrenIntoTree = (node: any, targetPath: string, newChildren: any[
 
 function App() {
   const COMPACT_EDITOR_MAX_WIDTH = 900;
-  const COMPACT_EDITOR_PANEL_MIN_RATIO = 0.6;
+  const COMPACT_EDITOR_PANEL_MIN_RATIO = 0.4;
+  const COMPACT_EDITOR_PANEL_MANUAL_MIN_HEIGHT = 220;
   const COMPACT_EDITOR_PREVIEW_MIN_HEIGHT = 220;
   const COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT = 64;
   const COMPACT_EDITOR_HORIZONTAL_INSET = 32;
@@ -535,13 +536,14 @@ function App() {
     };
   }, [adjustments.crop, adjustments.orientationSteps, selectedImage?.height, selectedImage?.width]);
 
-  const compactEditorPanelMinHeight =
+  const compactEditorPanelAutoMinHeight =
     viewportSize.height > 0 ? Math.max(320, Math.round(viewportSize.height * COMPACT_EDITOR_PANEL_MIN_RATIO)) : 340;
+  const compactEditorPanelManualMinHeight = COMPACT_EDITOR_PANEL_MANUAL_MIN_HEIGHT;
   const compactEditorPreviewMaxHeight =
     viewportSize.height > 0
       ? Math.max(
           COMPACT_EDITOR_PREVIEW_MIN_HEIGHT,
-          viewportSize.height - compactEditorPanelMinHeight - COMPACT_EDITOR_STACK_GAP,
+          viewportSize.height - compactEditorPanelAutoMinHeight - COMPACT_EDITOR_STACK_GAP,
         )
       : COMPACT_EDITOR_PREVIEW_MIN_HEIGHT;
   const compactEditorPreviewFitHeight =
@@ -562,19 +564,21 @@ function App() {
   const compactEditorPanelDefaultHeight =
     viewportSize.height > 0
       ? Math.max(
-          compactEditorPanelMinHeight,
+          compactEditorPanelAutoMinHeight,
           viewportSize.height - compactEditorPreviewFitHeight - COMPACT_EDITOR_STACK_GAP,
         )
-      : compactEditorPanelMinHeight;
+      : compactEditorPanelAutoMinHeight;
   const compactEditorPanelMaxHeight =
     viewportSize.height > 0
       ? Math.max(
-          compactEditorPanelMinHeight,
+          compactEditorPanelManualMinHeight,
           viewportSize.height - COMPACT_EDITOR_PREVIEW_MIN_HEIGHT - COMPACT_EDITOR_STACK_GAP,
         )
       : 520;
+  const compactEditorPanelResolvedMinHeight =
+    compactEditorPanelHeightOverride === null ? compactEditorPanelAutoMinHeight : compactEditorPanelManualMinHeight;
   const compactEditorPanelHeight = Math.max(
-    compactEditorPanelMinHeight,
+    compactEditorPanelResolvedMinHeight,
     Math.min(compactEditorPanelHeightOverride ?? compactEditorPanelDefaultHeight, compactEditorPanelMaxHeight),
   );
   const compactEditorPanelCollapsedHeight = 96;
@@ -1826,7 +1830,7 @@ function App() {
         setter(
           Math.round(
             Math.max(
-              compactEditorPanelMinHeight,
+              compactEditorPanelManualMinHeight,
               Math.min(startSize - (moveEvent.clientY - startY), compactEditorPanelMaxHeight),
             ),
           ),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -273,6 +273,11 @@ const insertChildrenIntoTree = (node: any, targetPath: string, newChildren: any[
 
 function App() {
   const COMPACT_EDITOR_MAX_WIDTH = 900;
+  const COMPACT_EDITOR_PANEL_MIN_RATIO = 0.6;
+  const COMPACT_EDITOR_PREVIEW_MIN_HEIGHT = 220;
+  const COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT = 64;
+  const COMPACT_EDITOR_HORIZONTAL_INSET = 32;
+  const COMPACT_EDITOR_STACK_GAP = 8;
   const DEFAULT_IMPORT_SETTINGS: ImportSettings = {
     filenameTemplate: '{original_filename}',
     organizeByDate: false,
@@ -511,12 +516,62 @@ function App() {
   const isPortraitViewport = viewportSize.width > 0 && viewportSize.height > viewportSize.width;
   const isCompactPortrait =
     viewportSize.width > 0 && viewportSize.width <= COMPACT_EDITOR_MAX_WIDTH && isPortraitViewport;
+
+  const compactEditorImageDimensions = useMemo(() => {
+    if (!selectedImage?.width || !selectedImage?.height) {
+      return null;
+    }
+
+    const crop = adjustments.crop;
+    if (crop?.width && crop?.height) {
+      return { width: crop.width, height: crop.height };
+    }
+
+    const orientationSteps = adjustments.orientationSteps || 0;
+    const isSwapped = orientationSteps === 1 || orientationSteps === 3;
+    return {
+      width: isSwapped ? selectedImage.height : selectedImage.width,
+      height: isSwapped ? selectedImage.width : selectedImage.height,
+    };
+  }, [adjustments.crop, adjustments.orientationSteps, selectedImage?.height, selectedImage?.width]);
+
+  const compactEditorPanelMinHeight =
+    viewportSize.height > 0 ? Math.max(320, Math.round(viewportSize.height * COMPACT_EDITOR_PANEL_MIN_RATIO)) : 340;
+  const compactEditorPreviewMaxHeight =
+    viewportSize.height > 0
+      ? Math.max(
+          COMPACT_EDITOR_PREVIEW_MIN_HEIGHT,
+          viewportSize.height - compactEditorPanelMinHeight - COMPACT_EDITOR_STACK_GAP,
+        )
+      : COMPACT_EDITOR_PREVIEW_MIN_HEIGHT;
+  const compactEditorPreviewFitHeight =
+    compactEditorImageDimensions && viewportSize.width > 0
+      ? Math.round(
+          Math.max(
+            COMPACT_EDITOR_PREVIEW_MIN_HEIGHT,
+            Math.min(
+              (Math.max(0, viewportSize.width - COMPACT_EDITOR_HORIZONTAL_INSET) *
+                compactEditorImageDimensions.height) /
+                compactEditorImageDimensions.width +
+                COMPACT_EDITOR_PREVIEW_CHROME_HEIGHT,
+              compactEditorPreviewMaxHeight,
+            ),
+          ),
+        )
+      : compactEditorPreviewMaxHeight;
   const compactEditorPanelDefaultHeight =
-    viewportSize.height > 0 ? Math.max(300, Math.min(Math.round(viewportSize.height * 0.46), 520)) : 340;
-  const compactEditorPanelMinHeight = 220;
+    viewportSize.height > 0
+      ? Math.max(
+          compactEditorPanelMinHeight,
+          viewportSize.height - compactEditorPreviewFitHeight - COMPACT_EDITOR_STACK_GAP,
+        )
+      : compactEditorPanelMinHeight;
   const compactEditorPanelMaxHeight =
     viewportSize.height > 0
-      ? Math.max(compactEditorPanelMinHeight, Math.min(Math.round(viewportSize.height * 0.72), 620))
+      ? Math.max(
+          compactEditorPanelMinHeight,
+          viewportSize.height - COMPACT_EDITOR_PREVIEW_MIN_HEIGHT - COMPACT_EDITOR_STACK_GAP,
+        )
       : 520;
   const compactEditorPanelHeight = Math.max(
     compactEditorPanelMinHeight,
@@ -524,6 +579,10 @@ function App() {
   );
   const compactEditorPanelCollapsedHeight = 96;
   const [hasRenderedFirstFrame, setHasRenderedFirstFrame] = useState(false);
+
+  useEffect(() => {
+    setCompactEditorPanelHeightOverride(null);
+  }, [isCompactPortrait, selectedImage?.path]);
 
   useEffect(() => {
     if (currentFolderPath) {

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -140,6 +140,17 @@ const livePreviewQualityOptions: OptionItem<string>[] = [
   { value: 'performance', label: 'Performance' },
 ];
 
+const MIN_THUMBNAIL_WORKER_THREADS = 2;
+const MIN_DECODED_IMAGE_CACHE_SIZE = 2;
+const DEFAULT_THUMBNAIL_WORKER_THREADS = 4;
+const DEFAULT_DECODED_IMAGE_CACHE_SIZE = 5;
+
+const getDefaultThumbnailWorkerThreads = (osPlatform: string) =>
+  osPlatform === 'android' ? MIN_THUMBNAIL_WORKER_THREADS : DEFAULT_THUMBNAIL_WORKER_THREADS;
+
+const getDefaultDecodedImageCacheSize = (osPlatform: string) =>
+  osPlatform === 'android' ? MIN_DECODED_IMAGE_CACHE_SIZE : DEFAULT_DECODED_IMAGE_CACHE_SIZE;
+
 const backendOptions: OptionItem<string>[] = [
   { value: 'auto', label: 'Auto' },
   { value: 'vulkan', label: 'Vulkan' },
@@ -445,6 +456,8 @@ export default function SettingsPanel({
   const [tempLensModel, setTempLensModel] = useState<string>('');
 
   const osPlatform = useOsPlatform();
+  const defaultThumbnailWorkerThreads = getDefaultThumbnailWorkerThreads(osPlatform);
+  const defaultDecodedImageCacheSize = getDefaultDecodedImageCacheSize(osPlatform);
   const [processingSettings, setProcessingSettings] = useState({
     editorPreviewResolution: appSettings?.editorPreviewResolution || 1920,
     thumbnailResolution: appSettings?.thumbnailResolution || 720,
@@ -455,8 +468,8 @@ export default function SettingsPanel({
     useFullDpiRendering: appSettings?.useFullDpiRendering ?? false,
     useWgpuRenderer:
       appSettings?.useWgpuRenderer ?? (osPlatform === 'linux' || osPlatform === 'android' ? false : true),
-    thumbnailWorkerThreads: appSettings?.thumbnailWorkerThreads ?? 4,
-    imageCacheSize: appSettings?.imageCacheSize ?? 5,
+    thumbnailWorkerThreads: appSettings?.thumbnailWorkerThreads ?? defaultThumbnailWorkerThreads,
+    imageCacheSize: appSettings?.imageCacheSize ?? defaultDecodedImageCacheSize,
   });
   const [restartRequired, setRestartRequired] = useState(false);
   const [activeCategory, setActiveCategory] = useState('general');
@@ -504,11 +517,11 @@ export default function SettingsPanel({
       highResZoomMultiplier: appSettings?.highResZoomMultiplier || 1.0,
       useFullDpiRendering: appSettings?.useFullDpiRendering ?? false,
       useWgpuRenderer: appSettings?.useWgpuRenderer ?? true,
-      thumbnailWorkerThreads: appSettings?.thumbnailWorkerThreads ?? 4,
-      imageCacheSize: appSettings?.imageCacheSize ?? 5,
+      thumbnailWorkerThreads: appSettings?.thumbnailWorkerThreads ?? defaultThumbnailWorkerThreads,
+      imageCacheSize: appSettings?.imageCacheSize ?? defaultDecodedImageCacheSize,
     });
     setRestartRequired(false);
-  }, [appSettings]);
+  }, [appSettings, defaultDecodedImageCacheSize, defaultThumbnailWorkerThreads]);
 
   useEffect(() => {
     const fetchLogPath = async () => {
@@ -1632,11 +1645,11 @@ export default function SettingsPanel({
                     >
                       <Slider
                         label="Threads"
-                        min={2}
+                        min={MIN_THUMBNAIL_WORKER_THREADS}
                         max={10}
                         step={1}
                         value={processingSettings.thumbnailWorkerThreads}
-                        defaultValue={4}
+                        defaultValue={defaultThumbnailWorkerThreads}
                         onChange={(e: any) =>
                           handleProcessingSettingChange('thumbnailWorkerThreads', parseInt(e.target.value))
                         }
@@ -1650,11 +1663,11 @@ export default function SettingsPanel({
                     >
                       <Slider
                         label="Images"
-                        min={2}
+                        min={MIN_DECODED_IMAGE_CACHE_SIZE}
                         max={10}
                         step={1}
                         value={processingSettings.imageCacheSize}
-                        defaultValue={5}
+                        defaultValue={defaultDecodedImageCacheSize}
                         onChange={(e: any) => handleProcessingSettingChange('imageCacheSize', parseInt(e.target.value))}
                         fillOrigin="min"
                       />

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -151,6 +151,12 @@ const getDefaultThumbnailWorkerThreads = (osPlatform: string) =>
 const getDefaultDecodedImageCacheSize = (osPlatform: string) =>
   osPlatform === 'android' ? MIN_DECODED_IMAGE_CACHE_SIZE : DEFAULT_DECODED_IMAGE_CACHE_SIZE;
 
+const getDefaultEditorPreviewResolution = (osPlatform: string) => (osPlatform === 'android' ? 1280 : 1920);
+const getDefaultThumbnailResolution = (osPlatform: string) => (osPlatform === 'android' ? 640 : 720);
+const getDefaultEnableZoomHifi = (osPlatform: string) => osPlatform !== 'android';
+const getDefaultHighResZoomMultiplier = (osPlatform: string) => (osPlatform === 'android' ? 0.75 : 1.0);
+const getDefaultLivePreviewQuality = (osPlatform: string) => (osPlatform === 'android' ? 'performance' : 'high');
+
 const backendOptions: OptionItem<string>[] = [
   { value: 'auto', label: 'Auto' },
   { value: 'vulkan', label: 'Vulkan' },
@@ -463,13 +469,18 @@ export default function SettingsPanel({
   const osPlatform = useOsPlatform();
   const defaultThumbnailWorkerThreads = getDefaultThumbnailWorkerThreads(osPlatform);
   const defaultDecodedImageCacheSize = getDefaultDecodedImageCacheSize(osPlatform);
+  const defaultEditorPreviewResolution = getDefaultEditorPreviewResolution(osPlatform);
+  const defaultThumbnailResolution = getDefaultThumbnailResolution(osPlatform);
+  const defaultEnableZoomHifi = getDefaultEnableZoomHifi(osPlatform);
+  const defaultHighResZoomMultiplier = getDefaultHighResZoomMultiplier(osPlatform);
+  const defaultLivePreviewQuality = getDefaultLivePreviewQuality(osPlatform);
   const [processingSettings, setProcessingSettings] = useState({
-    editorPreviewResolution: appSettings?.editorPreviewResolution || 1920,
-    thumbnailResolution: appSettings?.thumbnailResolution || 720,
+    editorPreviewResolution: appSettings?.editorPreviewResolution || defaultEditorPreviewResolution,
+    thumbnailResolution: appSettings?.thumbnailResolution || defaultThumbnailResolution,
     rawHighlightCompression: appSettings?.rawHighlightCompression ?? 2.5,
     processingBackend: appSettings?.processingBackend || 'auto',
     linuxGpuOptimization: appSettings?.linuxGpuOptimization ?? false,
-    highResZoomMultiplier: appSettings?.highResZoomMultiplier || 1.0,
+    highResZoomMultiplier: appSettings?.highResZoomMultiplier || defaultHighResZoomMultiplier,
     useFullDpiRendering: appSettings?.useFullDpiRendering ?? false,
     useWgpuRenderer:
       appSettings?.useWgpuRenderer ?? (osPlatform === 'linux' || osPlatform === 'android' ? false : true),
@@ -514,19 +525,28 @@ export default function SettingsPanel({
       setAiProvider(appSettings?.aiProvider || 'cpu');
     }
     setProcessingSettings({
-      editorPreviewResolution: appSettings?.editorPreviewResolution || 1920,
-      thumbnailResolution: appSettings?.thumbnailResolution || 720,
+      editorPreviewResolution: appSettings?.editorPreviewResolution || defaultEditorPreviewResolution,
+      thumbnailResolution: appSettings?.thumbnailResolution || defaultThumbnailResolution,
       rawHighlightCompression: appSettings?.rawHighlightCompression ?? 2.5,
       processingBackend: appSettings?.processingBackend || 'auto',
       linuxGpuOptimization: appSettings?.linuxGpuOptimization ?? false,
-      highResZoomMultiplier: appSettings?.highResZoomMultiplier || 1.0,
+      highResZoomMultiplier: appSettings?.highResZoomMultiplier || defaultHighResZoomMultiplier,
       useFullDpiRendering: appSettings?.useFullDpiRendering ?? false,
-      useWgpuRenderer: appSettings?.useWgpuRenderer ?? true,
+      useWgpuRenderer:
+        appSettings?.useWgpuRenderer ?? (osPlatform === 'linux' || osPlatform === 'android' ? false : true),
       thumbnailWorkerThreads: appSettings?.thumbnailWorkerThreads ?? defaultThumbnailWorkerThreads,
       imageCacheSize: appSettings?.imageCacheSize ?? defaultDecodedImageCacheSize,
     });
     setRestartRequired(false);
-  }, [appSettings, defaultDecodedImageCacheSize, defaultThumbnailWorkerThreads]);
+  }, [
+    appSettings,
+    defaultDecodedImageCacheSize,
+    defaultEditorPreviewResolution,
+    defaultHighResZoomMultiplier,
+    defaultThumbnailResolution,
+    defaultThumbnailWorkerThreads,
+    osPlatform,
+  ]);
 
   useEffect(() => {
     const fetchLogPath = async () => {
@@ -1468,13 +1488,13 @@ export default function SettingsPanel({
                         Preview Rendering Strategy
                       </Text>
                       <PreviewModeSwitch
-                        mode={appSettings?.enableZoomHifi ? 'dynamic' : 'static'}
+                        mode={(appSettings?.enableZoomHifi ?? defaultEnableZoomHifi) ? 'dynamic' : 'static'}
                         onModeChange={handlePreviewModeChange}
                       />
 
                       <div className="mt-3">
                         <AnimatePresence mode="wait">
-                          {!(appSettings?.enableZoomHifi ?? true) ? (
+                          {!(appSettings?.enableZoomHifi ?? defaultEnableZoomHifi) ? (
                             <motion.div
                               key="static-preview"
                               initial={{ opacity: 0, x: 10 }}
@@ -1604,7 +1624,7 @@ export default function SettingsPanel({
                                     onSettingsChange({ ...appSettings, livePreviewQuality: value })
                                   }
                                   options={livePreviewQualityOptions}
-                                  value={appSettings?.livePreviewQuality || 'high'}
+                                  value={appSettings?.livePreviewQuality || defaultLivePreviewQuality}
                                   triggerClassName="bg-bg-primary"
                                 />
                               </SettingItem>

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -3,7 +3,7 @@ import ReactCrop from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { Stage, Layer, Ellipse, Line, Transformer, Group, Circle, Rect } from 'react-konva';
 import { PercentCrop, Crop } from 'react-image-crop';
-import { Adjustments, AiPatch, Coord, MaskContainer } from '../../../utils/adjustments';
+import { Adjustments, AiPatch, Coord, INITIAL_MASK_ADJUSTMENTS, MaskContainer } from '../../../utils/adjustments';
 import { Mask, SubMask, SubMaskMode, ToolType } from '../right/Masks';
 import { AppSettings, BrushSettings, SelectedImage } from '../../ui/AppProperties';
 import { RenderSize } from '../../../hooks/useImageRenderSize';
@@ -87,6 +87,16 @@ interface MaskOverlay {
   scale: number;
   subMask: SubMask;
 }
+
+const hasEffectiveMaskAdjustments = (adjustments: any): boolean => {
+  if (!adjustments) return false;
+
+  return Object.keys(INITIAL_MASK_ADJUSTMENTS).some((key) => {
+    if (key === 'sectionVisibility') return false;
+    const defaultValue = (INITIAL_MASK_ADJUSTMENTS as any)[key];
+    return JSON.stringify(adjustments[key] ?? defaultValue) !== JSON.stringify(defaultValue);
+  });
+};
 
 const MaskOverlay = memo(
   ({
@@ -982,6 +992,8 @@ const ImageCanvas = memo(
     const isInitialDrawing = (isMasking || isAiEditing) && activeSubMask?.parameters?.isInitialDraw === true;
 
     const isToolActive = isBrushActive || isAiSubjectActive || isInitialDrawing || isParametricActive;
+    const shouldHideMaskOverlayForSliderDrag =
+      isSliderDragging && (!isMasking || !activeContainer || hasEffectiveMaskAdjustments(activeContainer.adjustments));
 
     useEffect(() => {
       if (maskOverlayUrl && (isMasking || isAiEditing)) {
@@ -2045,7 +2057,12 @@ const ImageCanvas = memo(
                     height: `${imageRenderSize.height}px`,
                     left: `${imageRenderSize.offsetX}px`,
                     opacity:
-                      isShowingOriginal || isMaskControlHovered || isSliderDragging || isMaskInteractionActive ? 0 : 1,
+                      isShowingOriginal ||
+                      isMaskControlHovered ||
+                      shouldHideMaskOverlayForSliderDrag ||
+                      isMaskInteractionActive
+                        ? 0
+                        : 1,
                     top: `${imageRenderSize.offsetY}px`,
                     transition: 'opacity 300ms ease-in-out',
                     width: `${imageRenderSize.width}px`,

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -445,7 +445,7 @@ export default function ExportPanel({
               defaultPath: lastExportPath ?? undefined,
             });
 
-        if (outputFolder) {
+        if (isAndroid || outputFolder) {
           if (!isAndroid) {
             saveLastUsedPreset(outputFolder as string);
           }

--- a/src/components/panel/right/LibraryExportPanel.tsx
+++ b/src/components/panel/right/LibraryExportPanel.tsx
@@ -471,7 +471,7 @@ export default function LibraryExportPanel({
             defaultPath: lastExportPath ?? undefined,
           });
 
-      if (outputFolder) {
+      if (isAndroid || outputFolder) {
         if (!isAndroid) {
           saveLastUsedPreset(outputFolder as string);
         }

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -266,6 +266,7 @@ function DepthRangePicker({
   } | null>(null);
   const rafRef = useRef<number>(0);
   const [isLabelHovered, setIsLabelHovered] = useState(false);
+  const cleanupDragRef = useRef<(() => void) | null>(null);
 
   const vals = dragValues ?? { minDepth, maxDepth, minFade, maxFade };
   const fadeLeftEdge = Math.max(0, vals.minDepth - vals.minFade);
@@ -273,6 +274,7 @@ function DepthRangePicker({
 
   useEffect(() => {
     return () => {
+      cleanupDragRef.current?.();
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
   }, []);
@@ -360,6 +362,7 @@ function DepthRangePicker({
     const previousUserSelect = document.documentElement.style.userSelect;
 
     const target = e.currentTarget;
+    let didFinish = false;
 
     target.setPointerCapture?.(pointerId);
     document.documentElement.style.touchAction = 'none';
@@ -380,26 +383,47 @@ function DepthRangePicker({
       }
     };
 
-    const onUp = (upEvent: PointerEvent) => {
-      if (upEvent.pointerId !== pointerId) return;
-      setActiveHandle(null);
+    const finishDrag = (options: { updateState: boolean; commit: boolean }) => {
+      if (didFinish) return;
+      didFinish = true;
+
+      if (options.updateState) {
+        setActiveHandle(null);
+      }
       if (target.hasPointerCapture?.(pointerId)) target.releasePointerCapture(pointerId);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      onChange(latest);
+      if (options.commit) onChange(latest);
       onDragStateChange?.(false);
       document.documentElement.style.touchAction = previousTouchAction;
       document.documentElement.style.userSelect = previousUserSelect;
 
-      requestAnimationFrame(() => setDragValues(null));
+      if (options.updateState) {
+        requestAnimationFrame(() => setDragValues(null));
+      }
 
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
       document.removeEventListener('pointercancel', onUp);
+      target.removeEventListener('lostpointercapture', onLostPointerCapture);
+      cleanupDragRef.current = null;
     };
+
+    const onUp = (upEvent: PointerEvent) => {
+      if (upEvent.pointerId !== pointerId) return;
+      finishDrag({ updateState: true, commit: true });
+    };
+
+    const onLostPointerCapture = (lostEvent: PointerEvent) => {
+      if (lostEvent.pointerId !== pointerId) return;
+      finishDrag({ updateState: true, commit: true });
+    };
+
+    cleanupDragRef.current = () => finishDrag({ updateState: false, commit: false });
 
     document.addEventListener('pointermove', onMove, { passive: false });
     document.addEventListener('pointerup', onUp);
     document.addEventListener('pointercancel', onUp);
+    target.addEventListener('lostpointercapture', onLostPointerCapture);
   };
 
   const handleColor = (handle: string, isMain: boolean) =>
@@ -446,7 +470,7 @@ function DepthRangePicker({
         {isDragging && (
           <div
             className="fixed inset-0 z-[9999]"
-            style={{ cursor: activeHandle === 'range' ? 'grabbing' : 'ew-resize' }}
+            style={{ cursor: activeHandle === 'range' ? 'grabbing' : 'ew-resize', pointerEvents: 'none' }}
           />
         )}
 
@@ -1102,6 +1126,11 @@ export default function MasksPanel({
     if (onDragStateChange) onDragStateChange(true);
   };
 
+  const handleDragCancel = () => {
+    setActiveDragItem(null);
+    if (onDragStateChange) onDragStateChange(false);
+  };
+
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     const dragData = active.data.current as DragData;
@@ -1254,6 +1283,7 @@ export default function MasksPanel({
       sensors={sensors}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
       collisionDetection={pointerWithin}
     >
       <div

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -266,7 +266,6 @@ function DepthRangePicker({
   } | null>(null);
   const rafRef = useRef<number>(0);
   const [isLabelHovered, setIsLabelHovered] = useState(false);
-  const cleanupDragRef = useRef<(() => void) | null>(null);
 
   const vals = dragValues ?? { minDepth, maxDepth, minFade, maxFade };
   const fadeLeftEdge = Math.max(0, vals.minDepth - vals.minFade);
@@ -274,7 +273,6 @@ function DepthRangePicker({
 
   useEffect(() => {
     return () => {
-      cleanupDragRef.current?.();
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
     };
   }, []);
@@ -362,7 +360,6 @@ function DepthRangePicker({
     const previousUserSelect = document.documentElement.style.userSelect;
 
     const target = e.currentTarget;
-    let didFinish = false;
 
     target.setPointerCapture?.(pointerId);
     document.documentElement.style.touchAction = 'none';
@@ -383,47 +380,26 @@ function DepthRangePicker({
       }
     };
 
-    const finishDrag = (options: { updateState: boolean; commit: boolean }) => {
-      if (didFinish) return;
-      didFinish = true;
-
-      if (options.updateState) {
-        setActiveHandle(null);
-      }
+    const onUp = (upEvent: PointerEvent) => {
+      if (upEvent.pointerId !== pointerId) return;
+      setActiveHandle(null);
       if (target.hasPointerCapture?.(pointerId)) target.releasePointerCapture(pointerId);
       if (rafRef.current) cancelAnimationFrame(rafRef.current);
-      if (options.commit) onChange(latest);
+      onChange(latest);
       onDragStateChange?.(false);
       document.documentElement.style.touchAction = previousTouchAction;
       document.documentElement.style.userSelect = previousUserSelect;
 
-      if (options.updateState) {
-        requestAnimationFrame(() => setDragValues(null));
-      }
+      requestAnimationFrame(() => setDragValues(null));
 
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', onUp);
       document.removeEventListener('pointercancel', onUp);
-      target.removeEventListener('lostpointercapture', onLostPointerCapture);
-      cleanupDragRef.current = null;
     };
-
-    const onUp = (upEvent: PointerEvent) => {
-      if (upEvent.pointerId !== pointerId) return;
-      finishDrag({ updateState: true, commit: true });
-    };
-
-    const onLostPointerCapture = (lostEvent: PointerEvent) => {
-      if (lostEvent.pointerId !== pointerId) return;
-      finishDrag({ updateState: true, commit: true });
-    };
-
-    cleanupDragRef.current = () => finishDrag({ updateState: false, commit: false });
 
     document.addEventListener('pointermove', onMove, { passive: false });
     document.addEventListener('pointerup', onUp);
     document.addEventListener('pointercancel', onUp);
-    target.addEventListener('lostpointercapture', onLostPointerCapture);
   };
 
   const handleColor = (handle: string, isMain: boolean) =>
@@ -470,7 +446,7 @@ function DepthRangePicker({
         {isDragging && (
           <div
             className="fixed inset-0 z-[9999]"
-            style={{ cursor: activeHandle === 'range' ? 'grabbing' : 'ew-resize', pointerEvents: 'none' }}
+            style={{ cursor: activeHandle === 'range' ? 'grabbing' : 'ew-resize' }}
           />
         )}
 
@@ -1126,11 +1102,6 @@ export default function MasksPanel({
     if (onDragStateChange) onDragStateChange(true);
   };
 
-  const handleDragCancel = () => {
-    setActiveDragItem(null);
-    if (onDragStateChange) onDragStateChange(false);
-  };
-
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     const dragData = active.data.current as DragData;
@@ -1283,7 +1254,6 @@ export default function MasksPanel({
       sensors={sensors}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
-      onDragCancel={handleDragCancel}
       collisionDetection={pointerWithin}
     >
       <div

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -149,6 +149,9 @@ export interface AppSettings {
   aiConnectorAddress?: string;
   decorations?: any;
   editorPreviewResolution?: number;
+  thumbnailResolution?: number;
+  thumbnailWorkerThreads?: number;
+  imageCacheSize?: number;
   enableZoomHifi?: boolean;
   useFullDpiRendering?: boolean;
   highResZoomMultiplier?: number;

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { GLOBAL_KEYS } from './AppProperties';
-import { useOsPlatform } from '../../hooks/useOsPlatform';
 
 type SliderChangeEvent =
   | React.ChangeEvent<HTMLInputElement>
@@ -42,7 +41,6 @@ const Slider = ({
   fillOrigin = 'default',
   suffix = '',
 }: SliderProps) => {
-  const isAndroid = useOsPlatform() === 'android';
   const [displayValue, setDisplayValue] = useState<number>(value);
   const [isDragging, setIsDragging] = useState(false);
   const animationFrameRef = useRef<number | undefined>(undefined);
@@ -267,11 +265,6 @@ const Slider = ({
   };
 
   const handleMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
-    if (isAndroid && e.button !== 0) {
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
     if (Date.now() - lastUpTime.current < DOUBLE_CLICK_THRESHOLD_MS) {
       e.preventDefault();
       return;
@@ -484,7 +477,6 @@ const Slider = ({
           max={String(max)}
           min={String(min)}
           onChange={handleChange}
-          onContextMenu={isAndroid ? (e) => e.preventDefault() : undefined}
           onDoubleClick={handleReset}
           onKeyDown={handleRangeKeyDown}
           onMouseDown={handleMouseDown}

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -26,6 +26,7 @@ interface SliderProps {
 const DOUBLE_CLICK_THRESHOLD_MS = 300;
 const FINE_ADJUSTMENT_MULTIPLIER = 0.2;
 const TOUCH_DRAG_THRESHOLD_PX = 10;
+const TOUCH_NATIVE_CHANGE_SUPPRESSION_MS = 500;
 
 const Slider = ({
   defaultValue = 0,
@@ -57,6 +58,8 @@ const Slider = ({
     startY: number;
     latestX: number;
   } | null>(null);
+  const touchDragActiveRef = useRef(false);
+  const ignoreNativeChangeUntilRef = useRef(0);
 
   const fillPercentage = max !== min ? ((displayValue - min) / (max - min)) * 100 : 0;
   const originPercentage = useMemo(() => {
@@ -168,6 +171,7 @@ const Slider = ({
 
     const handlePointerUp = () => {
       lastUpTime.current = Date.now();
+      touchDragActiveRef.current = false;
       setIsDragging(false);
     };
 
@@ -249,6 +253,11 @@ const Slider = ({
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (pendingTouchRef.current || Date.now() < ignoreNativeChangeUntilRef.current) {
+      setDisplayValue(value);
+      return;
+    }
+
     if (!isDragging) {
       setDisplayValue(Number(e.target.value));
       onChange(e);
@@ -284,6 +293,8 @@ const Slider = ({
       startY: touch.clientY,
       latestX: touch.clientX,
     };
+    touchDragActiveRef.current = false;
+    ignoreNativeChangeUntilRef.current = Date.now() + TOUCH_NATIVE_CHANGE_SUPPRESSION_MS;
   };
 
   const handleTouchMove = (e: React.TouchEvent<HTMLInputElement>) => {
@@ -292,22 +303,19 @@ const Slider = ({
     const touch = e.touches[0];
     const pendingTouch = pendingTouchRef.current;
     pendingTouch.latestX = touch.clientX;
+    ignoreNativeChangeUntilRef.current = Date.now() + TOUCH_NATIVE_CHANGE_SUPPRESSION_MS;
 
     const deltaX = touch.clientX - pendingTouch.startX;
     const deltaY = touch.clientY - pendingTouch.startY;
 
-    if (
-      Math.abs(deltaY) > TOUCH_DRAG_THRESHOLD_PX &&
-      Math.abs(deltaY) > Math.abs(deltaX)
-    ) {
+    if (Math.abs(deltaY) > TOUCH_DRAG_THRESHOLD_PX && Math.abs(deltaY) > Math.abs(deltaX)) {
       pendingTouchRef.current = null;
+      ignoreNativeChangeUntilRef.current = Date.now() + TOUCH_NATIVE_CHANGE_SUPPRESSION_MS;
+      setDisplayValue(value);
       return;
     }
 
-    if (
-      Math.abs(deltaX) < TOUCH_DRAG_THRESHOLD_PX ||
-      Math.abs(deltaX) < Math.abs(deltaY)
-    ) {
+    if (Math.abs(deltaX) < TOUCH_DRAG_THRESHOLD_PX || Math.abs(deltaX) < Math.abs(deltaY)) {
       return;
     }
 
@@ -322,6 +330,8 @@ const Slider = ({
     accumulatedValueRef.current = rawValue;
     lastPointerXRef.current = touch.clientX;
     pendingTouchRef.current = null;
+    touchDragActiveRef.current = true;
+    ignoreNativeChangeUntilRef.current = Date.now() + TOUCH_NATIVE_CHANGE_SUPPRESSION_MS;
 
     if (e.cancelable) {
       e.preventDefault();
@@ -333,6 +343,10 @@ const Slider = ({
   };
 
   const handleTouchEnd = () => {
+    if (!touchDragActiveRef.current) {
+      ignoreNativeChangeUntilRef.current = Date.now() + TOUCH_NATIVE_CHANGE_SUPPRESSION_MS;
+      setDisplayValue(value);
+    }
     pendingTouchRef.current = null;
   };
 

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { GLOBAL_KEYS } from './AppProperties';
+import { useOsPlatform } from '../../hooks/useOsPlatform';
 
 type SliderChangeEvent =
   | React.ChangeEvent<HTMLInputElement>
@@ -41,6 +42,7 @@ const Slider = ({
   fillOrigin = 'default',
   suffix = '',
 }: SliderProps) => {
+  const isAndroid = useOsPlatform() === 'android';
   const [displayValue, setDisplayValue] = useState<number>(value);
   const [isDragging, setIsDragging] = useState(false);
   const animationFrameRef = useRef<number | undefined>(undefined);
@@ -265,6 +267,11 @@ const Slider = ({
   };
 
   const handleMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+    if (isAndroid && e.button !== 0) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     if (Date.now() - lastUpTime.current < DOUBLE_CLICK_THRESHOLD_MS) {
       e.preventDefault();
       return;
@@ -477,6 +484,7 @@ const Slider = ({
           max={String(max)}
           min={String(min)}
           onChange={handleChange}
+          onContextMenu={isAndroid ? (e) => e.preventDefault() : undefined}
           onDoubleClick={handleReset}
           onKeyDown={handleRangeKeyDown}
           onMouseDown={handleMouseDown}


### PR DESCRIPTION
## Description
Fixes and improvements for the Android Port

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] UI/UX improvement

## Changes Made
- Set default Thumbnail Worker Threads for Android
- Set default Decoded Image Cache for Android
- Added auto scaling UI as seen in the attached video
- Added support for the back gesture on android, now it doesn't directly close the app. Instead it goes from editor to gallery and then out of the app
- Back gesture works as only escape from the fullscreen view in the editor
- Sliders can't be touched anywhere anymore, only at the point
- Fix Export in Library
- More default settings for android
- Set default view mode in library to recursive on android

## Screenshots/Videos
https://github.com/user-attachments/assets/c0d02ab3-a4a7-4365-a2b0-644f65693224

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
