### PR TITLE
Extract embedded JPEG previews for fast interim thumbnails

### DIFF
--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -366,6 +366,8 @@ pub struct AppSettings {
     pub default_non_raw_tonemapper: Option<String>,
     #[serde(default)]
     pub enable_focus_mode: Option<bool>,
+    #[serde(default)]
+    pub use_embedded_jpeg_thumbnails: Option<bool>,
 }
 
 impl Default for AppSettings {
@@ -444,6 +446,7 @@ impl Default for AppSettings {
             default_raw_tonemapper: Some("agx".to_string()),
             default_non_raw_tonemapper: Some("basic".to_string()),
             enable_focus_mode: Some(false),
+            use_embedded_jpeg_thumbnails: Some(true),
         }
     }
 }

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -136,5 +136,7 @@ pub struct AppState {
     pub full_warped_cache: Mutex<Option<(u64, Arc<DynamicImage>)>>,
     pub full_transformed_cache: Mutex<Option<TransformedImageCache>>,
     pub decoded_image_cache: Mutex<DecodedImageCache>,
+    pub tiny_preview_queue: Arc<ThumbnailManager>,
+    pub embedded_preview_queue: Arc<ThumbnailManager>,
     pub thumbnail_manager: Arc<ThumbnailManager>,
 }

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -55,6 +55,36 @@ fn resolve_thumbnail_cache_dir(app_handle: &AppHandle) -> std::result::Result<Pa
     Ok(thumb_cache_dir)
 }
 
+fn resolve_embedded_preview_cache_dir(app_handle: &AppHandle) -> std::result::Result<PathBuf, String> {
+    let cache_dir = app_handle
+        .path()
+        .app_cache_dir()
+        .map_err(|e| e.to_string())?;
+    let preview_cache_dir = cache_dir.join("embedded-previews");
+    if !preview_cache_dir.exists() {
+        fs::create_dir_all(&preview_cache_dir).map_err(|e| e.to_string())?;
+    }
+    Ok(preview_cache_dir)
+}
+
+fn get_tiny_preview_cache_path(app_handle: &AppHandle, path: &str) -> std::result::Result<PathBuf, String> {
+    let cache_dir = resolve_embedded_preview_cache_dir(app_handle)?;
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    hasher.write(b"tiny");
+    let hash = hasher.finish();
+    Ok(cache_dir.join(format!("{:x}.jpg", hash)))
+}
+
+fn get_embedded_preview_cache_path(app_handle: &AppHandle, path: &str) -> std::result::Result<PathBuf, String> {
+    let cache_dir = resolve_embedded_preview_cache_dir(app_handle)?;
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    hasher.write(b"embedded");
+    let hash = hasher.finish();
+    Ok(cache_dir.join(format!("{:x}.jpg", hash)))
+}
+
 fn emit_thumbnail_cache_setup_error(app_handle: &AppHandle, path: &str, reason: &str) {
     let _ = app_handle.emit(
         "thumbnail-generation-error",
@@ -1064,13 +1094,20 @@ fn generate_single_thumbnail_and_cache(
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let target_width = settings.thumbnail_resolution.unwrap_or(720);
 
-    if let Ok(thumb_image) =
-        generate_thumbnail_data(path_str, gpu_context, preloaded_image, app_handle)
-        && let Ok(thumb_data) = encode_thumbnail(&thumb_image, target_width)
-    {
-        let _ = fs::write(&cache_path, &thumb_data);
-        let base64_str = general_purpose::STANDARD.encode(&thumb_data);
-        return Some((format!("data:image/jpeg;base64,{}", base64_str), rating));
+    match generate_thumbnail_data(path_str, gpu_context, preloaded_image, app_handle) {
+        Ok(thumb_image) => match encode_thumbnail(&thumb_image, target_width) {
+            Ok(thumb_data) => {
+                let _ = fs::write(&cache_path, &thumb_data);
+                let base64_str = general_purpose::STANDARD.encode(&thumb_data);
+                return Some((format!("data:image/jpeg;base64,{}", base64_str), rating));
+            }
+            Err(e) => {
+                log::error!("[thumbnail] encode failed for {}: {}", path_str, e);
+            }
+        },
+        Err(e) => {
+            log::error!("[thumbnail] generate_thumbnail_data failed for {}: {}", path_str, e);
+        }
     }
     None
 }
@@ -1127,6 +1164,8 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                                 "rating": rating
                             }),
                         );
