### PR TITLE
fix: canvas renderer layer for live preview

### DIFF
--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -20,6 +20,8 @@ import { useSettingsStore } from '../../store/useSettingsStore';
 import { useUIStore } from '../../store/useUIStore';
 import { useLibraryStore } from '../../store/useLibraryStore';
 import { useAiMasking } from '../../hooks/useAiMasking';
+import { usePreviewCanvas } from './editor/usePreviewCanvas';
+import type { InteractivePatch } from '../../store/useEditorStore';
 
 const parseRgb = (rgbStr: string): [number, number, number, number] => {
   const match = rgbStr.match(/[\d.]+/g);
@@ -297,6 +299,64 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
   const imageRenderSizeRef = useRef(imageRenderSize);
   imageRenderSizeRef.current = imageRenderSize;
 
+  const isWgpuActive = appSettings?.useWgpuRenderer !== false && hasRenderedFirstFrame;
+  const isMaxZoomRef = useRef(false);
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null);
+
+  const [displayState, setDisplayState] = useState<{ base: string | null; fade: string | null }>({
+    base: finalPreviewUrl || selectedImage?.thumbnailUrl || null,
+    fade: null,
+  });
+  const prevImageIdentityRef = useRef(selectedImage?.thumbnailUrl);
+  const retainedPatchRef = useRef<InteractivePatch | null>(null);
+
+  useEffect(() => {
+    if (interactivePatch) retainedPatchRef.current = interactivePatch;
+  }, [interactivePatch]);
+
+  useEffect(() => {
+    const newSrc = finalPreviewUrl || selectedImage?.thumbnailUrl || null;
+    const isNewImage = prevImageIdentityRef.current !== selectedImage?.thumbnailUrl;
+    if (isNewImage) {
+      prevImageIdentityRef.current = selectedImage?.thumbnailUrl;
+      setDisplayState({ base: newSrc, fade: null });
+      return;
+    }
+    if (isSliderDragging) {
+      setDisplayState({ base: newSrc, fade: null });
+    } else {
+      if (displayState.base !== newSrc && displayState.base) {
+        setDisplayState((prev) => ({ base: prev.base, fade: newSrc }));
+        const timer = setTimeout(() => setDisplayState({ base: newSrc, fade: null }), 150);
+        return () => clearTimeout(timer);
+      } else {
+        setDisplayState({ base: newSrc, fade: null });
+      }
+    }
+  }, [finalPreviewUrl, selectedImage?.thumbnailUrl, isSliderDragging]);
+
+  const currentTarget = finalPreviewUrl || selectedImage?.thumbnailUrl || null;
+  const baseIsReady = displayState.base === currentTarget && !displayState.fade;
+  const visiblePatch: InteractivePatch | null = interactivePatch ?? (baseIsReady ? null : retainedPatchRef.current);
+
+  useEffect(() => {
+    if (baseIsReady && !interactivePatch) retainedPatchRef.current = null;
+  }, [baseIsReady, interactivePatch]);
+
+  const { draw: drawPreview } = usePreviewCanvas({
+    canvasRef: previewCanvasRef,
+    containerRef: imageContainerRef,
+    baseUrl: displayState.base,
+    fadeUrl: displayState.fade,
+    patch: visiblePatch,
+    transformRef: transformStateRef,
+    imageRenderSizeRef,
+    isMaxZoomRef,
+    enabled: !isWgpuActive,
+  });
+  const drawPreviewRef = useRef(drawPreview);
+  drawPreviewRef.current = drawPreview;
+
   const transformConfig = useMemo(() => {
     if (!selectedImage || !imageRenderSize.scale || !originalSize) {
       return { minScale: 0.1, maxScale: 20 };
@@ -378,6 +438,8 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
       if (contentRef.current) {
         contentRef.current.style.transform = `translate(${x}px, ${y}px) scale(${scale})`;
       }
+
+      drawPreviewRef.current();
 
       if (!isTransitioningRef.current) {
         if (scale > 1.01) {
@@ -1899,6 +1961,7 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
 
   const isZoomActionActive = !isCropping && !isMasking && !isAiEditing && !isWbPickerActive;
   const isMaxZoom = transformState.scale >= maxScaleRef.current - 0.5;
+  isMaxZoomRef.current = isMaxZoom;
 
   let cursorStyle = 'default';
   if (isZoomActionActive) {
@@ -1910,8 +1973,6 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
       cursorStyle = 'zoom-in';
     }
   }
-
-  const isWgpuActive = appSettings?.useWgpuRenderer !== false && hasRenderedFirstFrame;
 
   return (
     <div
@@ -1972,12 +2033,18 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
           </div>
         )}
 
+        {!isWgpuActive && (
+          <canvas ref={previewCanvasRef} className="absolute inset-0 pointer-events-none" style={{ zIndex: 1 }} />
+        )}
+
         <div
           ref={contentRef}
           className="w-full h-full flex items-center justify-center touch-none origin-top-left"
           style={{
             transform: `translate(${transformState.positionX}px, ${transformState.positionY}px) scale(${transformState.scale})`,
             cursor: cursorStyle,
+            position: 'relative',
+            zIndex: 2,
           }}
           onPointerDown={handlePointerDown}
           onPointerMove={handlePointerMove}

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -855,69 +855,10 @@ const ImageCanvas = memo(
     const [straightenLine, setStraightenLine] = useState<any>(null);
     const isStraightening = useRef(false);
 
-    const [displayState, setDisplayState] = useState({
-      base: finalPreviewUrl || selectedImage.thumbnailUrl,
-      fade: null as string | null,
-    });
-    const [isFadingIn, setIsFadingIn] = useState(false);
-    const prevImageIdentityRef = useRef(selectedImage.thumbnailUrl);
-
     const [baseTool, setBaseTool] = useState<ToolType>(brushSettings?.tool ?? ToolType.Brush);
     const [isAltPressed, setIsAltPressed] = useState(false);
-    const retainedPatchRef = useRef<typeof interactivePatch>(null);
 
     const isWgpuActive = appSettings?.useWgpuRenderer !== false && selectedImage?.isReady && hasRenderedFirstFrame;
-
-    useEffect(() => {
-      if (interactivePatch) {
-        retainedPatchRef.current = interactivePatch;
-      }
-    }, [interactivePatch]);
-
-    useEffect(() => {
-      const newSrc = finalPreviewUrl || selectedImage.thumbnailUrl;
-      const isNewImage = prevImageIdentityRef.current !== selectedImage.thumbnailUrl;
-
-      if (isNewImage) {
-        prevImageIdentityRef.current = selectedImage.thumbnailUrl;
-        setDisplayState({ base: newSrc, fade: null });
-        setIsFadingIn(false);
-        return;
-      }
-
-      if (isSliderDragging) {
-        setDisplayState({ base: newSrc, fade: null });
-        setIsFadingIn(false);
-      } else {
-        if (displayState.base !== newSrc && displayState.base) {
-          setDisplayState((prev) => ({ base: prev.base, fade: newSrc }));
-          setIsFadingIn(false);
-
-          let frame1: number;
-          let frame2: number;
-
-          frame1 = requestAnimationFrame(() => {
-            frame2 = requestAnimationFrame(() => {
-              setIsFadingIn(true);
-            });
-          });
-
-          const timer = setTimeout(() => {
-            setDisplayState({ base: newSrc, fade: null });
-            setIsFadingIn(false);
-          }, 150);
-
-          return () => {
-            cancelAnimationFrame(frame1);
-            cancelAnimationFrame(frame2);
-            clearTimeout(timer);
-          };
-        } else {
-          setDisplayState({ base: newSrc, fade: null });
-          setIsFadingIn(false);
-        }
-      }
-    }, [finalPreviewUrl, selectedImage.thumbnailUrl, isSliderDragging]);
 
     useEffect(() => {
       setBaseTool(brushSettings?.tool ?? ToolType.Brush);
@@ -1925,17 +1866,6 @@ const ImageCanvas = memo(
       };
     }, [originalSrc]);
 
-    const currentTarget = finalPreviewUrl || selectedImage.thumbnailUrl;
-    const baseIsReady = displayState.base === currentTarget && !displayState.fade;
-
-    const visiblePatch = interactivePatch ?? (baseIsReady ? null : retainedPatchRef.current);
-
-    useEffect(() => {
-      if (baseIsReady && !interactivePatch) {
-        retainedPatchRef.current = null;
-      }
-    }, [baseIsReady, interactivePatch]);
-
     const uncroppedImageRenderSize = useMemo<Partial<RenderSize> | null>(() => {
       if (!selectedImage?.width || !selectedImage?.height || !imageRenderSize?.width || !imageRenderSize?.height) {
         return null;
@@ -2034,67 +1964,6 @@ const ImageCanvas = memo(
             }}
           >
             <div className="absolute inset-0 w-full h-full">
-              <svg
-                className="pointer-events-none"
-                style={
-                  imageRenderSize.width > 0 && imageRenderSize.height > 0
-                    ? {
-                        position: 'absolute',
-                        left: `${imageRenderSize.offsetX}px`,
-                        top: `${imageRenderSize.offsetY}px`,
-                        width: `${imageRenderSize.width}px`,
-                        height: `${imageRenderSize.height}px`,
-                        overflow: 'visible',
-                      }
-                    : {
-                        position: 'absolute',
-                        inset: '0px',
-                        width: '100%',
-                        height: '100%',
-                        overflow: 'visible',
-                      }
-                }
-                preserveAspectRatio={imageRenderSize.width > 0 && imageRenderSize.height > 0 ? 'none' : 'xMidYMid meet'}
-              >
-                {displayState.base && !isWgpuActive && (
-                  <image
-                    href={displayState.base}
-                    x="0"
-                    y="0"
-                    width="100%"
-                    height="100%"
-                    style={{ imageRendering: isMaxZoom ? 'pixelated' : 'auto' }}
-                  />
-                )}
-
-                {displayState.fade && !isWgpuActive && (
-                  <image
-                    href={displayState.fade}
-                    x="0"
-                    y="0"
-                    width="100%"
-                    height="100%"
-                    style={{
-                      imageRendering: isMaxZoom ? 'pixelated' : 'auto',
-                      opacity: isFadingIn ? 1 : 0,
-                      transition: 'opacity 150ms ease-in-out',
-                    }}
-                  />
-                )}
-
-                {visiblePatch && !isWgpuActive && (
-                  <image
-                    href={visiblePatch.url}
-                    x={`${visiblePatch.normX * 100}%`}
-                    y={`${visiblePatch.normY * 100}%`}
-                    width={`${visiblePatch.normW * 100}%`}
-                    height={`${visiblePatch.normH * 100}%`}
-                    preserveAspectRatio="none"
-                    style={{ imageRendering: isMaxZoom ? 'pixelated' : 'auto' }}
-                  />
-                )}
-              </svg>
-
               {originalSrc && (
                 <img
                   alt="Original"

--- a/src/components/panel/editor/usePreviewCanvas.ts
+++ b/src/components/panel/editor/usePreviewCanvas.ts
@@ -1,0 +1,203 @@
+import { useRef, useEffect, useCallback } from 'react';
+import type { RenderSize } from '../../../hooks/useImageRenderSize';
+import type { InteractivePatch } from '../../../store/useEditorStore';
+
+interface TransformState {
+  positionX: number;
+  positionY: number;
+  scale: number;
+}
+
+interface Options {
+  canvasRef: React.RefObject<HTMLCanvasElement | null>;
+  containerRef: React.RefObject<HTMLElement | null>;
+  baseUrl: string | null;
+  fadeUrl: string | null;
+  patch: InteractivePatch | null;
+  transformRef: React.RefObject<TransformState>;
+  imageRenderSizeRef: React.RefObject<RenderSize>;
+  isMaxZoomRef: React.RefObject<boolean>;
+  enabled: boolean;
+}
+
+export function usePreviewCanvas({
+  canvasRef,
+  containerRef,
+  baseUrl,
+  fadeUrl,
+  patch,
+  transformRef,
+  imageRenderSizeRef,
+  isMaxZoomRef,
+  enabled,
+}: Options) {
+  const baseImgRef = useRef<HTMLImageElement | null>(null);
+  const fadeImgRef = useRef<HTMLImageElement | null>(null);
+  const patchImgRef = useRef<HTMLImageElement | null>(null);
+  const fadeOpacityRef = useRef(0);
+  const fadeAnimRef = useRef<number | null>(null);
+  const patchRef = useRef(patch);
+  patchRef.current = patch;
+  const drawRef = useRef<() => void>(() => {});
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    const container = containerRef.current;
+    if (!canvas || !container || !enabled) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    const cW = container.clientWidth;
+    const cH = container.clientHeight;
+
+    const targetW = Math.round(cW * dpr);
+    const targetH = Math.round(cH * dpr);
+    if (canvas.width !== targetW || canvas.height !== targetH) {
+      canvas.width = targetW;
+      canvas.height = targetH;
+      canvas.style.width = `${cW}px`;
+      canvas.style.height = `${cH}px`;
+    }
+
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    const { positionX: tx, positionY: ty, scale: s } = transformRef.current;
+    const { width: rW, height: rH, offsetX: oX, offsetY: oY } = imageRenderSizeRef.current;
+    if (rW <= 0 || rH <= 0) return;
+
+    // Image bounds in container CSS pixels, accounting for the CSS transform on contentRef
+    const imgL = tx + oX * s;
+    const imgT = ty + oY * s;
+    const imgScaledW = rW * s;
+    const imgScaledH = rH * s;
+
+    // Clip to container bounds
+    const visL = Math.max(0, imgL);
+    const visT = Math.max(0, imgT);
+    const visR = Math.min(cW, imgL + imgScaledW);
+    const visB = Math.min(cH, imgT + imgScaledH);
+    if (visR <= visL || visB <= visT) return;
+
+    ctx.imageSmoothingEnabled = !isMaxZoomRef.current;
+    ctx.imageSmoothingQuality = 'high';
+
+    const drawLayer = (img: HTMLImageElement, alpha: number) => {
+      if (alpha <= 0) return;
+      // Map visible container region back to source natural pixels
+      const srcX = ((visL - imgL) / imgScaledW) * img.naturalWidth;
+      const srcY = ((visT - imgT) / imgScaledH) * img.naturalHeight;
+      const srcW = ((visR - visL) / imgScaledW) * img.naturalWidth;
+      const srcH = ((visB - visT) / imgScaledH) * img.naturalHeight;
+      ctx.globalAlpha = alpha;
+      ctx.drawImage(img, srcX, srcY, srcW, srcH, visL * dpr, visT * dpr, (visR - visL) * dpr, (visB - visT) * dpr);
+    };
+
+    if (baseImgRef.current) drawLayer(baseImgRef.current, 1);
+    if (fadeImgRef.current && fadeOpacityRef.current > 0) drawLayer(fadeImgRef.current, fadeOpacityRef.current);
+    ctx.globalAlpha = 1;
+
+    const p = patchRef.current;
+    if (patchImgRef.current && p) {
+      const pImg = patchImgRef.current;
+      const pL = imgL + p.normX * imgScaledW;
+      const pT = imgT + p.normY * imgScaledH;
+      const pW = p.normW * imgScaledW;
+      const pH = p.normH * imgScaledH;
+      const pVisL = Math.max(visL, pL);
+      const pVisT = Math.max(visT, pT);
+      const pVisR = Math.min(visR, pL + pW);
+      const pVisB = Math.min(visB, pT + pH);
+      if (pVisR > pVisL && pVisB > pVisT) {
+        ctx.drawImage(
+          pImg,
+          ((pVisL - pL) / pW) * pImg.naturalWidth,
+          ((pVisT - pT) / pH) * pImg.naturalHeight,
+          ((pVisR - pVisL) / pW) * pImg.naturalWidth,
+          ((pVisB - pVisT) / pH) * pImg.naturalHeight,
+          pVisL * dpr,
+          pVisT * dpr,
+          (pVisR - pVisL) * dpr,
+          (pVisB - pVisT) * dpr,
+        );
+      }
+    }
+  }, [canvasRef, containerRef, transformRef, imageRenderSizeRef, isMaxZoomRef, enabled]);
+
+  drawRef.current = draw;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const ro = new ResizeObserver(() => drawRef.current());
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [containerRef]);
+
+  useEffect(() => {
+    if (!baseUrl) {
+      baseImgRef.current = null;
+      draw();
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      baseImgRef.current = img;
+      draw();
+    };
+    img.src = baseUrl;
+  }, [baseUrl, draw]);
+
+  useEffect(() => {
+    if (fadeAnimRef.current) {
+      cancelAnimationFrame(fadeAnimRef.current);
+      fadeAnimRef.current = null;
+    }
+    if (!fadeUrl) {
+      fadeImgRef.current = null;
+      fadeOpacityRef.current = 0;
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      fadeImgRef.current = img;
+      fadeOpacityRef.current = 0;
+      const t0 = performance.now();
+      const animate = (now: number) => {
+        fadeOpacityRef.current = Math.min((now - t0) / 150, 1);
+        draw();
+        if (fadeOpacityRef.current < 1) {
+          fadeAnimRef.current = requestAnimationFrame(animate);
+        }
+      };
+      fadeAnimRef.current = requestAnimationFrame(animate);
+    };
+    img.src = fadeUrl;
+    return () => {
+      if (fadeAnimRef.current) {
+        cancelAnimationFrame(fadeAnimRef.current);
+        fadeAnimRef.current = null;
+      }
+    };
+  }, [fadeUrl, draw]);
+
+  useEffect(() => {
+    if (!patch?.url) {
+      patchImgRef.current = null;
+      draw();
+      return;
+    }
+    const img = new Image();
+    img.onload = () => {
+      patchImgRef.current = img;
+      draw();
+    };
+    img.src = patch.url;
+  }, [patch?.url, draw]);
+
+  useEffect(() => {
+    draw();
+  }, [enabled, draw]);
+
+  return { draw };
+}


### PR DESCRIPTION
## Description

Solves issue relating to the live preview in some situations being put onto a different compositing/rendering layer resulting in significantly worse image quality in the live preview.

This specifically occurred when the image was zoomed in and then panned in such a way that the heavily scaled image had hidden overflow that would be put behind another div that was scrollable (in the case I found it was the editor side bar).

See here for my original evidence of the issue
https://github.com/CyberTimon/RapidRAW/issues/1160#issuecomment-4507646192

Admittedly I don't have a system I can use that would correctly allow the GPU and enable `isWgpuActive` for me to confirm this is doesn't break that.

At the very least please treat this as a POC that the blurry issue is real and can be solved.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

Image is no longer plainly placed as a pannable image being scaled and moved. The view port previously being calculated is now instead used to render a crop of the original image into a canvas that occupies the live preview viewport. This simplifies the view layers greatly for the system having to render this.  The canvas is never behind other elements (compared to the image which was scaled and translated way out of bounds behind other things with hidden overflow).

Performance should be comperable I couldn't spot a difference by eye. I've only tested on my linux machine though.

Being in a canvas we now have full control of how the cropped viewport of the live preview is rendered.

## Screenshots/Videos

Before

[Screencast from 2026-05-22 22-04-29.webm](https://github.com/user-attachments/assets/c9a20393-72d0-4ced-aa88-24875fdfcc75)

After

[Screencast from 2026-05-22 22-02-18.webm](https://github.com/user-attachments/assets/1113bcbc-5ddf-4a4d-be2d-7677f22c66f4)

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Ubuntu 24.04
- **Hardware:** AMD 7600, AMD 7800XT, QHD Monitor

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

AI did a lot of the math for the translations to put the image into the canvas view. I'm sure this all could be refined further.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

