### PR TITLE
Fix link to discussions page in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -8,7 +8,7 @@ body:
       value: |
         Thanks for taking the time to report a bug! Please fill out the information below to help us understand and fix the issue.
 
-        > **Note:** This template is for reporting bugs and issues only. For feature requests, please use the [Discussions page](../../discussions) instead.
+        > **Note:** This template is for reporting bugs and issues only. For feature requests, please use the [Discussions page](discussions) instead.
 
   - type: textarea
     id: what-happened


### PR DESCRIPTION
## Description

Fix link to discussions page in issue template

## Type of Change

Documentation update

## Changes Made

The link is shown at https://github.com/CyberTimon/RapidRAW/issues, so the relative link `../../discussions` will first take out two parts (`RapidRaw/issues`) and then replace the remaining last part (`CyberTimon`) with `discussions`, resulting in a link pointing to `github.com/discussions`, rather than the intended `github.com/CyberTimon/RapidRAW/discussions`.

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->

## Testing

- [x] I have tested these changes locally and confirmed that they work as expected without issues

Tested by changing the URL with inspect element and seeing that it points to the correct place

**Test Configuration:**

N/A

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes


## AI Disclaimer:
Please state the involvement of AI in this PR:
- [x] This PR contains only blood, sweat, and coffee (AI-free)