+                    } else {
+                        log::warn!("[thumbnail] failed for: {}", path_to_process);
                     }
                     increment_thumbnail_progress(&state, &app_clone);
                 }
@@ -1138,6 +1177,110 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
             }
         });
     }
+
+    start_embedded_preview_workers(app_handle);
+}
+
+fn start_embedded_preview_workers(app_handle: tauri::AppHandle) {
+    let state = app_handle.state::<crate::AppState>();
+
+    // tiny-preview worker extracts the smallest embedded preview from RAW and JPEG files by reading
+    // the first 64KB of the file, allowing them to load extremely quickly.
+    {
+        let app_clone = app_handle.clone();
+        let manager = state.tiny_preview_queue.clone();
+        std::thread::spawn(move || loop {
+            let path = {
+                let mut q = manager.queue.lock().unwrap();
+                loop {
+                    if let Some(p) = q.pop_front() {
+                        break p;
+                    }
+                    q = manager.cvar.wait(q).unwrap();
+                }
+            };
+
+            if let Ok(cache_path) = get_tiny_preview_cache_path(&app_clone, &path) {
+                // Check if already cached
+                if let Ok(cached_bytes) = fs::read(&cache_path) {
+                    if let Some(encoded) = encode_embedded_preview(&cached_bytes) {
+                        let _ = app_clone.emit(
+                            "embedded-preview-generated",
+                            serde_json::json!({ "path": path, "data": encoded, "type": "tiny" }),
+                        );
+                    }
+                } else if let Some(bytes) = extract_tiny_preview(&path) {
+                    let _ = fs::write(&cache_path, &bytes);
+                    if let Some(encoded) = encode_embedded_preview(&bytes) {
+                        let _ = app_clone.emit(
+                            "embedded-preview-generated",
+                            serde_json::json!({ "path": path, "data": encoded, "type": "tiny" }),
+                        );
+                    } else {
+                        log::warn!("[tiny-preview] failed to encode: {}", path);
+                    }
+                } else {
+                    log::warn!("[tiny-preview] failed to extract: {}", path);
+                }
+            } else {
+                log::warn!("[tiny-preview] failed to get cache path: {}", path);
+            }
+        });
+    }
+
+    // embedded-preview worker extracts the full embedded preview (largest JPEG) from RAW files,
+    // these can be significantly larger than the tiny previews, on Fuji RAF files for example they
+    // can be ~1MB in size
+    {
+        let app_clone = app_handle.clone();
+        let manager = state.embedded_preview_queue.clone();
+        std::thread::spawn(move || loop {
+            let path = {
+                let mut q = manager.queue.lock().unwrap();
+                loop {
+                    if let Some(p) = q.pop_front() {
+                        break p;
+                    }
+                    q = manager.cvar.wait(q).unwrap();
+                }
+            };
+
+            if let Ok(settings) = crate::app_settings::load_settings(app_clone.clone()) {
+                if !settings.use_embedded_jpeg_thumbnails.unwrap_or(true) {
+                    continue;
+                }
+            }
+
+            if let Ok(cache_path) = get_embedded_preview_cache_path(&app_clone, &path) {
+                // Check if already cached
+                if let Ok(cached_bytes) = fs::read(&cache_path) {
+                    if let Some(encoded) = encode_embedded_preview(&cached_bytes) {
+                        let _ = app_clone.emit(
+                            "embedded-preview-generated",
+                            serde_json::json!({ "path": path, "data": encoded, "type": "embedded" }),
+                        );
+                    }
+                } else if let Some(bytes) = extract_full_embedded_preview(&path) {
+                    let _ = fs::write(&cache_path, &bytes);
+                    if let Some(encoded) = encode_embedded_preview(&bytes) {
+                        let _ = app_clone.emit(
+                            "embedded-preview-generated",
+                            serde_json::json!({ "path": path, "data": encoded, "type": "embedded" }),
+                        );
+                    } else {
+                        log::warn!("[embedded-preview] failed to encode: {}", path);
+                    }
+                }
+            } else {
+                log::warn!("[embedded-preview] failed to get cache path: {}", path);
+            }
+        });
+    }
+}
+
+fn encode_embedded_preview(jpeg_bytes: &[u8]) -> Option<String> {
+    let base64_str = base64::engine::general_purpose::STANDARD.encode(jpeg_bytes);
+    Some(format!("data:image/jpeg;base64,{}", base64_str))
 }
 
 #[tauri::command]
