### PR TITLE
Fix raw highlights clipping 

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -871,7 +871,16 @@ fn generate_original_transformed_preview(
 
     let mut image_for_preview = loaded_image.image.as_ref().clone();
     if loaded_image.is_raw {
-        apply_cpu_default_raw_processing(&mut image_for_preview);
+        let tone_mapper = adjustments_clone
+            .get("toneMapper")
+            .and_then(|v| v.as_str())
+            .unwrap_or("basic");
+
+        if tone_mapper == "agx" {
+            crate::image_processing::apply_cpu_agx_tonemap(&mut image_for_preview);
+        } else {
+            apply_cpu_default_raw_processing(&mut image_for_preview);
+        }
     }
 
     let (transformed_full_res, _unscaled_crop_offset) =

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -133,16 +133,28 @@ fn develop_internal(
         safe_highlight_compression
     };
 
+    let soft_knee = |x: f32| -> f32 {
+        if x <= 1.0 {
+            x
+        } else if clamp_limit <= 1.0 {
+            1.0
+        } else {
+            let over = x - 1.0;
+            let range = clamp_limit - 1.0;
+            1.0 + range * (over / (over + range))
+        }
+    };
+
     check_cancel()?;
 
     match &mut developed_intermediate {
         Intermediate::Monochrome(pixels) => {
             pixels.data.iter_mut().for_each(|p| {
-                let mut linear_val = *p * rescale_factor;
+                let mut v = (*p * rescale_factor).max(0.0);
                 if is_linear_format && apply_ungamma {
-                    linear_val = srgb_to_linear(linear_val.clamp(0.0, 1.0));
+                    v = srgb_to_linear(v.clamp(0.0, 1.0));
                 }
-                *p = linear_val.clamp(0.0, clamp_limit);
+                *p = soft_knee(v).clamp(0.0, clamp_limit);
             });
         }
         Intermediate::ThreeColor(pixels) => {
@@ -158,43 +170,42 @@ fn develop_internal(
                 }
 
                 let max_c = r.max(g).max(b);
-
-                let (final_r, final_g, final_b) = if max_c > 1.0 {
-                    let min_c = r.min(g).min(b);
-                    let compression_factor =
-                        (1.0 - (max_c - 1.0) / (safe_highlight_compression - 1.0)).clamp(0.0, 1.0);
-                    let compressed_r = min_c + (r - min_c) * compression_factor;
-                    let compressed_g = min_c + (g - min_c) * compression_factor;
-                    let compressed_b = min_c + (b - min_c) * compression_factor;
-                    let compressed_max = compressed_r.max(compressed_g).max(compressed_b);
-
-                    if compressed_max > 1e-6 {
-                        let rescale = max_c / compressed_max;
-                        (
-                            compressed_r * rescale,
-                            compressed_g * rescale,
-                            compressed_b * rescale,
-                        )
-                    } else {
-                        (max_c, max_c, max_c)
-                    }
+                let scale = if max_c > 1.0 {
+                    soft_knee(max_c) / max_c
                 } else {
-                    (r, g, b)
+                    1.0
                 };
 
-                p[0] = final_r.clamp(0.0, clamp_limit);
-                p[1] = final_g.clamp(0.0, clamp_limit);
-                p[2] = final_b.clamp(0.0, clamp_limit);
+                let mut r_s = r * scale;
+                let mut g_s = g * scale;
+                let mut b_s = b * scale;
+
+                let min_c = r.min(g).min(b);
+                let mid_c = r + g + b - max_c - min_c;
+                let desat_start = 0.6;
+                let desat_end = 1.0;
+                if mid_c > desat_start {
+                    let t = ((mid_c - desat_start) / (desat_end - desat_start)).clamp(0.0, 1.0);
+                    let blend = t * t * (3.0 - 2.0 * t);
+                    let neutral = max_c * scale;
+                    r_s = r_s * (1.0 - blend) + neutral * blend;
+                    g_s = g_s * (1.0 - blend) + neutral * blend;
+                    b_s = b_s * (1.0 - blend) + neutral * blend;
+                }
+
+                p[0] = r_s.clamp(0.0, clamp_limit);
+                p[1] = g_s.clamp(0.0, clamp_limit);
+                p[2] = b_s.clamp(0.0, clamp_limit);
             });
         }
         Intermediate::FourColor(pixels) => {
             pixels.data.iter_mut().for_each(|p| {
                 p.iter_mut().for_each(|c| {
-                    let mut linear_val = *c * rescale_factor;
+                    let mut v = (*c * rescale_factor).max(0.0);
                     if is_linear_format && apply_ungamma {
-                        linear_val = srgb_to_linear(linear_val.clamp(0.0, 1.0));
+                        v = srgb_to_linear(v.clamp(0.0, 1.0));
                     }
-                    *c = linear_val.clamp(0.0, clamp_limit);
+                    *c = soft_knee(v).clamp(0.0, clamp_limit);
                 });
             });
         }

--- a/src/hooks/useImageProcessing.ts
+++ b/src/hooks/useImageProcessing.ts
@@ -51,14 +51,15 @@ export function useImageProcessing(
 
   const geometricAdjustmentsKey = useMemo(() => {
     if (!adjustments) return '';
-    const { crop, rotation, flipHorizontal, flipVertical, orientationSteps } = adjustments;
-    return JSON.stringify({ crop, rotation, flipHorizontal, flipVertical, orientationSteps });
+    const { crop, rotation, flipHorizontal, flipVertical, orientationSteps, toneMapper } = adjustments;
+    return JSON.stringify({ crop, rotation, flipHorizontal, flipVertical, orientationSteps, toneMapper });
   }, [
     adjustments?.crop,
     adjustments?.rotation,
     adjustments?.flipHorizontal,
     adjustments?.flipVertical,
     adjustments?.orientationSteps,
+    adjustments?.toneMapper,
   ]);
 
   const calculateROI = useCallback(() => {


### PR DESCRIPTION
## Description
This PR resolves an issue where high-brightness regions (highlights) in RAW files (such as `.NEF`) were rendered unnaturally, flattening gradients into white blobs and suffering from "hue twists". It also restores the required HDR headroom (>1.0) so the downstream AgX filmic tonemapper can function correctly without being starved of dynamic range.
In the second commit, a "show original" bug was fixed - the difference is now shown with the selected tone mapper instead of the hard-coded basic one. 

## Type of Change
- [x] Bug fix

## Changes Made
- **Restored HDR Headroom:** Added a temporary `whitelevel = u32::MAX` override in `develop_internal` to bypass `rawler`'s automatic hard-clipping. This preserves >1.0 sensor values created by WB/color-matrix calibration for the downstream WGSL shader.
- **Implemented Chromaticity-Preserving Soft-Knee:** Replaced the flawed per-channel highlight compression with a smooth, asymptotic `soft_knee` roll-off mathematical shoulder.
- **Fixed Hue Twist:** Highlight compression is now applied to the *maximum* RGB channel (`max_c`), and the rest of the channels are scaled proportionally (`soft_knee(max_c) / max_c`). This preserves the precise RGB ratio, keeping saturated lights true to their color instead of twisting toward white.
- **Unified Processing:** Applied the updated `soft_knee` scaling logic safely across `ThreeColor`, `Monochrome`, and `FourColor` intermediate formats.

## Screenshots/Videos
| Before (Clipped Highlights & Hue Twist) | After (Restored HDR Headroom & Gradients) |
| :---: | :---: |
|<img width="2048" height="2676" alt="fix-before" src="https://github.com/user-attachments/assets/954648df-2d69-4900-b185-7b16f500948b" /> | <img width="2048" height="2676" alt="fix-after" src="https://github.com/user-attachments/assets/c3cd820c-7722-4d06-b52b-4f165ebf3763" />|

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Ubuntu 24.04
- **Hardware:**  Nvidia RTX 2070, Intel

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors (0 Clippy warnings)

## Additional Notes
By combining the HDR pass-through (giving the shader proper linear values) with the proportional chromaticity scalar, RapidRAW now accurately matches or exceeds the highlight volume rendering of natural RAW processors like Shotwell. 

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)


The AI indeed generated the above=) 