### PR TITLE
fix: tooltip stays on the page

### DIFF
--- a/src/components/ui/GlobalTooltip.tsx
+++ b/src/components/ui/GlobalTooltip.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useLayoutEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { AnimatePresence, motion } from 'framer-motion';
 import clsx from 'clsx';
@@ -7,19 +7,24 @@ import { TextColors, TextVariants, TextWeights } from '../../types/typography';
 
 const TOOLTIP_DELAY = 500;
 const OFFSET = 8;
+const TOOLTIP_VIEWPORT_MARGIN = 12;
+
+const clamp = (value: number, min: number, max: number) => Math.max(min, Math.min(value, max));
 
 interface TooltipData {
   content: string;
-  x: number;
+  centerX: number;
   y: number;
   isAbove: boolean;
 }
 
 export default function GlobalTooltip() {
   const [tooltip, setTooltip] = useState<TooltipData | null>(null);
+  const [leftOverride, setLeftOverride] = useState<number | null>(null);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const targetRef = useRef<HTMLElement | null>(null);
   const rafRef = useRef<number>(0);
+  const tooltipRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const clearTimer = () => {
@@ -48,18 +53,16 @@ export default function GlobalTooltip() {
       if (!content) return null;
 
       const rect = el.getBoundingClientRect();
-      let x = rect.left + rect.width / 2;
+      const centerX = rect.left + rect.width / 2;
       let y = rect.bottom + OFFSET;
       let isAbove = false;
-
-      x = Math.max(20, Math.min(x, window.innerWidth - 20));
 
       if (y + 40 > window.innerHeight) {
         y = rect.top - OFFSET;
         isAbove = true;
       }
 
-      return { content, x, y, isAbove };
+      return { content, centerX, y, isAbove };
     };
 
     const watchTarget = () => {
@@ -99,6 +102,7 @@ export default function GlobalTooltip() {
           return;
         }
 
+        setLeftOverride(null);
         setTooltip(data);
         watchTarget();
       }, TOOLTIP_DELAY);
@@ -141,16 +145,41 @@ export default function GlobalTooltip() {
     };
   }, []);
 
+  useLayoutEffect(() => {
+    if (!tooltip) {
+      if (leftOverride !== null) setLeftOverride(null);
+      return;
+    }
+
+    const el = tooltipRef.current;
+    if (!el) return;
+
+    const width = el.offsetWidth;
+    const minLeft = TOOLTIP_VIEWPORT_MARGIN;
+    const maxLeft = Math.max(minLeft, window.innerWidth - TOOLTIP_VIEWPORT_MARGIN - width);
+    const desiredLeft = tooltip.centerX - width / 2;
+    const clampedLeft = clamp(desiredLeft, minLeft, maxLeft);
+    // Compensate for the -50% translateX so the original animation stays identical.
+    const adjustedCenterX = clampedLeft + width / 2;
+
+    if (leftOverride !== adjustedCenterX) {
+      setLeftOverride(adjustedCenterX);
+    }
+  }, [tooltip, leftOverride]);
+
+  const left = leftOverride !== null ? leftOverride : tooltip?.centerX ?? 0;
+
   return createPortal(
     <AnimatePresence mode="wait">
       {tooltip && (
         <motion.div
+          ref={tooltipRef}
           key={tooltip.content}
           initial={{ opacity: 0, scale: 0.9, y: tooltip.isAbove ? 5 : -5, x: '-50%' }}
           animate={{ opacity: 1, scale: 1, y: tooltip.isAbove ? -10 : 0, x: '-50%' }}
           exit={{ opacity: 0, scale: 0.9, x: '-50%' }}
           transition={{ duration: 0.15, ease: 'easeOut' }}
-          style={{ top: tooltip.y, left: tooltip.x }}
+          style={{ top: tooltip.y, left }}
           className={clsx(
             'fixed z-100 pointer-events-none',
             'bg-surface/80 backdrop-blur-xs',


### PR DESCRIPTION
## Description
Tooltips could be clipped by the edge of the page

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Measure the actual width of the tooltip and use that to determine place on the page

## Screenshots/Videos
Before:
<img width="347" height="205" alt="Screenshot 2026-05-09 at 09 28 26" src="https://github.com/user-attachments/assets/eb45c171-25f0-4213-a7d9-189e90249619" />

After:
<img width="444" height="276" alt="Screenshot 2026-05-09 at 09 30 25" src="https://github.com/user-attachments/assets/86423951-26f1-4986-b484-d54257787504" />

Existing remains the same:
<img width="346" height="158" alt="Screenshot 2026-05-09 at 09 30 33" src="https://github.com/user-attachments/assets/07c00fcf-bb4b-4469-aeda-66f4c2223a19" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues
     - [x] Tried out a few different tooltips to see that they still work as expected.

**Test Configuration:**
- **OS:** (Tahoe 26.3)
- **Hardware:** (M4 Mac Mini)

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)