@@ -1155,8 +1298,35 @@ pub fn update_thumbnail_queue(
         }
     }
 
+    {
+        let mut tiny_queue = state.tiny_preview_queue.queue.lock().unwrap();
+        for path in &unique_paths {
+            if !tiny_queue.contains(path) {
+                tiny_queue.push_back(path.clone());
+            }
+        }
+        drop(tiny_queue);
+        state.tiny_preview_queue.cvar.notify_all();
+    }
+    {
+        let should_use_embedded = crate::app_settings::load_settings(app_handle.clone())
+            .ok()
+            .and_then(|s| s.use_embedded_jpeg_thumbnails)
+            .unwrap_or(true);
+
+        if should_use_embedded {
+            let mut embedded_queue = state.embedded_preview_queue.queue.lock().unwrap();
+            for path in &unique_paths {
+                if is_raw_file(&path) && !embedded_queue.contains(path) {
+                    embedded_queue.push_back(path.clone());
+                }
+            }
+            drop(embedded_queue);
+            state.embedded_preview_queue.cvar.notify_all();
+        }
+    }
+
     let mut queue = state.thumbnail_manager.queue.lock().unwrap();
-    queue.clear();
 
     let path_count = unique_paths.len();
     for path in unique_paths {
@@ -2298,14 +2468,23 @@ pub fn clear_thumbnail_cache(app_handle: AppHandle) -> Result<(), String> {
         .app_cache_dir()
         .map_err(|e| e.to_string())?;
     let thumb_cache_dir = cache_dir.join("thumbnails");
+    let embedded_cache_dir = cache_dir.join("embedded-previews");
 
     if thumb_cache_dir.exists() {
         fs::remove_dir_all(&thumb_cache_dir)
             .map_err(|e| format!("Failed to remove thumbnail cache: {}", e))?;
     }
 
+    if embedded_cache_dir.exists() {
+        fs::remove_dir_all(&embedded_cache_dir)
+            .map_err(|e| format!("Failed to remove embedded-previews cache: {}", e))?;
+    }
+
     fs::create_dir_all(&thumb_cache_dir)
         .map_err(|e| format!("Failed to recreate thumbnail cache directory: {}", e))?;
+
+    fs::create_dir_all(&embedded_cache_dir)
+        .map_err(|e| format!("Failed to recreate embedded-previews cache directory: {}", e))?;
 
     Ok(())
 }
@@ -3148,5 +3327,189 @@ pub fn sync_metadata_to_xmp(source_path: &Path, metadata: &ImageMetadata, create
         }
 
         let _ = fs::write(&xmp_file, content);
+    }
+}
+
+/// Read first 64 KB and extract the smallest embedded JPEG (EXIF thumbnail).
+/// Works for both RAW and JPEG files. Applies EXIF rotation from the header.
+pub fn extract_tiny_preview(path: &str) -> Option<Vec<u8>> {
+    let (source_path, _) = parse_virtual_path(path);
+    let mut f = fs::File::open(&source_path).ok()?;
+    let mut buf = vec![0u8; 65_536];
+    let n = std::io::Read::read(&mut f, &mut buf).ok()?;
+    buf.truncate(n);
+    
+    let mut thumbnail = find_embedded_jpegs(&buf).into_iter().next()?;
+    
+    // Try to read EXIF orientation from the header we already have
+    if let Some(exif) = crate::exif_processing::read_exif(&buf) {
+        if let Some(field) = exif.get_field(exif::Tag::Orientation, exif::In::PRIMARY) {
+            if let exif::Value::Short(vals) = &field.value {
+                if let Some(&orientation) = vals.first() {
+                    if let Some(rotated) = apply_exif_rotation(&thumbnail, orientation) {
+                        thumbnail = rotated;
+                    }
+                }
+            }
+        }
+    }
+    
+    Some(thumbnail)
+}
+
+/// Map entire file and extract the largest embedded JPEG preview.
+/// Returns None for non-RAW files.
+pub fn extract_full_embedded_preview(path: &str) -> Option<Vec<u8>> {
+    let (source_path, _) = parse_virtual_path(path);
+    if !is_raw_file(path) {
+        return None;
+    }
+    let data: Box<dyn std::ops::Deref<Target = [u8]>> = match read_file_mapped(&source_path) {
+        Ok(m) => Box::new(m),
+        Err(_) => Box::new(fs::read(&source_path).ok()?),
+    };
+
+    let jpegs = if data.len() > 16 && &data[..16] == b"FUJIFILMCCD-RAW " {
+        extract_raf_full_preview(&data).into_iter().collect::<Vec<_>>()
+    } else {
+        find_embedded_jpegs(&data)
+    };
+
+    jpegs.into_iter().max_by_key(|b| b.len())
+}
+
+/// Extract full-size embedded JPEG from Fujifilm RAF using header offsets.
+fn extract_raf_full_preview(data: &[u8]) -> Option<Vec<u8>> {
+    if data.len() < 0x60 {
+        return None;
+    }
+    let jpeg_off = u32::from_be_bytes(data[0x54..0x58].try_into().unwrap_or([0; 4])) as usize;
+    let jpeg_len = u32::from_be_bytes(data[0x58..0x5C].try_into().unwrap_or([0; 4])) as usize;
+
+    if jpeg_off == 0 || jpeg_len == 0 || jpeg_off + jpeg_len > data.len() {
+        log::warn!("[embedded] RAF header offsets out of range (off={} len={})", jpeg_off, jpeg_len);
+        return find_embedded_jpegs(data).into_iter().max_by_key(|b| b.len());
+    }
+
+    Some(data[jpeg_off..jpeg_off + jpeg_len].to_vec())
+}
+
+/// Find all valid JPEG blobs in data, sorted smallest-first.
+fn find_embedded_jpegs(data: &[u8]) -> Vec<Vec<u8>> {
+    let mut found: Vec<Vec<u8>> = Vec::new();
+    let mut i = 0;
+
+    while i + 1 < data.len() {
+        if data[i] == 0xFF && data[i + 1] == 0xD8 {
+            let start = i;
+            if let Some(end) = find_jpeg_end(data, start) {
+                let len = end - start;
+                if len > 5_000 {
+                    found.push(data[start..end].to_vec());
+                }
+                i = start + 2;
+            } else {
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    found.dedup_by_key(|b| b.len());
+    found.sort_by_key(|b| b.len());
+    found
+}
+
+/// Walk JPEG markers properly to find EOI without mistaking entropy data.
+fn find_jpeg_end(data: &[u8], start: usize) -> Option<usize> {
+    let mut i = start + 2;
+
+    loop {
+        while i < data.len() && data[i] != 0xFF {
+            i += 1;
+        }
+        while i < data.len() && data[i] == 0xFF {
+            i += 1;
+        }
+        if i >= data.len() {
+            return None;
+        }
+
+        let marker = data[i];
+        i += 1;
+
+        match marker {
+            0xD9 => return Some(i),
+            0x00 => {}
+            0xD0..=0xD7 | 0x01 => {}
+            0xD8 => {}
+            0xDA => {
+                if i + 2 > data.len() {
+                    return None;
+                }
+                let hdr_len = u16::from_be_bytes([data[i], data[i + 1]]) as usize;
+                if hdr_len < 2 {
+                    return None;
+                }
+                i += hdr_len;
+                while i + 1 < data.len() {
+                    if data[i] == 0xFF {
+                        let b = data[i + 1];
+                        if b == 0x00 || (0xD0..=0xD7).contains(&b) {
+                            i += 2;
+                        } else {
+                            break;
+                        }
+                    } else {
+                        i += 1;
+                    }
+                }
+            }
+            _ => {
+                if i + 2 > data.len() {
+                    return None;
+                }
+                let seg_len = u16::from_be_bytes([data[i], data[i + 1]]) as usize;
+                if seg_len < 2 {
+                    return None;
+                }
+                i += seg_len;
+            }
+        }
+    }
+}
+
+/// Apply EXIF orientation to a JPEG thumbnail.
+/// 1=Normal, 2=Flip H, 3=Rotate 180, 4=Flip V, 5=Transpose, 6=Rotate 90 CW, 7=Transverse, 8=Rotate 270 CW
+fn apply_exif_rotation(jpeg_bytes: &[u8], orientation: u16) -> Option<Vec<u8>> {
+    // Only apply rotations; for simplicity, return original if non-standard
+    match orientation {
+        1 => Some(jpeg_bytes.to_vec()), // Normal
+        6 => {
+            // Rotate 90 CW
+            let img = image::load_from_memory_with_format(jpeg_bytes, image::ImageFormat::Jpeg).ok()?;
+            let rotated = img.rotate90();
+            let mut buf = std::io::Cursor::new(Vec::new());
+            rotated.write_to(&mut buf, image::ImageFormat::Jpeg).ok()?;
+            Some(buf.into_inner())
+        }
+        3 => {
+            // Rotate 180
+            let img = image::load_from_memory_with_format(jpeg_bytes, image::ImageFormat::Jpeg).ok()?;
+            let rotated = img.rotate180();
+            let mut buf = std::io::Cursor::new(Vec::new());
+            rotated.write_to(&mut buf, image::ImageFormat::Jpeg).ok()?;
+            Some(buf.into_inner())
+        }
+        8 => {
+            // Rotate 270 CW (same as 90 CCW)
+            let img = image::load_from_memory_with_format(jpeg_bytes, image::ImageFormat::Jpeg).ok()?;
+            let rotated = img.rotate270();
+            let mut buf = std::io::Cursor::new(Vec::new());
+            rotated.write_to(&mut buf, image::ImageFormat::Jpeg).ok()?;
+            Some(buf.into_inner())
+        }
+        _ => Some(jpeg_bytes.to_vec()), // Return original for flip operations (2,4,5,7)
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1824,6 +1824,7 @@ fn frontend_ready(
     let is_first_run = !state
         .window_setup_complete
         .swap(true, std::sync::atomic::Ordering::Relaxed);
+
     #[cfg(target_os = "android")]
     let _ = (is_first_run, &window);
 
@@ -2228,6 +2229,8 @@ pub fn run() {
             full_warped_cache: Mutex::new(None),
             full_transformed_cache: Mutex::new(None),
             decoded_image_cache: Mutex::new(DecodedImageCache::new(5)),
+            tiny_preview_queue: ThumbnailManager::new(),
+            embedded_preview_queue: ThumbnailManager::new(),
             thumbnail_manager: ThumbnailManager::new(),
         })
         .invoke_handler(tauri::generate_handler![

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -493,8 +493,21 @@ function App() {
     color: 15,
   });
   const { showContextMenu } = useContextMenu();
-  const [thumbnails, setThumbnails] = useState<Record<string, string>>({});
-  const { requestThumbnails, clearThumbnailQueue, markGenerated } = useThumbnails();
+  const { thumbnails, getThumbnailForPath, requestThumbnails, clearThumbnailQueue, markGenerated } = useThumbnails(
+    appSettings,
+    supportedTypes,
+  );
+
+  // Update selectedImage thumbnail URL whenever a better thumbnail becomes available
+  useEffect(() => {
+    if (selectedImage?.path) {
+      const newThumbnailUrl = getThumbnailForPath(selectedImage.path);
+      if (newThumbnailUrl && newThumbnailUrl !== selectedImage.thumbnailUrl) {
+        setSelectedImage((prev) => (prev ? { ...prev, thumbnailUrl: newThumbnailUrl } : null));
+      }
+    }
+  }, [getThumbnailForPath, selectedImage?.path, selectedImage?.thumbnailUrl]);
+
   const [thumbnailProgress, setThumbnailProgress] = useState<Progress>({ current: 0, total: 0 });
   const transformWrapperRef = useRef<any>(null);
   const isProgrammaticZoom = useRef(false);
@@ -2195,7 +2208,6 @@ function App() {
       setIsViewLoading(true);
       setSearchCriteria({ tags: [], text: '', mode: 'OR' });
       setLibraryScrollTop(0);
-      setThumbnails({});
       imageCacheRef.current.clear();
       try {
         setCurrentFolderPath(path);
@@ -2553,7 +2565,7 @@ function App() {
       if (isFrontendCached) {
         setSelectedImage({
           ...cached.selectedImage,
-          thumbnailUrl: thumbnails[path] || cached.selectedImage.thumbnailUrl,
+          thumbnailUrl: getThumbnailForPath(path) || cached.selectedImage.thumbnailUrl,
         });
         setOriginalSize(cached.originalSize);
         setPreviewSize(cached.previewSize);
@@ -2617,7 +2629,7 @@ function App() {
         metadata: null,
         originalUrl: null,
         path,
-        thumbnailUrl: thumbnails[path],
+        thumbnailUrl: getThumbnailForPath(path),
         width: 0,
       });
       setOriginalSize({ width: 0, height: 0 });
@@ -3419,18 +3431,6 @@ function App() {
       listen('thumbnail-generation-complete', () => {
         if (isEffectActive) {
           setThumbnailProgress({ current: 0, total: 0 });
-        }
-      }),
-      listen('thumbnail-generated', (event: any) => {
-        if (isEffectActive) {
-          const { path, data, rating } = event.payload;
-          if (data) {
-            setThumbnails((prev) => ({ ...prev, [path]: data }));
-            markGenerated(path);
-          }
-          if (rating !== undefined) {
-            setImageRatings((prev) => ({ ...prev, [path]: rating }));
-          }
         }
       }),
       listen('ai-model-download-start', (event: any) => {
@@ -5828,9 +5828,9 @@ function App() {
         isProcessing={panoramaModalState.isProcessing}
         loadingImageUrl={
           panoramaModalState.stitchingSourcePaths.length > 0
-            ? thumbnails[
-                panoramaModalState.stitchingSourcePaths[Math.floor(panoramaModalState.stitchingSourcePaths.length / 2)]
-              ] || null
+            ? getThumbnailForPath(
+                panoramaModalState.stitchingSourcePaths[Math.floor(panoramaModalState.stitchingSourcePaths.length / 2)],
+              ) || null
             : null
         }
         onClose={() =>
@@ -5856,9 +5856,9 @@ function App() {
         isProcessing={hdrModalState.isProcessing}
         loadingImageUrl={
           hdrModalState.stitchingSourcePaths.length > 0
-            ? thumbnails[
-                hdrModalState.stitchingSourcePaths[Math.floor(hdrModalState.stitchingSourcePaths.length / 2)]
-              ] || null
+            ? getThumbnailForPath(
+                hdrModalState.stitchingSourcePaths[Math.floor(hdrModalState.stitchingSourcePaths.length / 2)],
+              ) || null
             : null
         }
         onClose={() =>
@@ -5907,7 +5907,7 @@ function App() {
         targetPaths={denoiseModalState.targetPaths}
         loadingImageUrl={
           denoiseModalState.targetPaths.length > 0
-            ? thumbnails[denoiseModalState.targetPaths[0]] ||
+            ? getThumbnailForPath(denoiseModalState.targetPaths[0]) ||
               (selectedImage?.path === denoiseModalState.targetPaths[0] ? finalPreviewUrl : null)
             : null
         }

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1657,6 +1657,20 @@ export default function SettingsPanel({
                     </SettingItem>
 
                     <SettingItem
+                      label="Use Embedded JPEG Thumbnails"
+                      description="Extracts embedded JPEG thumbnails from RAW files for quick previews (inaccurate)."
+                    >
+                      <Switch
+                        checked={appSettings?.useEmbeddedJpegThumbnails ?? true}
+                        id="embedded-jpeg-thumbnails-toggle"
+                        label="Enable Embedded JPEG Thumbnails"
+                        onChange={(checked) => {
+                          onSettingsChange({ ...appSettings, useEmbeddedJpegThumbnails: checked });
+                        }}
+                      />
+                    </SettingItem>
+
+                    <SettingItem
                       label="RAW Highlight Recovery"
                       description="Controls how much detail is recovered from clipped highlights in RAW files. Higher values recover more detail but can introduce purple artefacts."
                     >

--- a/src/hooks/useThumbnails.tsx
+++ b/src/hooks/useThumbnails.tsx
@@ -1,10 +1,64 @@
-import { useRef, useCallback, useMemo, useEffect } from 'react';
+import { useRef, useCallback, useMemo, useEffect, useState } from 'react';
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import debounce from 'lodash.debounce';
+import { SupportedTypes } from '../components/ui/AppProperties';
 
-export function useThumbnails() {
+interface ThumbnailSet {
+  Preview?: string; // Full generated thumbnail (best quality)
+  Embedded?: string; // Full embedded preview
+  Tiny?: string; // Tiny preview from 64KB
+}
+
+export function useThumbnails(appSettings?: any, supportedTypes?: SupportedTypes) {
   const generatedRef = useRef<Set<string>>(new Set());
   const pendingQueueRef = useRef<Set<string>>(new Set());
+  const [thumbnails, setThumbnails] = useState<Record<string, ThumbnailSet>>({});
+
+  // Clear thumbnails when embedded preview setting changes (to refresh display)
+  useEffect(() => {
+    setThumbnails({});
+  }, [appSettings?.useEmbeddedJpegThumbnails]);
+
+  // Get best available thumbnail for a path (Preview > Embedded > Tiny)
+  const getThumbnailForPath = useCallback(
+    (path: string): string | undefined => {
+      const thumbnailSet = thumbnails[path];
+      const shouldUseEmbedded = appSettings?.useEmbeddedJpegThumbnails ?? true;
+
+      // If embedded previews disabled for RAW files, only use actual Preview
+      if (!shouldUseEmbedded && supportedTypes) {
+        const fileExtension = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
+        if (supportedTypes.raw.some((t) => t.toLowerCase() === fileExtension)) {
+          return thumbnailSet?.Preview;
+        }
+      }
+
+      return thumbnailSet?.Preview || thumbnailSet?.Embedded || thumbnailSet?.Tiny;
+    },
+    [thumbnails, appSettings?.useEmbeddedJpegThumbnails, supportedTypes],
+  );
+
+  const flatThumbnails = useMemo(() => {
+    const result: Record<string, string> = {};
+    const shouldUseEmbedded = appSettings?.useEmbeddedJpegThumbnails ?? true;
+
+    for (const [path, thumbnailSet] of Object.entries(thumbnails)) {
+      // If embedded previews disabled for RAW files, only use actual Preview
+      if (!shouldUseEmbedded && supportedTypes) {
+        const fileExtension = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
+        const isRaw = supportedTypes.raw.some((t) => t.toLowerCase() === fileExtension);
+        if (isRaw) {
+          if (thumbnailSet?.Preview) result[path] = thumbnailSet.Preview;
+          continue;
+        }
+      }
+
+      const bestThumbnail = thumbnailSet?.Preview || thumbnailSet?.Embedded || thumbnailSet?.Tiny;
+      if (bestThumbnail) result[path] = bestThumbnail;
+    }
+    return result;
+  }, [thumbnails, appSettings?.useEmbeddedJpegThumbnails, supportedTypes]);
 
   const flushQueueToBackend = useMemo(
     () =>
@@ -57,12 +111,68 @@ export function useThumbnails() {
     generatedRef.current.clear();
     pendingQueueRef.current.clear();
     flushQueueToBackend.cancel();
+    setThumbnails({});
     invoke('update_thumbnail_queue', { paths: [] }).catch(console.error);
   }, [flushQueueToBackend]);
 
+  // Set up event listeners for thumbnail generation
   useEffect(() => {
-    return () => flushQueueToBackend.cancel();
-  }, [flushQueueToBackend]);
+    let unlistenEmbedded: (() => void) | null = null;
+    let unlistenThumbnail: (() => void) | null = null;
 
-  return { requestThumbnails, clearThumbnailQueue, markGenerated };
+    (async () => {
+      unlistenEmbedded = await listen('embedded-preview-generated', (event: any) => {
+        const { path, data, type: previewType } = event.payload;
+        if (data) {
+          setThumbnails((prev) => {
+            const current = prev[path];
+            // If we already have a Preview, don't add anything
+            if (current?.Preview) {
+              return prev;
+            }
+            // Route to correct tier based on type
+            if (previewType === 'tiny') {
+              return {
+                ...prev,
+                [path]: { ...current, Tiny: data },
+              };
+            } else if (previewType === 'embedded') {
+              // Embedded replaces Tiny
+              return {
+                ...prev,
+                [path]: { Preview: current?.Preview, Embedded: data },
+              };
+            }
+            return prev;
+          });
+        }
+      });
+
+      unlistenThumbnail = await listen('thumbnail-generated', (event: any) => {
+        const { path, data } = event.payload;
+        if (data) {
+          // Full Preview - clear all lower tiers
+          setThumbnails((prev) => ({
+            ...prev,
+            [path]: { Preview: data },
+          }));
+          markGenerated(path);
+        }
+      });
+    })();
+
+    return () => {
+      unlistenEmbedded?.();
+      unlistenThumbnail?.();
+      flushQueueToBackend.cancel();
+    };
+  }, [markGenerated, flushQueueToBackend]);
+
+  return {
+    thumbnails: flatThumbnails,
+    getThumbnailForPath,
+    requestThumbnails,
+    clearThumbnailQueue,
+    markGenerated,
+  };
 }


### PR DESCRIPTION
This commit expands the thumbnail generation system to include two new tiers of embedded JPEG previews:

For RAW files:
- "Tiny" previews are extracted from the first 64K of a file
  - These are also scanned for any orientation metadata which is applied if present.
- "Embedded" previews extract the full embedded JPEG preview
  - These can be significantly larger than the tiny previews, on Fuji RAF files for example they can be ~1MB in size, but they are still much faster to decode than generating a thumbnail from the RAW data.

For JPEG files:
- Only "Tiny" previews are extracted

This commit also adds a new setting (default enabled) to allow users to disable the use of embedded JPEG thumbnails on RAWs if they prefer.

From a usability and first time user experience perspective this is a huge improvement especially when browsing large libraries of RAW and JPEG files. Other RAW editors utilize these embedded previews so I believe users will understand that final thumbnails will be more accurate.

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

Backend:
- Spawns two new workers for tiny/embedded previews
- Adds scanning of files for tiny/embedded previews
  - More efficient scanning for RAF files, (Fuji) others can come later
- Adds setting for disabling RAW embedded previews
  - Even off, tiny previews are used for JPEG files

Frontend: 
- Extract a few Thumbnail state providers into the useThumbnails hook
- Add "flattening" the 3 possible thumbnails for consumers of thumbnails (Selects best possible thumbnail available and only gives that one to components)

## Screenshots/Videos

https://github.com/user-attachments/assets/a98f039f-a051-45d7-bde9-da1802099377

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Bazzite  Linux 6.17.7-ba29.fc43.x86_64
- **Hardware:** Ryzen 5800X3D, Radeon RX9070 XT, 32GB memory
- Tested with Fujifilm RAF and JPEG files only. More testing would be great but if a preview fails nothing happens other than old behavior.

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [X] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

AI was instrumental in writing the actual extraction logic of JPEG previews.
