### PR TITLE
New Compact UI, some adjustments for Android

### DIFF
--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -283,6 +283,10 @@ pub fn default_open_tree_sections() -> Vec<String> {
     vec!["current".to_string()]
 }
 
+pub fn default_ui_mode_option() -> Option<String> {
+    Some("modern".to_string())
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AppSettings {
@@ -307,6 +311,8 @@ pub struct AppSettings {
     pub sort_criteria: Option<SortCriteria>,
     pub filter_criteria: Option<FilterCriteria>,
     pub theme: Option<String>,
+    #[serde(default = "default_ui_mode_option")]
+    pub ui_mode: Option<String>,
     #[serde(default)]
     pub font_family: Option<String>,
     pub decorations: Option<bool>,
@@ -407,6 +413,7 @@ impl Default for AppSettings {
             sort_criteria: None,
             filter_criteria: None,
             theme: Some("dark".to_string()),
+            ui_mode: Some("modern".to_string()),
             font_family: None,
             decorations: Some(false),
             ai_connector_address: None,

--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -284,7 +284,11 @@ pub fn default_open_tree_sections() -> Vec<String> {
 }
 
 pub fn default_ui_mode_option() -> Option<String> {
-    Some("modern".to_string())
+    if cfg!(target_os = "android") {
+        Some("compact".to_string())
+    } else {
+        Some("modern".to_string())
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -413,7 +417,7 @@ impl Default for AppSettings {
             sort_criteria: None,
             filter_criteria: None,
             theme: Some("dark".to_string()),
-            ui_mode: Some("modern".to_string()),
+            ui_mode: default_ui_mode_option(),
             font_family: None,
             decorations: Some(false),
             ai_connector_address: None,

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -32,7 +32,7 @@ import Switch from '../ui/Switch';
 import Input from '../ui/Input';
 import Slider from '../ui/Slider';
 import { ThemeProps, THEMES, DEFAULT_THEME_ID } from '../../utils/themes';
-import { Invokes } from '../ui/AppProperties';
+import { Invokes, UiMode } from '../ui/AppProperties';
 import {
   formatKeyCode,
   KeybindDefinition,
@@ -158,6 +158,11 @@ const linearRawOptions: OptionItem<string>[] = [
 const tonemapperOptions: OptionItem<string>[] = [
   { value: 'agx', label: 'AgX' },
   { value: 'basic', label: 'Basic' },
+];
+
+const uiModeOptions: OptionItem<UiMode>[] = [
+  { value: UiMode.Modern, label: 'Modern' },
+  { value: UiMode.Compact, label: 'Compact' },
 ];
 
 const settingCategories = [
@@ -1005,6 +1010,18 @@ export default function SettingsPanel({
                         onChange={(value: any) => onSettingsChange({ ...appSettings, theme: value })}
                         options={THEMES.map((theme: ThemeProps) => ({ value: theme.id, label: theme.name }))}
                         value={appSettings?.theme || DEFAULT_THEME_ID}
+                        triggerClassName="bg-bg-primary"
+                      />
+                    </SettingItem>
+
+                    <SettingItem
+                      label="UI Style"
+                      description="Choose a spacious modern interface or a denser compact layout."
+                    >
+                      <Dropdown
+                        onChange={(value: UiMode) => onSettingsChange({ ...appSettings, uiMode: value })}
+                        options={uiModeOptions}
+                        value={appSettings?.uiMode || UiMode.Modern}
                         triggerClassName="bg-bg-primary"
                       />
                     </SettingItem>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -536,6 +536,7 @@ export default function SettingsPanel({
   const [tempLensModel, setTempLensModel] = useState<string>('');
 
   const osPlatform = useOsPlatform();
+  const defaultUiMode = osPlatform === 'android' ? UiMode.Compact : UiMode.Modern;
   const [processingSettings, setProcessingSettings] = useState({
     editorPreviewResolution: appSettings?.editorPreviewResolution || 1920,
     thumbnailResolution: appSettings?.thumbnailResolution || 720,
@@ -1021,7 +1022,7 @@ export default function SettingsPanel({
                       <Dropdown
                         onChange={(value: UiMode) => onSettingsChange({ ...appSettings, uiMode: value })}
                         options={uiModeOptions}
-                        value={appSettings?.uiMode || UiMode.Modern}
+                        value={appSettings?.uiMode || defaultUiMode}
                         triggerClassName="bg-bg-primary"
                       />
                     </SettingItem>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1015,8 +1015,8 @@ export default function SettingsPanel({
                     </SettingItem>
 
                     <SettingItem
-                      label="UI Style"
-                      description="Choose a spacious modern interface or a denser compact layout."
+                      label="UI Design"
+                      description="Choose between the default Modern layout and a Compact layout."
                     >
                       <Dropdown
                         onChange={(value: UiMode) => onSettingsChange({ ...appSettings, uiMode: value })}

--- a/src/components/panel/editor/EditorToolbar.tsx
+++ b/src/components/panel/editor/EditorToolbar.tsx
@@ -2,10 +2,11 @@ import { memo, useState, useEffect, useRef, useMemo } from 'react';
 import { Eye, EyeOff, ArrowLeft, Maximize, Loader2, Undo, Redo, Waves } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
-import { SelectedImage } from '../../ui/AppProperties';
+import { SelectedImage, UiMode } from '../../ui/AppProperties';
 import { IconAperture, IconCalendar, IconClock, IconFocalLength, IconIso, IconShutter } from './ExifIcons';
 import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
+import { useSettingsStore } from '../../../store/useSettingsStore';
 
 interface EditorToolbarProps {
   canRedo: boolean;
@@ -55,6 +56,7 @@ const EditorToolbar = memo(
     const [isHistoryVisible, setIsHistoryVisible] = useState(false);
     const historyContainerRef = useRef<HTMLDivElement>(null);
     const historyButtonRef = useRef<HTMLDivElement>(null);
+    const isCompactUi = useSettingsStore((state) => state.appSettings?.uiMode === UiMode.Compact);
 
     const showResolution = !isAndroid && selectedImage.width > 0 && selectedImage.height > 0;
     const [displayedResolution, setDisplayedResolution] = useState('');
@@ -327,12 +329,21 @@ const EditorToolbar = memo(
     };
 
     const isExpanded = isInfoHovered && (hasExif || isLoading);
+    const toolbarButtonPadding = isCompactUi ? 'p-1.5' : 'p-2';
 
     return (
-      <div className="relative shrink-0 flex items-center justify-between px-4 h-14 gap-4 z-40">
+      <div
+        className={clsx(
+          'relative shrink-0 flex items-center justify-between z-40',
+          isCompactUi ? 'px-3 h-10 gap-3' : 'px-4 h-14 gap-4',
+        )}
+      >
         <div className="flex items-center gap-2 shrink-0 z-40">
           <button
-            className="bg-surface text-text-primary p-2 rounded-full hover:bg-card-active transition-colors shrink-0"
+            className={clsx(
+              'bg-surface text-text-primary rounded-full hover:bg-card-active transition-colors shrink-0',
+              toolbarButtonPadding,
+            )}
             onClick={onBackToLibrary}
             onKeyDown={handleButtonKeyDown}
             data-tooltip="Back to Library"
@@ -341,16 +352,16 @@ const EditorToolbar = memo(
           </button>
 
           <div className="hidden 2xl:flex items-center gap-2" aria-hidden="true">
-            <div className="p-2 invisible pointer-events-none">
+            <div className={clsx(toolbarButtonPadding, 'invisible pointer-events-none')}>
               <Undo size={20} />
             </div>
-            <div className="p-2 invisible pointer-events-none">
+            <div className={clsx(toolbarButtonPadding, 'invisible pointer-events-none')}>
               <Undo size={20} />
             </div>
-            <div className="p-2 invisible pointer-events-none">
+            <div className={clsx(toolbarButtonPadding, 'invisible pointer-events-none')}>
               <Undo size={20} />
             </div>
-            <div className="p-2 invisible pointer-events-none">
+            <div className={clsx(toolbarButtonPadding, 'invisible pointer-events-none')}>
               <Undo size={20} />
             </div>
           </div>
@@ -359,15 +370,22 @@ const EditorToolbar = memo(
         <div className="flex-1 flex justify-center min-w-0 relative h-full">
           <div
             className={clsx(
-              'bg-surface flex flex-col items-center overflow-hidden transition-all duration-200 ease-out pt-2',
+              'bg-surface flex flex-col items-center overflow-hidden transition-all duration-200 ease-out',
+              isCompactUi ? 'pt-1' : 'pt-2',
               isExpanded
-                ? 'h-18 px-8 rounded-2xl absolute min-w-[340px] whitespace-nowrap shadow-2xl shadow-black/50'
-                : 'h-9 px-4 rounded-[18px] absolute min-w-0 w-auto max-w-full shadow-none',
+                ? clsx(
+                    'px-8 rounded-2xl absolute min-w-[340px] whitespace-nowrap shadow-2xl shadow-black/50',
+                    isCompactUi ? 'h-16' : 'h-18',
+                  )
+                : clsx(
+                    'px-4 rounded-[18px] absolute min-w-0 w-auto max-w-full shadow-none',
+                    isCompactUi ? 'h-7' : 'h-9',
+                  ),
             )}
             onMouseEnter={() => setIsInfoHovered(true)}
             onMouseLeave={() => setIsInfoHovered(false)}
             style={{
-              top: '10px',
+              top: isCompactUi ? '6px' : '10px',
               transform: 'translateX(-50%)',
               left: '50%',
               zIndex: isExpanded ? 50 : 0,
@@ -525,7 +543,10 @@ const EditorToolbar = memo(
         <div className="flex items-center gap-2 shrink-0 z-40">
           <div className="relative flex items-center gap-2" ref={historyButtonRef}>
             <button
-              className="bg-surface text-text-primary p-2 rounded-full hover:bg-card-active transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className={clsx(
+                'bg-surface text-text-primary rounded-full hover:bg-card-active transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+                toolbarButtonPadding,
+              )}
               disabled={!canUndo}
               onClick={onUndo}
               onKeyDown={handleButtonKeyDown}
@@ -538,7 +559,10 @@ const EditorToolbar = memo(
               <Undo size={20} />
             </button>
             <button
-              className="bg-surface text-text-primary p-2 rounded-full hover:bg-card-active transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className={clsx(
+                'bg-surface text-text-primary rounded-full hover:bg-card-active transition-colors disabled:opacity-50 disabled:cursor-not-allowed',
+                toolbarButtonPadding,
+              )}
               disabled={!canRedo}
               onClick={onRedo}
               onKeyDown={handleButtonKeyDown}
@@ -611,7 +635,8 @@ const EditorToolbar = memo(
 
           <button
             className={clsx(
-              'p-2 rounded-full transition-colors',
+              'rounded-full transition-colors',
+              toolbarButtonPadding,
               showOriginal
                 ? 'bg-accent text-button-text hover:bg-accent/90 hover:text-button-text'
                 : 'bg-surface hover:bg-card-active text-text-primary',
@@ -623,7 +648,10 @@ const EditorToolbar = memo(
             {showOriginal ? <EyeOff size={20} /> : <Eye size={20} />}
           </button>
           <button
-            className="bg-surface text-text-primary p-2 rounded-full hover:bg-card-active transition-colors disabled:opacity-50 disabled:cursor-not-allowed relative"
+            className={clsx(
+              'bg-surface text-text-primary rounded-full hover:bg-card-active transition-colors disabled:opacity-50 disabled:cursor-not-allowed relative',
+              toolbarButtonPadding,
+            )}
             onClick={onToggleFullScreen}
             onKeyDown={handleButtonKeyDown}
             data-tooltip="Toggle Fullscreen (F)"

--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -1735,7 +1735,11 @@ function SettingsPanel({
 
   return (
     <div
-      className={`space-y-2 transition-opacity duration-300 ${!isActive ? 'opacity-50 pointer-events-none' : ''}`}
+      className={clsx(
+        isCompactUi ? 'space-y-0' : 'space-y-2',
+        'transition-opacity duration-300',
+        !isActive && 'opacity-50 pointer-events-none',
+      )}
       onClick={(e) => e.stopPropagation()}
     >
       <CollapsibleSection
@@ -1745,7 +1749,7 @@ function SettingsPanel({
         canToggleVisibility={false}
         isContentVisible={true}
       >
-        <div className="space-y-4 pt-2">
+        <div className={clsx(isCompactUi ? 'space-y-2 pt-1' : 'space-y-4 pt-2')}>
           {aiModelDownloadStatus && aiModelDownloadStatus.includes('Inpainting') && (
             <Text
               as="div"
@@ -1841,7 +1845,7 @@ function SettingsPanel({
         canToggleVisibility={false}
         isContentVisible={true}
       >
-        <div className="space-y-4 pt-2">
+        <div className={clsx(isCompactUi ? 'space-y-2 pt-1' : 'space-y-4 pt-2')}>
           <Switch
             checked={!!(isComponentMode ? activeSubMask.invert : displayContainer.invert)}
             label={isComponentMode ? 'Invert Component' : 'Invert Selection'}

--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -52,7 +52,7 @@ import {
   getSubMaskName,
 } from './Masks';
 import { Adjustments, AiPatch } from '../../../utils/adjustments';
-import { OPTION_SEPARATOR } from '../../ui/AppProperties';
+import { OPTION_SEPARATOR, UiMode } from '../../ui/AppProperties';
 import { createSubMask } from '../../../utils/maskUtils';
 import Text from '../../ui/Text';
 import { TEXT_COLOR_KEYS, TextColors, TextVariants, TextWeights } from '../../../types/typography';
@@ -293,6 +293,7 @@ export default function AIPanel() {
   const { setAdjustments } = useEditorActions();
   const { handleGenerativeReplace, handleDeleteAiPatch, handleGenerateAiForegroundMask } = useAiMasking();
   const appSettings = useSettingsStore((s) => s.appSettings);
+  const isCompactUi = appSettings?.uiMode === UiMode.Compact;
   const aiProvider = appSettings?.aiProvider || 'cpu';
 
   const { user, isSignedIn } = useUser();
@@ -1090,6 +1091,7 @@ export default function AIPanel() {
                   onGenerativeReplace={handleGenerativeReplace}
                   collapsibleState={collapsibleState}
                   setCollapsibleState={setCollapsibleState}
+                  isCompactUi={isCompactUi}
                   isGenerativeAvailable={isGenerativeAvailable}
                 />
               </motion.div>
@@ -1686,6 +1688,7 @@ function SettingsPanel({
   onGenerativeReplace,
   collapsibleState,
   setCollapsibleState,
+  isCompactUi,
   isGenerativeAvailable,
 }: any) {
   const isActive = !!container;
@@ -1737,7 +1740,7 @@ function SettingsPanel({
     >
       <CollapsibleSection
         title="Generative Replace"
-        isOpen={collapsibleState.generative}
+        isOpen={isCompactUi || collapsibleState.generative}
         onToggle={() => handleToggleSection('generative')}
         canToggleVisibility={false}
         isContentVisible={true}
@@ -1833,7 +1836,7 @@ function SettingsPanel({
 
       <CollapsibleSection
         title={isComponentMode ? `${getSubMaskName(activeSubMask)} Properties` : 'Selection Properties'}
-        isOpen={collapsibleState.properties}
+        isOpen={isCompactUi || collapsibleState.properties}
         onToggle={() => handleToggleSection('properties')}
         canToggleVisibility={false}
         isContentVisible={true}

--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -1740,7 +1740,7 @@ function SettingsPanel({
     >
       <CollapsibleSection
         title="Generative Replace"
-        isOpen={isCompactUi || collapsibleState.generative}
+        isOpen={collapsibleState.generative}
         onToggle={() => handleToggleSection('generative')}
         canToggleVisibility={false}
         isContentVisible={true}
@@ -1836,7 +1836,7 @@ function SettingsPanel({
 
       <CollapsibleSection
         title={isComponentMode ? `${getSubMaskName(activeSubMask)} Properties` : 'Selection Properties'}
-        isOpen={isCompactUi || collapsibleState.properties}
+        isOpen={collapsibleState.properties}
         onToggle={() => handleToggleSection('properties')}
         canToggleVisibility={false}
         isContentVisible={true}

--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -63,6 +63,7 @@ import { useProcessStore } from '../../../store/useProcessStore';
 import { useUIStore } from '../../../store/useUIStore';
 import { useEditorActions } from '../../../hooks/useEditorActions';
 import { useAiMasking } from '../../../hooks/useAiMasking';
+import RightPanelHeader, { rightPanelHeaderActionClassName } from './RightPanelHeader';
 
 interface DragData {
   type: 'Container' | 'SubMask' | 'Creation';
@@ -917,16 +918,17 @@ export default function AIPanel() {
       collisionDetection={pointerWithin}
     >
       <div className="flex flex-col h-full select-none overflow-hidden" onContextMenu={handlePanelContextMenu}>
-        <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-          <Text variant={TextVariants.title}>Inpainting</Text>
-          <button
-            className="p-2 rounded-full hover:bg-surface transition-colors"
-            onClick={handleResetAllAiEdits}
-            data-tooltip="Reset Inpainting"
-          >
-            <RotateCcw size={18} />
-          </button>
-        </div>
+        <RightPanelHeader title="Inpainting">
+          {(isCompact) => (
+            <button
+              className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+              onClick={handleResetAllAiEdits}
+              data-tooltip="Reset Inpainting"
+            >
+              <RotateCcw size={18} />
+            </button>
+          )}
+        </RightPanelHeader>
 
         <div className="flex-1 overflow-y-auto overflow-x-hidden flex flex-col min-h-0 p-4">
           <AnimatePresence mode="wait">

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -12,7 +12,7 @@ import Waveform from '../editor/Waveform';
 import Resizer from '../../ui/Resizer';
 import { Adjustments, SectionVisibility, INITIAL_ADJUSTMENTS, ADJUSTMENT_SECTIONS } from '../../../utils/adjustments';
 import { useContextMenu } from '../../../context/ContextMenuContext';
-import { OPTION_SEPARATOR, Orientation } from '../../ui/AppProperties';
+import { OPTION_SEPARATOR, Orientation, UiMode } from '../../ui/AppProperties';
 import Text from '../../ui/Text';
 import { TextVariants } from '../../../types/typography';
 import { useShallow } from 'zustand/react/shallow';
@@ -35,6 +35,7 @@ export default function Controls() {
       theme: state.theme,
     })),
   );
+  const isCompactUi = appSettings?.uiMode === UiMode.Compact;
 
   const { collapsibleSectionsState, setUI } = useUIStore(
     useShallow((state) => ({
@@ -295,7 +296,7 @@ export default function Controls() {
             <div className="shrink-0 group" key={sectionName}>
               <CollapsibleSection
                 isContentVisible={sectionVisibility[sectionName as keyof SectionVisibility]}
-                isOpen={collapsibleSectionsState[sectionName as keyof typeof collapsibleSectionsState]}
+                isOpen={isCompactUi || collapsibleSectionsState[sectionName as keyof typeof collapsibleSectionsState]}
                 onContextMenu={(e: any) => handleSectionContextMenu(e, sectionName)}
                 onToggle={() => handleToggleSection(sectionName)}
                 onToggleVisibility={() => handleToggleVisibility(sectionName)}

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -21,6 +21,7 @@ import { useSettingsStore } from '../../../store/useSettingsStore';
 import { useUIStore } from '../../../store/useUIStore';
 import { useEditorActions } from '../../../hooks/useEditorActions';
 import { useWaveformControls } from '../../../hooks/useWaveformControls';
+import RightPanelHeader, { rightPanelHeaderActionClassName } from './RightPanelHeader';
 
 export default function Controls() {
   const { showContextMenu } = useContextMenu();
@@ -207,37 +208,45 @@ export default function Controls() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-        <Text variant={TextVariants.title}>Adjustments</Text>
-        <div className="flex items-center gap-1">
-          <button
-            className="p-2 rounded-full hover:bg-surface disabled:cursor-not-allowed transition-colors"
-            disabled={!selectedImage?.isReady}
-            onClick={handleAutoAdjustments}
-            data-tooltip="Auto Adjust Image"
-          >
-            <Aperture size={18} />
-          </button>
-          <button
-            className={clsx(
-              'p-2 rounded-full transition-colors',
-              isWaveformVisible ? 'bg-surface hover:bg-card-active' : 'hover:bg-surface',
-            )}
-            onClick={onToggleWaveform}
-            data-tooltip="Toggle Analytics Display"
-          >
-            <ChartArea size={18} />
-          </button>
-          <button
-            className="p-2 rounded-full hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            disabled={!selectedImage}
-            onClick={handleResetAdjustments}
-            data-tooltip="Reset Adjustments"
-          >
-            <RotateCcw size={18} />
-          </button>
-        </div>
-      </div>
+      <RightPanelHeader title="Adjustments">
+        {(isCompact) => (
+          <div className="flex items-center gap-1">
+            <button
+              className={rightPanelHeaderActionClassName(
+                isCompact,
+                'rounded-full hover:bg-surface disabled:cursor-not-allowed',
+              )}
+              disabled={!selectedImage?.isReady}
+              onClick={handleAutoAdjustments}
+              data-tooltip="Auto Adjust Image"
+            >
+              <Aperture size={18} />
+            </button>
+            <button
+              className={rightPanelHeaderActionClassName(
+                isCompact,
+                'rounded-full',
+                isWaveformVisible ? 'bg-surface hover:bg-card-active' : 'hover:bg-surface',
+              )}
+              onClick={onToggleWaveform}
+              data-tooltip="Toggle Analytics Display"
+            >
+              <ChartArea size={18} />
+            </button>
+            <button
+              className={rightPanelHeaderActionClassName(
+                isCompact,
+                'rounded-full hover:bg-surface disabled:opacity-50 disabled:cursor-not-allowed',
+              )}
+              disabled={!selectedImage}
+              onClick={handleResetAdjustments}
+              data-tooltip="Reset Adjustments"
+            >
+              <RotateCcw size={18} />
+            </button>
+          </div>
+        )}
+      </RightPanelHeader>
 
       <AnimatePresence initial={false}>
         {isWaveformVisible && (

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -301,7 +301,7 @@ export default function Controls() {
         )}
       </AnimatePresence>
 
-      <div className="grow overflow-y-auto p-4 flex flex-col gap-2">
+      <div className={clsx('grow overflow-y-auto p-4 flex flex-col', isCompactUi ? 'gap-0' : 'gap-2')}>
         {Object.keys(ADJUSTMENT_SECTIONS).map((sectionName: string) => {
           const SectionComponent: any = {
             basic: BasicAdjustments,

--- a/src/components/panel/right/ControlsPanel.tsx
+++ b/src/components/panel/right/ControlsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { RotateCcw, Copy, ClipboardPaste, Aperture, ChartArea } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
@@ -92,6 +92,28 @@ export default function Controls() {
       })),
     [setUI],
   );
+  const hasAppliedCompactOpenDefaults = useRef(false);
+
+  useEffect(() => {
+    if (!isCompactUi) {
+      hasAppliedCompactOpenDefaults.current = false;
+      return;
+    }
+
+    if (hasAppliedCompactOpenDefaults.current) {
+      return;
+    }
+
+    setCollapsibleState((prev: any) => ({
+      ...prev,
+      basic: true,
+      color: true,
+      curves: true,
+      details: true,
+      effects: true,
+    }));
+    hasAppliedCompactOpenDefaults.current = true;
+  }, [isCompactUi, setCollapsibleState]);
 
   const handleToggleVisibility = (sectionName: string) => {
     setAdjustments((prev: Adjustments) => {
@@ -296,7 +318,7 @@ export default function Controls() {
             <div className="shrink-0 group" key={sectionName}>
               <CollapsibleSection
                 isContentVisible={sectionVisibility[sectionName as keyof SectionVisibility]}
-                isOpen={isCompactUi || collapsibleSectionsState[sectionName as keyof typeof collapsibleSectionsState]}
+                isOpen={collapsibleSectionsState[sectionName as keyof typeof collapsibleSectionsState]}
                 onContextMenu={(e: any) => handleSectionContextMenu(e, sectionName)}
                 onToggle={() => handleToggleSection(sectionName)}
                 onToggleVisibility={() => handleToggleVisibility(sectionName)}

--- a/src/components/panel/right/CropPanel.tsx
+++ b/src/components/panel/right/CropPanel.tsx
@@ -23,6 +23,7 @@ import Slider from '../../ui/Slider';
 import { TEXT_COLOR_KEYS, TextColors, TextVariants, TextWeights } from '../../../types/typography';
 import { useEditorStore } from '../../../store/useEditorStore';
 import { useEditorActions } from '../../../hooks/useEditorActions';
+import RightPanelHeader, { rightPanelHeaderActionClassName } from './RightPanelHeader';
 
 const BASE_RATIO = 1.618;
 const ORIGINAL_RATIO = 0;
@@ -423,16 +424,17 @@ export default function CropPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-        <Text variant={TextVariants.title}>Crop & Transform</Text>
-        <button
-          className="p-2 rounded-full hover:bg-surface transition-colors"
-          onClick={handleReset}
-          data-tooltip="Reset Crop & Transform"
-        >
-          <RotateCcw size={18} />
-        </button>
-      </div>
+      <RightPanelHeader title="Crop & Transform">
+        {(isCompact) => (
+          <button
+            className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+            onClick={handleReset}
+            data-tooltip="Reset Crop & Transform"
+          >
+            <RotateCcw size={18} />
+          </button>
+        )}
+      </RightPanelHeader>
 
       <div className="grow overflow-y-auto p-4 space-y-8">
         {selectedImage ? (

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -29,6 +29,7 @@ import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
 import { useShallow } from 'zustand/react/shallow';
 import { useEditorStore } from '../../../store/useEditorStore';
+import RightPanelHeader from './RightPanelHeader';
 
 interface ExportPanelProps {
   exportState: ExportState;
@@ -524,9 +525,7 @@ export default function ExportPanel({
 
   return (
     <div className="flex flex-col h-full">
-      <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-        <Text variant={TextVariants.title}>Export</Text>
-      </div>
+      <RightPanelHeader title="Export" />
       <div className="grow overflow-y-auto p-4 space-y-8">
         {canExport ? (
           <>

--- a/src/components/panel/right/LibraryExportPanel.tsx
+++ b/src/components/panel/right/LibraryExportPanel.tsx
@@ -26,6 +26,7 @@ import { useExportSettings } from '../../../hooks/useExportSettings';
 import { useOsPlatform } from '../../../hooks/useOsPlatform';
 import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
+import RightPanelHeader, { rightPanelHeaderActionClassName } from './RightPanelHeader';
 
 interface LibraryExportPanelProps {
   exportState: ExportState;
@@ -510,15 +511,19 @@ export default function LibraryExportPanel({
 
   return (
     <div className="h-full bg-bg-secondary rounded-lg flex flex-col">
-      <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-        <Text variant={TextVariants.title}>Export</Text>
-        <button
-          onClick={onClose}
-          className="p-1 rounded-md text-text-secondary hover:bg-surface hover:text-text-primary"
-        >
-          <X size={20} />
-        </button>
-      </div>
+      <RightPanelHeader title="Export">
+        {(isCompact) => (
+          <button
+            onClick={onClose}
+            className={rightPanelHeaderActionClassName(
+              isCompact,
+              'rounded-md text-text-secondary hover:bg-surface hover:text-text-primary',
+            )}
+          >
+            <X size={20} />
+          </button>
+        )}
+      </RightPanelHeader>
       <div className="grow overflow-y-auto p-4 space-y-8">
         {canExport ? (
           <>

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -2349,7 +2349,11 @@ function SettingsPanel({
 
   return (
     <div
-      className={`space-y-2 transition-opacity duration-300 ${!isActive ? 'opacity-50 pointer-events-none' : ''}`}
+      className={clsx(
+        isCompactUi ? 'space-y-0' : 'space-y-2',
+        'transition-opacity duration-300',
+        !isActive && 'opacity-50 pointer-events-none',
+      )}
       onClick={(e) => e.stopPropagation()}
     >
       <CollapsibleSection
@@ -2371,7 +2375,7 @@ function SettingsPanel({
         canToggleVisibility={false}
         isContentVisible={true}
       >
-        <div className="space-y-4 pt-2">
+        <div className={clsx(isCompactUi ? 'space-y-2 pt-1' : 'space-y-4 pt-2')}>
           <Switch
             checked={!!(isComponentMode ? activeSubMask.invert : displayContainer.invert)}
             label={isComponentMode ? 'Invert Component' : 'Invert Mask'}
@@ -2483,7 +2487,7 @@ function SettingsPanel({
       <div
         onMouseEnter={() => setIsMaskControlHovered(true)}
         onMouseLeave={() => setIsMaskControlHovered(false)}
-        className="flex flex-col gap-2"
+        className={clsx('flex flex-col', isCompactUi ? 'gap-0' : 'gap-2')}
       >
         {Object.keys(ADJUSTMENT_SECTIONS).map((sectionName) => {
           const SectionComponent: any = {

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -85,6 +85,7 @@ import { useAiMasking } from '../../../hooks/useAiMasking';
 import { useEditorActions } from '../../../hooks/useEditorActions';
 import { useUIStore } from '../../../store/useUIStore';
 import { useWaveformControls } from '../../../hooks/useWaveformControls';
+import RightPanelHeader, { rightPanelHeaderActionClassName } from './RightPanelHeader';
 
 interface DragData {
   type: 'Container' | 'SubMask' | 'Creation';
@@ -1243,28 +1244,30 @@ export default function MasksPanel() {
       collisionDetection={pointerWithin}
     >
       <div className="flex flex-col h-full select-none overflow-hidden" onContextMenu={handlePanelContextMenu}>
-        <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-          <Text variant={TextVariants.title}>Masking</Text>
-          <div className="flex items-center gap-1">
-            <button
-              className={clsx(
-                'p-2 rounded-full transition-colors',
-                isWaveformVisible ? 'bg-surface hover:bg-card-active' : 'hover:bg-surface',
-              )}
-              onClick={onToggleWaveform}
-              data-tooltip="Toggle Analytics Display"
-            >
-              <ChartArea size={18} />
-            </button>
-            <button
-              className="p-2 rounded-full hover:bg-surface transition-colors"
-              onClick={handleResetAllMasks}
-              data-tooltip="Reset Masking"
-            >
-              <RotateCcw size={18} />
-            </button>
-          </div>
-        </div>
+        <RightPanelHeader title="Masking">
+          {(isCompact) => (
+            <div className="flex items-center gap-1">
+              <button
+                className={rightPanelHeaderActionClassName(
+                  isCompact,
+                  'rounded-full',
+                  isWaveformVisible ? 'bg-surface hover:bg-card-active' : 'hover:bg-surface',
+                )}
+                onClick={onToggleWaveform}
+                data-tooltip="Toggle Analytics Display"
+              >
+                <ChartArea size={18} />
+              </button>
+              <button
+                className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+                onClick={handleResetAllMasks}
+                data-tooltip="Reset Masking"
+              >
+                <RotateCcw size={18} />
+              </button>
+            </div>
+          )}
+        </RightPanelHeader>
 
         <AnimatePresence initial={false}>
           {isWaveformVisible && (

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -73,7 +73,7 @@ import {
   ADJUSTMENT_SECTIONS,
 } from '../../../utils/adjustments';
 import { useContextMenu } from '../../../context/ContextMenuContext';
-import { OPTION_SEPARATOR, Orientation } from '../../ui/AppProperties';
+import { OPTION_SEPARATOR, Orientation, UiMode } from '../../ui/AppProperties';
 import { createSubMask } from '../../../utils/maskUtils';
 import { usePresets } from '../../../hooks/usePresets';
 import Text from '../../ui/Text';
@@ -555,6 +555,7 @@ export default function MasksPanel() {
       appSettings: state.appSettings,
     })),
   );
+  const isCompactUi = appSettings?.uiMode === UiMode.Compact;
 
   const { aiModelDownloadStatus } = useProcessStore(
     useShallow((state) => ({
@@ -1442,6 +1443,7 @@ export default function MasksPanel() {
                   updateSubMask={updateSubMask}
                   histogram={histogram}
                   appSettings={appSettings}
+                  isCompactUi={isCompactUi}
                   isGeneratingAiMask={isGeneratingAiMask}
                   setIsMaskControlHovered={setIsMaskControlHovered}
                   collapsibleState={collapsibleState}
@@ -2121,6 +2123,7 @@ function SettingsPanel({
   updateSubMask,
   histogram,
   appSettings,
+  isCompactUi,
   isGeneratingAiMask: _isGeneratingAiMask,
   setIsMaskControlHovered,
   collapsibleState,
@@ -2328,7 +2331,7 @@ function SettingsPanel({
     >
       <CollapsibleSection
         title={isComponentMode ? `${getSubMaskName(activeSubMask)} Properties` : 'Mask Properties'}
-        isOpen={isSettingsSectionOpen}
+        isOpen={isCompactUi || isSettingsSectionOpen}
         onToggle={() => {
           const isOpening = !isSettingsSectionOpen;
           setSettingsSectionOpen(isOpening);
@@ -2472,7 +2475,7 @@ function SettingsPanel({
             <CollapsibleSection
               key={sectionName}
               title={title}
-              isOpen={collapsibleState[sectionName]}
+              isOpen={isCompactUi || collapsibleState[sectionName]}
               isContentVisible={sectionVisibility[sectionName]}
               onToggle={() => handleToggleSection(sectionName)}
               onToggleVisibility={() => handleToggleVisibility(sectionName)}

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -641,6 +641,7 @@ export default function MasksPanel() {
   const [isSettingsSectionOpen, setSettingsSectionOpen] = useState(true);
   const [isSettingsPanelEverOpened, setIsSettingsPanelEverOpened] = useState(false);
   const hasPerformedInitialSelection = useRef(false);
+  const hasAppliedCompactOpenDefaults = useRef(false);
   const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
   const [analyzingSubMaskId, setAnalyzingSubMaskId] = useState<string | null>(null);
 
@@ -648,6 +649,28 @@ export default function MasksPanel() {
   const { presets } = usePresets(adjustments);
 
   const { setNodeRef: setRootDroppableRef, isOver: isRootOver } = useDroppable({ id: 'mask-list-root' });
+
+  useEffect(() => {
+    if (!isCompactUi) {
+      hasAppliedCompactOpenDefaults.current = false;
+      return;
+    }
+
+    if (hasAppliedCompactOpenDefaults.current) {
+      return;
+    }
+
+    setCollapsibleState((prev: any) => ({
+      ...prev,
+      basic: true,
+      color: true,
+      curves: true,
+      details: true,
+      effects: true,
+    }));
+    setSettingsSectionOpen(true);
+    hasAppliedCompactOpenDefaults.current = true;
+  }, [isCompactUi]);
 
   const activeContainer = adjustments.masks?.find((m) => m.id === activeMaskContainerId);
   const activeSubMaskData = activeContainer?.subMasks?.find((sm) => sm.id === activeMaskId);
@@ -2331,7 +2354,7 @@ function SettingsPanel({
     >
       <CollapsibleSection
         title={isComponentMode ? `${getSubMaskName(activeSubMask)} Properties` : 'Mask Properties'}
-        isOpen={isCompactUi || isSettingsSectionOpen}
+        isOpen={isSettingsSectionOpen}
         onToggle={() => {
           const isOpening = !isSettingsSectionOpen;
           setSettingsSectionOpen(isOpening);
@@ -2475,7 +2498,7 @@ function SettingsPanel({
             <CollapsibleSection
               key={sectionName}
               title={title}
-              isOpen={isCompactUi || collapsibleState[sectionName]}
+              isOpen={collapsibleState[sectionName]}
               isContentVisible={sectionVisibility[sectionName]}
               onToggle={() => handleToggleSection(sectionName)}
               onToggleVisibility={() => handleToggleVisibility(sectionName)}

--- a/src/components/panel/right/MetadataPanel.tsx
+++ b/src/components/panel/right/MetadataPanel.tsx
@@ -13,6 +13,7 @@ import { useLibraryStore } from '../../../store/useLibraryStore';
 import { useSettingsStore } from '../../../store/useSettingsStore';
 import { useProcessStore } from '../../../store/useProcessStore';
 import { useLibraryActions } from '../../../hooks/useLibraryActions';
+import RightPanelHeader from './RightPanelHeader';
 
 interface CameraSetting {
   format?(value: number): string | number;
@@ -320,9 +321,7 @@ export default function MetadataPanel() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-        <Text variant={TextVariants.title}>Metadata</Text>
-      </div>
+      <RightPanelHeader title="Metadata" />
       <div className="grow overflow-y-auto p-4 custom-scrollbar">
         {selectedImage ? (
           <div className="flex flex-col gap-6">

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -44,6 +44,7 @@ import { Invokes, OPTION_SEPARATOR, Panel, Preset, SelectedImage } from '../../u
 import { useEditorStore } from '../../../store/useEditorStore';
 import { useUIStore } from '../../../store/useUIStore';
 import { useEditorActions } from '../../../hooks/useEditorActions';
+import RightPanelHeader, { rightPanelHeaderActionClassName } from './RightPanelHeader';
 
 interface DroppableFolderItemProps {
   children: any;
@@ -941,42 +942,43 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
   return (
     <DndContext sensors={sensors} onDragStart={handleDragStart} onDragEnd={handleDragEnd}>
       <div className="flex flex-col h-full">
-        <div className="p-4 flex justify-between items-center shrink-0 border-b border-surface">
-          <Text variant={TextVariants.title}>Presets</Text>
-          <div className="flex items-center gap-1">
-            <button
-              className="p-2 rounded-full hover:bg-surface transition-colors"
-              onClick={onNavigateToCommunity}
-              data-tooltip="Explore Community Presets"
-            >
-              <Users size={18} />
-            </button>
-            <button
-              className="p-2 rounded-full hover:bg-surface transition-colors"
-              disabled={isLoading}
-              onClick={handleImportPresets}
-              data-tooltip="Import presets from .rrpreset file"
-            >
-              <FileUp size={18} />
-            </button>
-            <button
-              className="p-2 rounded-full hover:bg-surface transition-colors"
-              disabled={presets.length === 0 || isLoading}
-              onClick={handleExportAllPresets}
-              data-tooltip="Export all presets to .rrpreset file"
-            >
-              <FileDown size={18} />
-            </button>
-            <button
-              className="p-2 rounded-full hover:bg-surface transition-colors"
-              disabled={isLoading}
-              onClick={() => setConfigureModalState({ isOpen: true, preset: null })}
-              data-tooltip="Save as new preset"
-            >
-              <Plus size={18} />
-            </button>
-          </div>
-        </div>
+        <RightPanelHeader title="Presets">
+          {(isCompact) => (
+            <div className="flex items-center gap-1">
+              <button
+                className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+                onClick={onNavigateToCommunity}
+                data-tooltip="Explore Community Presets"
+              >
+                <Users size={18} />
+              </button>
+              <button
+                className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+                disabled={isLoading}
+                onClick={handleImportPresets}
+                data-tooltip="Import presets from .rrpreset file"
+              >
+                <FileUp size={18} />
+              </button>
+              <button
+                className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+                disabled={presets.length === 0 || isLoading}
+                onClick={handleExportAllPresets}
+                data-tooltip="Export all presets to .rrpreset file"
+              >
+                <FileDown size={18} />
+              </button>
+              <button
+                className={rightPanelHeaderActionClassName(isCompact, 'rounded-full hover:bg-surface')}
+                disabled={isLoading}
+                onClick={() => setConfigureModalState({ isOpen: true, preset: null })}
+                data-tooltip="Save as new preset"
+              >
+                <Plus size={18} />
+              </button>
+            </div>
+          )}
+        </RightPanelHeader>
 
         <div
           className={`grow overflow-y-auto p-4 space-y-2 rounded-lg transition-colors ${

--- a/src/components/panel/right/RightPanelHeader.tsx
+++ b/src/components/panel/right/RightPanelHeader.tsx
@@ -1,0 +1,30 @@
+import { type ReactNode } from 'react';
+import clsx, { type ClassValue } from 'clsx';
+import Text from '../../ui/Text';
+import { UiMode } from '../../ui/AppProperties';
+import { TextVariants } from '../../../types/typography';
+import { useSettingsStore } from '../../../store/useSettingsStore';
+
+interface RightPanelHeaderProps {
+  children?: ReactNode | ((isCompact: boolean) => ReactNode);
+  title: string;
+}
+
+export const rightPanelHeaderActionClassName = (isCompact: boolean, ...className: ClassValue[]) =>
+  clsx(isCompact ? 'p-1' : 'p-2', 'transition-colors', className);
+
+export default function RightPanelHeader({ children, title }: RightPanelHeaderProps) {
+  const isCompact = useSettingsStore((state) => state.appSettings?.uiMode === UiMode.Compact);
+
+  return (
+    <div
+      className={clsx(
+        'flex justify-between items-center shrink-0 border-b border-surface',
+        isCompact ? 'px-3 py-2' : 'p-4',
+      )}
+    >
+      <Text variant={TextVariants.title}>{title}</Text>
+      {typeof children === 'function' ? children(isCompact) : children}
+    </div>
+  );
+}

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -151,6 +151,11 @@ export enum Theme {
   Snow = 'snow',
 }
 
+export enum UiMode {
+  Modern = 'modern',
+  Compact = 'compact',
+}
+
 export enum ThumbnailAspectRatio {
   Cover = 'cover',
   Contain = 'contain',
@@ -174,6 +179,7 @@ export interface AppSettings {
   libraryViewMode?: LibraryViewMode;
   sortCriteria?: SortCriteria;
   theme: Theme;
+  uiMode?: UiMode;
   thumbnailSize?: ThumbnailSize;
   thumbnailAspectRatio?: ThumbnailAspectRatio;
   uiVisibility?: UiVisibility;

--- a/src/components/ui/CollapsibleSection.tsx
+++ b/src/components/ui/CollapsibleSection.tsx
@@ -92,7 +92,7 @@ export default function CollapsibleSection({
       <div
         className={clsx(
           'w-full flex items-center justify-between text-left transition-colors duration-200',
-          isCompact ? 'px-0 py-2 text-white' : 'px-4 py-3 hover:bg-card-active',
+          isCompact ? 'px-0 py-1 text-white' : 'px-4 py-3 hover:bg-card-active',
         )}
         onClick={onToggle}
         onMouseEnter={handleMouseEnter}
@@ -100,7 +100,7 @@ export default function CollapsibleSection({
       >
         <div className="flex items-center gap-2">
           <Text
-            variant={TextVariants.title}
+            variant={isCompact ? TextVariants.heading : TextVariants.title}
             weight={TextWeights.normal}
             color={isCompact ? TextColors.white : TextColors.primary}
           >
@@ -133,7 +133,7 @@ export default function CollapsibleSection({
         <div
           className={clsx(
             'transition-opacity duration-300',
-            isCompact ? 'px-0 pb-3 text-white' : 'px-4 pb-4',
+            isCompact ? 'px-0 pb-2 text-white' : 'px-4 pb-4',
             !isContentVisible && 'opacity-30 pointer-events-none',
           )}
           ref={contentRef}

--- a/src/components/ui/CollapsibleSection.tsx
+++ b/src/components/ui/CollapsibleSection.tsx
@@ -2,7 +2,9 @@ import { useRef, useEffect, useState } from 'react';
 import { ChevronDown, Eye, EyeOff } from 'lucide-react';
 import clsx from 'clsx';
 import Text from './Text';
-import { TextVariants, TextWeights } from '../../types/typography';
+import { TextColors, TextVariants, TextWeights } from '../../types/typography';
+import { UiMode } from './AppProperties';
+import { useSettingsStore } from '../../store/useSettingsStore';
 
 interface CollapsibleSectionProps {
   canToggleVisibility?: boolean;
@@ -25,6 +27,7 @@ export default function CollapsibleSection({
   onToggleVisibility = () => {},
   title,
 }: CollapsibleSectionProps) {
+  const isCompact = useSettingsStore((state) => state.appSettings?.uiMode === UiMode.Compact);
   const contentRef = useRef<HTMLDivElement | null>(null);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const [isHovering, setIsHovering] = useState(false);
@@ -77,22 +80,38 @@ export default function CollapsibleSection({
   };
 
   return (
-    <div className="bg-surface rounded-lg overflow-hidden shrink-0" onContextMenu={onContextMenu}>
+    <div
+      className={clsx(
+        'rounded-lg overflow-hidden shrink-0',
+        isCompact
+          ? 'bg-transparent [&_button]:!text-white [&_h1]:!text-white [&_h2]:!text-white [&_h3]:!text-white [&_input]:!text-white [&_label]:!text-white [&_p]:!text-white [&_span]:!text-white [&_textarea]:!text-white'
+          : 'bg-surface',
+      )}
+      onContextMenu={onContextMenu}
+    >
       <div
-        className="w-full px-4 py-3 flex items-center justify-between text-left hover:bg-card-active transition-colors duration-200"
+        className={clsx(
+          'w-full flex items-center justify-between text-left transition-colors duration-200',
+          isCompact ? 'px-0 py-2 text-white' : 'px-4 py-3 hover:bg-card-active',
+        )}
         onClick={onToggle}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
       >
         <div className="flex items-center gap-2">
-          <Text variant={TextVariants.title} weight={TextWeights.normal}>
+          <Text
+            variant={TextVariants.title}
+            weight={TextWeights.normal}
+            color={isCompact ? TextColors.white : TextColors.primary}
+          >
             {title}
           </Text>
           {canToggleVisibility && (
             <div className="w-6 h-6 flex items-center justify-center">
               <button
                 className={clsx(
-                  'p-1 rounded-full text-text-secondary hover:bg-bg-primary z-10 transition-opacity duration-300',
+                  'p-1 rounded-full z-10 transition-opacity duration-300',
+                  isCompact ? 'text-white hover:bg-white/10' : 'text-text-secondary hover:bg-bg-primary',
                   isHovering || !isContentVisible ? 'opacity-100' : 'opacity-0 pointer-events-none',
                 )}
                 onClick={handleVisibilityClick}
@@ -104,14 +123,17 @@ export default function CollapsibleSection({
           )}
         </div>
         <ChevronDown
-          className={clsx('text-accent transition-transform duration-300', { 'rotate-180': isOpen })}
+          className={clsx(isCompact ? 'text-white' : 'text-accent', 'transition-transform duration-300', {
+            'rotate-180': isOpen,
+          })}
           size={20}
         />
       </div>
       <div ref={wrapperRef} className="overflow-hidden transition-all duration-300 ease-in-out">
         <div
           className={clsx(
-            'px-4 pb-4 transition-opacity duration-300',
+            'transition-opacity duration-300',
+            isCompact ? 'px-0 pb-3 text-white' : 'px-4 pb-4',
             !isContentVisible && 'opacity-30 pointer-events-none',
           )}
           ref={contentRef}

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { GLOBAL_KEYS } from './AppProperties';
+import { GLOBAL_KEYS, UiMode } from './AppProperties';
+import { useSettingsStore } from '../../store/useSettingsStore';
 
 type SliderChangeEvent =
   | React.ChangeEvent<HTMLInputElement>
@@ -41,6 +42,7 @@ const Slider = ({
   fillOrigin = 'default',
   suffix = '',
 }: SliderProps) => {
+  const isCompact = useSettingsStore((state) => state.appSettings?.uiMode === UiMode.Compact);
   const [displayValue, setDisplayValue] = useState<number>(value);
   const [isDragging, setIsDragging] = useState(false);
   const animationFrameRef = useRef<number | undefined>(undefined);
@@ -432,8 +434,8 @@ const Slider = ({
   const numericValue = isNaN(Number(value)) ? 0 : Number(value);
 
   return (
-    <div className="mb-2 group" ref={containerRef}>
-      <div className="flex justify-between items-center mb-1">
+    <div className={`${isCompact ? 'mb-1' : 'mb-2'} group`} ref={containerRef}>
+      <div className={`flex justify-between items-center ${isCompact ? 'mb-0' : 'mb-1'}`}>
         <div
           className={`grid ${typeof label === 'string' ? 'cursor-pointer' : ''}`}
           onClick={typeof label === 'string' ? handleReset : undefined}
@@ -488,7 +490,7 @@ const Slider = ({
         </div>
       </div>
 
-      <div className="relative w-full h-5">
+      <div className={`relative w-full ${isCompact ? 'h-4' : 'h-5'}`}>
         <div
           className={`absolute top-1/2 left-0 w-full h-1.5 -translate-y-1/4 rounded-full pointer-events-none ${
             trackClassName || 'bg-card-active'

--- a/src/components/views/EditorView.tsx
+++ b/src/components/views/EditorView.tsx
@@ -21,7 +21,7 @@ import { useLibraryStore } from '../../store/useLibraryStore';
 import { useProcessStore } from '../../store/useProcessStore';
 import { useSettingsStore } from '../../store/useSettingsStore';
 
-import { ImageFile, Orientation, Panel, ThumbnailAspectRatio } from '../ui/AppProperties';
+import { ImageFile, Orientation, Panel, ThumbnailAspectRatio, UiMode } from '../ui/AppProperties';
 
 const panelVariants: any = {
   animate: (direction: number) => ({
@@ -139,6 +139,7 @@ export default function EditorView({
       handleSettingsChange: state.handleSettingsChange,
     })),
   );
+  const isCompactUi = appSettings?.uiMode === UiMode.Compact;
 
   const editorNode = (
     <Editor
@@ -246,7 +247,7 @@ export default function EditorView({
     <div className={clsx('flex grow h-full min-h-0', isCompactPortrait ? 'flex-col gap-2' : 'flex-row')}>
       <div className={clsx('flex-1 flex flex-col min-w-0', isCompactPortrait && 'min-h-0')}>
         {editorNode}
-        {!isCompactPortrait && editorBottomBarNode}
+        {!isCompactUi && !isCompactPortrait && editorBottomBarNode}
       </div>
       <div
         className={clsx(
@@ -285,7 +286,7 @@ export default function EditorView({
                 layout="horizontal"
               />
             </div>
-            <div className="shrink-0 border-t border-surface">{editorBottomBarComponent}</div>
+            {!isCompactUi && <div className="shrink-0 border-t border-surface">{editorBottomBarComponent}</div>}
           </>
         ) : (
           <>


### PR DESCRIPTION
## Description
This PR adds the option to choose between "Modern" and "Compact" UI. Compact is the default for android devices.

## Type of Change
- [x] New feature
- [x] Code refactoring
- [x] UI/UX improvement

## Changes Made
- Add "Compact" UI Setting
- Smaller margins for headers, texts and compact cards
- Redesign compact cards with no background and more width

## Screenshots/Videos
<img width="1920" height="1032" alt="Screenshot from 2026-05-24 03-35-14" src="https://github.com/user-attachments/assets/f5546401-31b5-47ea-8f30-5a79654b5621" />
<img width="1920" height="1032" alt="Screenshot from 2026-05-24 03-35-34" src="https://github.com/user-attachments/assets/d78511ff-2fd6-4a28-a64f-1d22360e2c42" />
<img width="720" height="1468" alt="Screenshot_20260524_033708_RapidRAW" src="https://github.com/user-attachments/assets/da4505b7-5ec6-4e59-8ee2-6199e68a1ea0" />


## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
When this is accepted, I want to rework the auto scaler and the general preview on vertical devices to be more space efficient. I would like to add tabs instead of the compact cards for vertical devices.

## AI Disclaimer:
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
