### PR TITLE
fix: preserve EXIF timezone offset in JPEG export

### DIFF
--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::formats::is_raw_file;
 use crate::image_processing::ImageMetadata;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
 use exif::{Exif, In, Value};
 use little_exif::exif_tag::ExifTag;
 use little_exif::filetype::FileExtension;
@@ -29,6 +29,48 @@ fn to_ir64(val: &exif::SRational) -> iR64 {
 
 fn clean_creation_datetime_str(s: &str) -> &str {
     s.trim().trim_matches('"').trim_matches('\'').trim()
+}
+
+// Parse "+HH:MM" / "-HH:MM" offset into total seconds east of UTC.
+fn parse_offset_secs(s: &str) -> Option<i64> {
+    let s = s.trim().trim_matches('"');
+    if s.len() < 6 {
+        return None;
+    }
+    let sign: i64 = if s.starts_with('-') { -1 } else { 1 };
+    let rest = if s.starts_with('+') || s.starts_with('-') {
+        &s[1..]
+    } else {
+        s
+    };
+    let mut parts = rest.splitn(2, ':');
+    let h = parts.next()?.parse::<i64>().ok()?;
+    let m = parts.next()?.parse::<i64>().ok()?;
+    Some(sign * (h * 3600 + m * 60))
+}
+
+// Combine a datetime string with an optional offset into EXIF inline format.
+// Input dt may use dashes or colons as date separator; output always uses colons.
+// Result: "YYYY:MM:DD HH:MM:SS+HH:MM" or "YYYY:MM:DD HH:MM:SS" if no offset.
+fn combine_datetime_with_offset(dt: &str, offset: Option<&str>) -> String {
+    let dt = dt.trim_matches('"').trim();
+    let normalized = if dt.len() >= 10 {
+        format!("{}{}", dt[..10].replace('-', ":"), &dt[10..])
+    } else {
+        dt.to_string()
+    };
+    let bare = if normalized.len() >= 19 {
+        &normalized[..19]
+    } else {
+        normalized.as_str()
+    };
+    match offset
+        .map(|s| s.trim().trim_matches('"'))
+        .filter(|s| !s.is_empty())
+    {
+        Some(off) => format!("{}{}", bare, off),
+        None => bare.to_string(),
+    }
 }
 
 fn fmt_date_str(s: String) -> String {
@@ -544,7 +586,29 @@ pub fn get_creation_date_from_path(path: &Path) -> DateTime<Utc> {
         && let Some(dt_str) = map.get("DateTimeOriginal").or(map.get("CreateDate"))
         && let Some(dt) = parse_creation_datetime(dt_str)
     {
-        return DateTime::from_naive_utc_and_offset(dt, Utc);
+        let offset_secs = map
+            .get("OffsetTimeOriginal")
+            .or_else(|| map.get("OffsetTime"))
+            .and_then(|s| parse_offset_secs(s))
+            .or_else(|| {
+                // Sidecar may be stale (created before OffsetTime support); read from file.
+                if !is_raw_file(path.to_string_lossy().as_ref()) {
+                    return None;
+                }
+                let loader = rawler::RawLoader::new();
+                let raw_source = rawler::rawsource::RawSource::new(path).ok()?;
+                let decoder = loader.get_decoder(&raw_source).ok()?;
+                let meta = decoder
+                    .raw_metadata(&raw_source, &Default::default())
+                    .ok()?;
+                meta.exif
+                    .offset_time_original
+                    .as_deref()
+                    .or(meta.exif.offset_time.as_deref())
+                    .and_then(parse_offset_secs)
+            })
+            .unwrap_or(0);
+        return DateTime::from_naive_utc_and_offset(dt - Duration::seconds(offset_secs), Utc);
     }
 
     if let Ok(file) = std::fs::File::open(path) {
@@ -568,11 +632,28 @@ pub fn get_creation_date_from_path(path: &Path) -> DateTime<Utc> {
             && let Ok(decoder) = loader.get_decoder(&raw_source)
             && let Ok(metadata) = decoder.raw_metadata(&raw_source, &Default::default())
         {
-            if let Some(dt) = parse_raw_creation_date(metadata.exif.date_time_original.as_deref()) {
-                return dt;
+            let offset_secs = metadata
+                .exif
+                .offset_time_original
+                .as_deref()
+                .or(metadata.exif.offset_time.as_deref())
+                .and_then(parse_offset_secs)
+                .unwrap_or(0);
+            if let Some(dt) =
+                parse_creation_datetime(metadata.exif.date_time_original.as_deref().unwrap_or(""))
+            {
+                return DateTime::from_naive_utc_and_offset(
+                    dt - Duration::seconds(offset_secs),
+                    Utc,
+                );
             }
-            if let Some(dt) = parse_raw_creation_date(metadata.exif.create_date.as_deref()) {
-                return dt;
+            if let Some(dt) =
+                parse_creation_datetime(metadata.exif.create_date.as_deref().unwrap_or(""))
+            {
+                return DateTime::from_naive_utc_and_offset(
+                    dt - Duration::seconds(offset_secs),
+                    Utc,
+                );
             }
         }
     }
@@ -706,10 +787,27 @@ pub fn write_image_with_metadata(
             metadata.set_tag(ExifTag::ImageDescription(clean_s(val)));
         }
         if let Some(val) = map.get("DateTimeOriginal") {
-            metadata.set_tag(ExifTag::DateTimeOriginal(clean_s(val)));
+            let offset = map.get("OffsetTimeOriginal").map(String::as_str);
+            metadata.set_tag(ExifTag::DateTimeOriginal(combine_datetime_with_offset(
+                &clean_s(val),
+                offset,
+            )));
         }
         if let Some(val) = map.get("CreateDate") {
-            metadata.set_tag(ExifTag::CreateDate(clean_s(val)));
+            let offset = map.get("OffsetTime").map(String::as_str);
+            metadata.set_tag(ExifTag::CreateDate(combine_datetime_with_offset(
+                &clean_s(val),
+                offset,
+            )));
+        }
+        if let Some(val) = map.get("OffsetTime") {
+            metadata.set_tag(ExifTag::OffsetTime(clean_s(val)));
+        }
+        if let Some(val) = map.get("OffsetTimeOriginal") {
+            metadata.set_tag(ExifTag::OffsetTimeOriginal(clean_s(val)));
+        }
+        if let Some(val) = map.get("OffsetTimeDigitized") {
+            metadata.set_tag(ExifTag::OffsetTimeDigitized(clean_s(val)));
         }
         if let Some(val) = map.get("FNumber")
             && let Some(ur) = parse_ur64(val)
@@ -786,10 +884,31 @@ pub fn write_image_with_metadata(
                 metadata.set_tag(ExifTag::Copyright(get_string_val(f)));
             }
             if let Some(f) = exif_obj.get_field(exif::Tag::DateTimeOriginal, exif::In::PRIMARY) {
-                metadata.set_tag(ExifTag::DateTimeOriginal(get_string_val(f)));
+                let offset = exif_obj
+                    .get_field(exif::Tag::OffsetTimeOriginal, exif::In::PRIMARY)
+                    .map(|of| get_string_val(of));
+                metadata.set_tag(ExifTag::DateTimeOriginal(combine_datetime_with_offset(
+                    &get_string_val(f),
+                    offset.as_deref(),
+                )));
             }
             if let Some(f) = exif_obj.get_field(exif::Tag::DateTime, exif::In::PRIMARY) {
-                metadata.set_tag(ExifTag::CreateDate(get_string_val(f)));
+                let offset = exif_obj
+                    .get_field(exif::Tag::OffsetTime, exif::In::PRIMARY)
+                    .map(|of| get_string_val(of));
+                metadata.set_tag(ExifTag::CreateDate(combine_datetime_with_offset(
+                    &get_string_val(f),
+                    offset.as_deref(),
+                )));
+            }
+            if let Some(f) = exif_obj.get_field(exif::Tag::OffsetTime, exif::In::PRIMARY) {
+                metadata.set_tag(ExifTag::OffsetTime(get_string_val(f)));
+            }
+            if let Some(f) = exif_obj.get_field(exif::Tag::OffsetTimeOriginal, exif::In::PRIMARY) {
+                metadata.set_tag(ExifTag::OffsetTimeOriginal(get_string_val(f)));
+            }
+            if let Some(f) = exif_obj.get_field(exif::Tag::OffsetTimeDigitized, exif::In::PRIMARY) {
+                metadata.set_tag(ExifTag::OffsetTimeDigitized(get_string_val(f)));
             }
             if let Some(f) = exif_obj.get_field(exif::Tag::FNumber, exif::In::PRIMARY)
                 && let exif::Value::Rational(v) = &f.value
@@ -895,11 +1014,23 @@ pub fn write_image_with_metadata(
             if let Some(copyright) = exif.copyright {
                 metadata.set_tag(ExifTag::Copyright(copyright));
             }
-            if let Some(dt) = exif.date_time_original {
-                metadata.set_tag(ExifTag::DateTimeOriginal(dt));
+            if let Some(ref dt) = exif.date_time_original {
+                let combined =
+                    combine_datetime_with_offset(dt, exif.offset_time_original.as_deref());
+                metadata.set_tag(ExifTag::DateTimeOriginal(combined));
             }
-            if let Some(dt) = exif.create_date {
-                metadata.set_tag(ExifTag::CreateDate(dt));
+            if let Some(ref dt) = exif.create_date {
+                let combined = combine_datetime_with_offset(dt, exif.offset_time.as_deref());
+                metadata.set_tag(ExifTag::CreateDate(combined));
+            }
+            if let Some(ot) = exif.offset_time {
+                metadata.set_tag(ExifTag::OffsetTime(ot));
+            }
+            if let Some(oto) = exif.offset_time_original {
+                metadata.set_tag(ExifTag::OffsetTimeOriginal(oto));
+            }
+            if let Some(otd) = exif.offset_time_digitized {
+                metadata.set_tag(ExifTag::OffsetTimeDigitized(otd));
             }
             if let Some(lens_make) = exif.lens_make {
                 metadata.set_tag(ExifTag::LensMake(lens_make));


### PR DESCRIPTION
## Summary

- **Bug 1 fixed:** `DateTimeOriginal` was written without inline timezone offset (e.g. `2026-06-05 11:33:26` instead of `2026:06:05 11:33:26+02:00`), causing Apple Photos and other viewers to misinterpret the time as UTC
- **Bug 2 fixed:** Exported JPEG file modification time was +2h — `get_creation_date_from_path` treated local camera time as UTC before calling `set_file_times`
- **OffsetTime tags added:** All three write branches now write `OffsetTime`, `OffsetTimeOriginal`, and `OffsetTimeDigitized` tags for maximum compatibility

## Changes in `src-tauri/src/exif_processing.rs`

- `combine_datetime_with_offset`: new helper that normalises the date separator (dashes → colons) and appends the timezone offset inline per EXIF 2.31 spec
- `parse_offset_secs`: new helper that converts `+HH:MM` / `-HH:MM` strings to seconds east of UTC; strips surrounding quotes from `kamadak-exif` `display_value()` output to prevent silent parse failures
- `get_creation_date_from_path` (sidecar branch): reads `OffsetTimeOriginal`/`OffsetTime` from the sidecar map and subtracts the offset before constructing `DateTime<Utc>`; falls back to reading the offset directly from the RAW file via `rawler` when the sidecar predates OffsetTime support
- `get_creation_date_from_path` (rawler branch): same UTC conversion applied
- `write_image_with_metadata` (all three branches — sidecar map, kamadak-exif, rawler): `DateTimeOriginal` and `CreateDate` now include the inline offset; all three OffsetTime* tags are written

## Test plan

- [ ] Export a JPEG from an ARW/RAW source with a known timezone offset
- [ ] Verify `DateTimeOriginal` in exported JPEG contains inline offset (e.g. `2026:06:05 11:33:26+02:00`)
- [ ] Verify `OffsetTimeOriginal` / `OffsetTime` / `OffsetTimeDigitized` tags are present
- [ ] Verify file modification date/time matches capture time (not offset by the UTC difference)
- [ ] Import exported JPEG into Apple Photos and confirm displayed time is correct
- [ ] Test with a sidecar created before this fix (no `OffsetTime` key) to confirm rawler fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)