### PR TITLE
Add local hue slider to masks and globally

### DIFF
--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -2230,11 +2230,7 @@ fn get_mask_adjustments_from_json(adj: &serde_json::Value) -> MaskAdjustments {
         flare_amount: get_val("effects", "flareAmount", SCALES.flares),
         sharpness_threshold: get_val("details", "sharpnessThreshold", SCALES.sharpness_threshold),
 
-        hue: if is_visible("color") {
-            adj["hue"].as_f64().unwrap_or(0.0) as f32
-        } else {
-            0.0
-        },
+        hue: get_val("color", "hue", 1.0),
         _pad_cg1: 0.0,
         _pad_cg2: 0.0,
         color_grading_shadows: if is_visible("color") {

--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -1264,6 +1264,10 @@ pub struct GlobalAdjustments {
     pub temperature: f32,
     pub tint: f32,
     pub vibrance: f32,
+    pub hue: f32,
+    _pad_color1: f32,
+    _pad_color2: f32,
+    _pad_color3: f32,
 
     pub sharpness: f32,
     pub luma_noise_reduction: f32,
@@ -1995,6 +1999,10 @@ fn get_global_adjustments_from_json(
         temperature: get_val("color", "temperature", SCALES.temperature, None),
         tint: get_val("color", "tint", SCALES.tint, None),
         vibrance: get_val("color", "vibrance", SCALES.vibrance, None),
+        hue: get_val("color", "hue", 1.0, None),
+        _pad_color1: 0.0,
+        _pad_color2: 0.0,
+        _pad_color3: 0.0,
 
         sharpness: get_val("details", "sharpness", SCALES.sharpness, None),
         luma_noise_reduction: get_val(

--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -1362,9 +1362,9 @@ pub struct MaskAdjustments {
     pub flare_amount: f32,
     pub sharpness_threshold: f32,
 
+    pub hue: f32,
     _pad_cg1: f32,
     _pad_cg2: f32,
-    _pad_cg3: f32,
     pub color_grading_shadows: ColorGradeSettings,
     pub color_grading_midtones: ColorGradeSettings,
     pub color_grading_highlights: ColorGradeSettings,
@@ -2222,9 +2222,13 @@ fn get_mask_adjustments_from_json(adj: &serde_json::Value) -> MaskAdjustments {
         flare_amount: get_val("effects", "flareAmount", SCALES.flares),
         sharpness_threshold: get_val("details", "sharpnessThreshold", SCALES.sharpness_threshold),
 
+        hue: if is_visible("color") {
+            adj["hue"].as_f64().unwrap_or(0.0) as f32
+        } else {
+            0.0
+        },
         _pad_cg1: 0.0,
         _pad_cg2: 0.0,
-        _pad_cg3: 0.0,
         color_grading_shadows: if is_visible("color") {
             parse_color_grade_settings(&cg_obj["shadows"])
         } else {

--- a/src-tauri/src/shaders/shader.wgsl
+++ b/src-tauri/src/shaders/shader.wgsl
@@ -234,6 +234,15 @@ fn linear_to_srgb(c: vec3<f32>) -> vec3<f32> {
     return select(higher, lower, c_clamped <= cutoff);
 }
 
+fn linear_to_srgb_extended(c: vec3<f32>) -> vec3<f32> {
+    let safe_c = max(c, vec3<f32>(0.0));
+    let cutoff = vec3<f32>(0.0031308);
+    let a = vec3<f32>(0.055);
+    let higher = (1.0 + a) * pow(safe_c, vec3<f32>(1.0 / 2.4)) - a;
+    let lower = safe_c * 12.92;
+    return select(higher, lower, safe_c <= cutoff);
+}
+
 fn rgb_to_hsv(c: vec3<f32>) -> vec3<f32> {
     let c_max = max(c.r, max(c.g, c.b));
     let c_min = min(c.r, min(c.g, c.b));
@@ -268,11 +277,12 @@ fn apply_hue_shift(color: vec3<f32>, shift_degrees: f32) -> vec3<f32> {
     if (abs(shift_degrees) < 0.01) {
         return color;
     }
-    let safe_color = max(color, vec3<f32>(0.0));
-    let hsv = rgb_to_hsv(safe_color);
+    let srgb_color = linear_to_srgb_extended(color);
+    let hsv = rgb_to_hsv(srgb_color);
     var shifted_h = hsv.x + shift_degrees;
     shifted_h = (shifted_h + 360.0) % 360.0;
-    return hsv_to_rgb(vec3<f32>(shifted_h, hsv.y, hsv.z));
+    let shifted_srgb = hsv_to_rgb(vec3<f32>(shifted_h, hsv.y, hsv.z));
+    return srgb_to_linear(shifted_srgb);
 }
 
 fn get_raw_hsl_influence(hue: f32, center: f32, width: f32) -> f32 {

--- a/src-tauri/src/shaders/shader.wgsl
+++ b/src-tauri/src/shaders/shader.wgsl
@@ -42,6 +42,10 @@ struct GlobalAdjustments {
     temperature: f32,
     tint: f32,
     vibrance: f32,
+    hue: f32,
+    _pad_color1: f32,
+    _pad_color2: f32,
+    _pad_color3: f32,
 
     sharpness: f32,
     luma_noise_reduction: f32,
@@ -1470,7 +1474,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     var t_halation = adjustments.global.halation_amount;
     var t_flare = adjustments.global.flare_amount;
     var t_sharpness = adjustments.global.sharpness;
-    var t_hue: f32 = 0.0;
+    var t_hue = adjustments.global.hue;
 
     var h0_h = adjustments.global.hsl[0].hue; var h0_s = adjustments.global.hsl[0].saturation; var h0_l = adjustments.global.hsl[0].luminance;
     var h1_h = adjustments.global.hsl[1].hue; var h1_s = adjustments.global.hsl[1].saturation; var h1_l = adjustments.global.hsl[1].luminance;

--- a/src-tauri/src/shaders/shader.wgsl
+++ b/src-tauri/src/shaders/shader.wgsl
@@ -138,9 +138,9 @@ struct MaskAdjustments {
     flare_amount: f32,
     sharpness_threshold: f32,
 
+    hue: f32,
     _pad_cg1: f32,
     _pad_cg2: f32,
-    _pad_cg3: f32,
     color_grading_shadows: ColorGradeSettings,
     color_grading_midtones: ColorGradeSettings,
     color_grading_highlights: ColorGradeSettings,
@@ -258,6 +258,17 @@ fn hsv_to_rgb(c: vec3<f32>) -> vec3<f32> {
     else if (h < 300.0) { rgb_prime = vec3<f32>(X, 0.0, C); }
     else { rgb_prime = vec3<f32>(C, 0.0, X); }
     return rgb_prime + vec3<f32>(m, m, m);
+}
+
+fn apply_hue_shift(color: vec3<f32>, shift_degrees: f32) -> vec3<f32> {
+    if (abs(shift_degrees) < 0.01) {
+        return color;
+    }
+    let safe_color = max(color, vec3<f32>(0.0));
+    let hsv = rgb_to_hsv(safe_color);
+    var shifted_h = hsv.x + shift_degrees;
+    shifted_h = (shifted_h + 360.0) % 360.0;
+    return hsv_to_rgb(vec3<f32>(shifted_h, hsv.y, hsv.z));
 }
 
 fn get_raw_hsl_influence(hue: f32, center: f32, width: f32) -> f32 {
@@ -1459,6 +1470,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     var t_halation = adjustments.global.halation_amount;
     var t_flare = adjustments.global.flare_amount;
     var t_sharpness = adjustments.global.sharpness;
+    var t_hue: f32 = 0.0;
 
     var h0_h = adjustments.global.hsl[0].hue; var h0_s = adjustments.global.hsl[0].saturation; var h0_l = adjustments.global.hsl[0].luminance;
     var h1_h = adjustments.global.hsl[1].hue; var h1_s = adjustments.global.hsl[1].saturation; var h1_l = adjustments.global.hsl[1].luminance;
@@ -1496,6 +1508,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
             t_glow += m.glow_amount * influence;
             t_halation += m.halation_amount * influence;
             t_flare += m.flare_amount * influence;
+            t_hue += m.hue * influence;
 
             h0_h += m.hsl[0].hue * influence; h0_s += m.hsl[0].saturation * influence; h0_l += m.hsl[0].luminance * influence;
             h1_h += m.hsl[1].hue * influence; h1_s += m.hsl[1].saturation * influence; h1_l += m.hsl[1].luminance * influence;
@@ -1590,6 +1603,7 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     composite_rgb_linear = apply_highlights_adjustment(composite_rgb_linear, tonal_blurred, is_raw, t_highlights);
     composite_rgb_linear = apply_color_calibration(composite_rgb_linear, adjustments.global.color_calibration);
     composite_rgb_linear = apply_hsl_panel(composite_rgb_linear, final_hsl, absolute_coord_i);
+    composite_rgb_linear = apply_hue_shift(composite_rgb_linear, t_hue);
     composite_rgb_linear = apply_creative_color(composite_rgb_linear, t_saturation, t_vibrance);
 
     composite_rgb_linear = apply_color_grading(

--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -122,7 +122,7 @@ const ColorGradingPanel = ({ adjustments, setAdjustments, onDragStateChange }: C
     }));
   };
 
-  const handleGlobalChange = (grading: ColorGrading, value: string) => {
+  const handleColorGradingSliderChange = (grading: ColorGrading, value: string) => {
     setAdjustments((prev: Partial<Adjustments>) => ({
       ...prev,
       colorGrading: {
@@ -267,7 +267,7 @@ const ColorGradingPanel = ({ adjustments, setAdjustments, onDragStateChange }: C
           label={t('adjustments.color.grading.blending')}
           max={100}
           min={0}
-          onChange={(e: any) => handleGlobalChange(ColorGrading.Blending, e.target.value)}
+          onChange={(e: any) => handleColorGradingSliderChange(ColorGrading.Blending, e.target.value)}
           step={1}
           value={colorGrading.blending}
           onDragStateChange={onDragStateChange}
@@ -277,7 +277,7 @@ const ColorGradingPanel = ({ adjustments, setAdjustments, onDragStateChange }: C
           label={t('adjustments.color.grading.balance')}
           max={100}
           min={-100}
-          onChange={(e: any) => handleGlobalChange(ColorGrading.Balance, e.target.value)}
+          onChange={(e: any) => handleColorGradingSliderChange(ColorGrading.Balance, e.target.value)}
           step={1}
           value={colorGrading.balance}
           onDragStateChange={onDragStateChange}
@@ -447,7 +447,7 @@ export default function ColorPanel({
     document.documentElement.style.setProperty(`--hsl-mixer-sat-${activeColor}`, `${effectiveSaturation}%`);
   }, [effectiveHue, currentHsl.saturation, activeColor]);
 
-  const handleGlobalChange = (key: ColorAdjustment, value: string) => {
+  const handleAdjustmentChange = (key: ColorAdjustment, value: string) => {
     setAdjustments((prev: Partial<Adjustments>) => ({ ...prev, [key]: parseFloat(value) }));
   };
 
@@ -496,7 +496,7 @@ export default function ColorPanel({
           label={t('adjustments.color.temperature')}
           max={100}
           min={-100}
-          onChange={(e: any) => handleGlobalChange(ColorAdjustment.Temperature, e.target.value)}
+          onChange={(e: any) => handleAdjustmentChange(ColorAdjustment.Temperature, e.target.value)}
           step={1}
           value={adjustments.temperature || 0}
           trackClassName="temperature-gradient-track"
@@ -506,7 +506,7 @@ export default function ColorPanel({
           label={t('adjustments.color.tint')}
           max={100}
           min={-100}
-          onChange={(e: any) => handleGlobalChange(ColorAdjustment.Tint, e.target.value)}
+          onChange={(e: any) => handleAdjustmentChange(ColorAdjustment.Tint, e.target.value)}
           step={1}
           value={adjustments.tint || 0}
           trackClassName="tint-gradient-track"
@@ -522,7 +522,7 @@ export default function ColorPanel({
           label={t('adjustments.color.vibrance')}
           max={100}
           min={-100}
-          onChange={(e: any) => handleGlobalChange(ColorAdjustment.Vibrance, e.target.value)}
+          onChange={(e: any) => handleAdjustmentChange(ColorAdjustment.Vibrance, e.target.value)}
           step={1}
           value={adjustments.vibrance || 0}
           onDragStateChange={onDragStateChange}
@@ -531,7 +531,7 @@ export default function ColorPanel({
           label={t('adjustments.color.saturation')}
           max={100}
           min={-100}
-          onChange={(e: any) => handleGlobalChange(ColorAdjustment.Saturation, e.target.value)}
+          onChange={(e: any) => handleAdjustmentChange(ColorAdjustment.Saturation, e.target.value)}
           step={1}
           value={adjustments.saturation || 0}
           onDragStateChange={onDragStateChange}
@@ -546,7 +546,7 @@ export default function ColorPanel({
           label={t('adjustments.color.hue', 'Hue')}
           max={180}
           min={-180}
-          onChange={(e: any) => handleGlobalChange(ColorAdjustment.Hue, e.target.value)}
+          onChange={(e: any) => handleAdjustmentChange(ColorAdjustment.Hue, e.target.value)}
           step={1}
           value={adjustments.hue || 0}
           trackClassName="hue-range-track"

--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -470,45 +470,6 @@ export default function ColorPanel({
 
   return (
     <div className="space-y-4">
-      {isForMask && (
-        <div className="p-2 bg-bg-tertiary rounded-md">
-          <Text variant={TextVariants.heading} className="mb-2">
-            {t('adjustments.color.localHueTitle', 'Local Hue')}
-          </Text>
-          <Slider
-            label={t('adjustments.color.hue', 'Hue')}
-            max={180}
-            min={-180}
-            onChange={(e: any) => handleGlobalChange(ColorAdjustment.Hue, e.target.value)}
-            step={1}
-            value={adjustments.hue || 0}
-            trackClassName="hue-range-track"
-            onDragStateChange={onDragStateChange}
-            fineAdjustment={adjustments.useFineAdjustment}
-          />
-          <div className="flex items-center gap-2 mt-1">
-            <input
-              type="checkbox"
-              id="useFineAdjustment"
-              checked={!!adjustments.useFineAdjustment}
-              onChange={(e) =>
-                setAdjustments((prev: Partial<Adjustments>) => ({
-                  ...prev,
-                  useFineAdjustment: e.target.checked,
-                }))
-              }
-              className="rounded border-surface bg-bg-secondary text-accent focus:ring-accent w-4 h-4 cursor-pointer"
-            />
-            <label
-              htmlFor="useFineAdjustment"
-              className="text-xs text-text-secondary select-none cursor-pointer hover:text-text-primary"
-            >
-              {t('adjustments.color.useFineAdjustment', 'Use Fine Adjustment')}
-            </label>
-          </div>
-        </div>
-      )}
-
       <div className="p-2 bg-bg-tertiary rounded-md">
         <div className="flex justify-between items-center mb-2">
           <Text variant={TextVariants.heading}>{t('adjustments.color.whiteBalance')}</Text>
@@ -576,6 +537,24 @@ export default function ColorPanel({
           onDragStateChange={onDragStateChange}
         />
       </div>
+
+      {isForMask && (
+        <div className="p-2 bg-bg-tertiary rounded-md">
+          <Text variant={TextVariants.heading} className="mb-2">
+            {t('adjustments.color.localHueTitle', 'Local Hue')}
+          </Text>
+          <Slider
+            label={t('adjustments.color.hue', 'Hue')}
+            max={180}
+            min={-180}
+            onChange={(e: any) => handleGlobalChange(ColorAdjustment.Hue, e.target.value)}
+            step={1}
+            value={adjustments.hue || 0}
+            trackClassName="hue-range-track"
+            onDragStateChange={onDragStateChange}
+          />
+        </div>
+      )}
 
       <div className="p-2 bg-bg-tertiary rounded-md">
         <Text variant={TextVariants.heading} className="mb-3">

--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -538,23 +538,21 @@ export default function ColorPanel({
         />
       </div>
 
-      {isForMask && (
-        <div className="p-2 bg-bg-tertiary rounded-md">
-          <Text variant={TextVariants.heading} className="mb-2">
-            {t('adjustments.color.localHueTitle', 'Local Hue')}
-          </Text>
-          <Slider
-            label={t('adjustments.color.hue', 'Hue')}
-            max={180}
-            min={-180}
-            onChange={(e: any) => handleGlobalChange(ColorAdjustment.Hue, e.target.value)}
-            step={1}
-            value={adjustments.hue || 0}
-            trackClassName="hue-range-track"
-            onDragStateChange={onDragStateChange}
-          />
-        </div>
-      )}
+      <div className="p-2 bg-bg-tertiary rounded-md">
+        <Text variant={TextVariants.heading} className="mb-2">
+          {isForMask ? t('adjustments.color.localHueTitle', 'Local Hue') : t('adjustments.color.hue', 'Hue')}
+        </Text>
+        <Slider
+          label={t('adjustments.color.hue', 'Hue')}
+          max={180}
+          min={-180}
+          onChange={(e: any) => handleGlobalChange(ColorAdjustment.Hue, e.target.value)}
+          step={1}
+          value={adjustments.hue || 0}
+          trackClassName="hue-range-track"
+          onDragStateChange={onDragStateChange}
+        />
+      </div>
 
       <div className="p-2 bg-bg-tertiary rounded-md">
         <Text variant={TextVariants.heading} className="mb-3">

--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -470,6 +470,45 @@ export default function ColorPanel({
 
   return (
     <div className="space-y-4">
+      {isForMask && (
+        <div className="p-2 bg-bg-tertiary rounded-md">
+          <Text variant={TextVariants.heading} className="mb-2">
+            {t('adjustments.color.localHueTitle', 'Local Hue')}
+          </Text>
+          <Slider
+            label={t('adjustments.color.hue', 'Hue')}
+            max={180}
+            min={-180}
+            onChange={(e: any) => handleGlobalChange(ColorAdjustment.Hue, e.target.value)}
+            step={1}
+            value={adjustments.hue || 0}
+            trackClassName="hue-range-track"
+            onDragStateChange={onDragStateChange}
+            fineAdjustment={adjustments.useFineAdjustment}
+          />
+          <div className="flex items-center gap-2 mt-1">
+            <input
+              type="checkbox"
+              id="useFineAdjustment"
+              checked={!!adjustments.useFineAdjustment}
+              onChange={(e) =>
+                setAdjustments((prev: Partial<Adjustments>) => ({
+                  ...prev,
+                  useFineAdjustment: e.target.checked,
+                }))
+              }
+              className="rounded border-surface bg-bg-secondary text-accent focus:ring-accent w-4 h-4 cursor-pointer"
+            />
+            <label
+              htmlFor="useFineAdjustment"
+              className="text-xs text-text-secondary select-none cursor-pointer hover:text-text-primary"
+            >
+              {t('adjustments.color.useFineAdjustment', 'Use Fine Adjustment')}
+            </label>
+          </div>
+        </div>
+      )}
+
       <div className="p-2 bg-bg-tertiary rounded-md">
         <div className="flex justify-between items-center mb-2">
           <Text variant={TextVariants.heading}>{t('adjustments.color.whiteBalance')}</Text>

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -22,7 +22,6 @@ interface SliderProps {
   trackClassName?: string;
   fillOrigin?: 'min' | 'default';
   suffix?: string;
-  fineAdjustment?: boolean;
 }
 
 const DOUBLE_CLICK_THRESHOLD_MS = 300;
@@ -42,7 +41,6 @@ const Slider = ({
   trackClassName,
   fillOrigin = 'default',
   suffix = '',
-  fineAdjustment = false,
 }: SliderProps) => {
   const { t } = useTranslation();
   const [displayValue, setDisplayValue] = useState<number>(value);
@@ -175,8 +173,7 @@ const Slider = ({
       const deltaX = clientX - lastPointerXRef.current;
       const { min: curMin, max: curMax } = rangeRef.current;
 
-      const isFine = shiftKey || fineAdjustment;
-      const multiplier = isFine ? FINE_ADJUSTMENT_MULTIPLIER : 1;
+      const multiplier = shiftKey ? FINE_ADJUSTMENT_MULTIPLIER : 1;
       const deltaValue = (deltaX / sliderWidth) * (curMax - curMin) * multiplier;
 
       const prevAccumulated = accumulatedValueRef.current;
@@ -215,7 +212,7 @@ const Slider = ({
       window.removeEventListener('touchend', handlePointerUp);
       window.removeEventListener('touchcancel', handlePointerUp);
     };
-  }, [isDragging, fineAdjustment]);
+  }, [isDragging]);
 
   useEffect(() => {
     if (isDragging) {
@@ -367,8 +364,7 @@ const Slider = ({
     if (!inputEl) return;
 
     const rect = inputEl.getBoundingClientRect();
-    const isFine = e.shiftKey || e.altKey || fineAdjustment;
-    const multiplier = isFine ? FINE_ADJUSTMENT_MULTIPLIER : 1;
+    const multiplier = e.shiftKey || e.altKey ? FINE_ADJUSTMENT_MULTIPLIER : 1;
     const rawValue = pendingTouch.startValue + (deltaX / rect.width) * (max - min) * multiplier;
     const snappedValue = snapToStep(rawValue);
 

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -22,6 +22,7 @@ interface SliderProps {
   trackClassName?: string;
   fillOrigin?: 'min' | 'default';
   suffix?: string;
+  fineAdjustment?: boolean;
 }
 
 const DOUBLE_CLICK_THRESHOLD_MS = 300;
@@ -41,6 +42,7 @@ const Slider = ({
   trackClassName,
   fillOrigin = 'default',
   suffix = '',
+  fineAdjustment = false,
 }: SliderProps) => {
   const { t } = useTranslation();
   const [displayValue, setDisplayValue] = useState<number>(value);
@@ -173,7 +175,8 @@ const Slider = ({
       const deltaX = clientX - lastPointerXRef.current;
       const { min: curMin, max: curMax } = rangeRef.current;
 
-      const multiplier = shiftKey ? FINE_ADJUSTMENT_MULTIPLIER : 1;
+      const isFine = shiftKey || fineAdjustment;
+      const multiplier = isFine ? FINE_ADJUSTMENT_MULTIPLIER : 1;
       const deltaValue = (deltaX / sliderWidth) * (curMax - curMin) * multiplier;
 
       const prevAccumulated = accumulatedValueRef.current;
@@ -212,7 +215,7 @@ const Slider = ({
       window.removeEventListener('touchend', handlePointerUp);
       window.removeEventListener('touchcancel', handlePointerUp);
     };
-  }, [isDragging]);
+  }, [isDragging, fineAdjustment]);
 
   useEffect(() => {
     if (isDragging) {
@@ -364,7 +367,9 @@ const Slider = ({
     if (!inputEl) return;
 
     const rect = inputEl.getBoundingClientRect();
-    const rawValue = pendingTouch.startValue + (deltaX / rect.width) * (max - min);
+    const isFine = e.shiftKey || e.altKey || fineAdjustment;
+    const multiplier = isFine ? FINE_ADJUSTMENT_MULTIPLIER : 1;
+    const rawValue = pendingTouch.startValue + (deltaX / rect.width) * (max - min) * multiplier;
     const snappedValue = snapToStep(rawValue);
 
     accumulatedValueRef.current = rawValue;
@@ -460,6 +465,15 @@ const Slider = ({
   };
 
   const numericValue = isNaN(Number(value)) ? 0 : Number(value);
+  const getTrackStyle = () => {
+    if (trackClassName === 'hue-range-track') {
+      return {
+        background:
+          'linear-gradient(to right, #ff0000 0%, #ff8000 8.3%, #ffff00 16.7%, #80ff00 25%, #00ff00 33.3%, #00ff80 41.7%, #00ffff 50%, #0080ff 58.3%, #0000ff 66.7%, #8000ff 75%, #ff00ff 83.3%, #ff0080 91.7%, #ff0000 100%)',
+      };
+    }
+    return undefined;
+  };
 
   return (
     <div className="mb-2 group" ref={containerRef}>
@@ -523,6 +537,7 @@ const Slider = ({
           className={`absolute top-1/2 left-0 w-full h-1.5 -translate-y-1/4 rounded-full pointer-events-none ${
             trackClassName || 'bg-card-active'
           }`}
+          style={getTrackStyle()}
         />
         <div
           className="absolute top-1/2 h-1.5 -translate-y-1/4 rounded-full pointer-events-none bg-accent/25"

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -29,6 +29,9 @@ const FINE_ADJUSTMENT_MULTIPLIER = 0.2;
 const TOUCH_DRAG_THRESHOLD_PX = 10;
 const TOUCH_THUMB_HIT_RADIUS_PX = 24;
 
+const hasFineAdjustmentModifier = (event: MouseEvent | TouchEvent | React.MouseEvent | React.TouchEvent) =>
+  'shiftKey' in event && (event.shiftKey || event.altKey);
+
 const Slider = ({
   defaultValue = 0,
   label,
@@ -163,11 +166,11 @@ const Slider = ({
       if ('touches' in e) {
         if (e.touches.length === 0) return;
         clientX = e.touches[0].clientX;
-        shiftKey = e.shiftKey || e.altKey;
+        shiftKey = hasFineAdjustmentModifier(e);
         if (e.cancelable) e.preventDefault();
       } else {
         clientX = (e as MouseEvent).clientX;
-        shiftKey = (e as MouseEvent).shiftKey || (e as MouseEvent).altKey;
+        shiftKey = hasFineAdjustmentModifier(e);
       }
 
       const deltaX = clientX - lastPointerXRef.current;
@@ -364,7 +367,7 @@ const Slider = ({
     if (!inputEl) return;
 
     const rect = inputEl.getBoundingClientRect();
-    const multiplier = e.shiftKey || e.altKey ? FINE_ADJUSTMENT_MULTIPLIER : 1;
+    const multiplier = hasFineAdjustmentModifier(e) ? FINE_ADJUSTMENT_MULTIPLIER : 1;
     const rawValue = pendingTouch.startValue + (deltaX / rect.width) * (max - min) * multiplier;
     const snappedValue = snapToStep(rawValue);
 

--- a/src/utils/adjustments.ts
+++ b/src/utils/adjustments.ts
@@ -177,6 +177,7 @@ export interface Adjustments {
   halationAmount: number;
   highlights: number;
   hsl: Hsl;
+  hue: number;
   lensCorrectionMode: 'auto' | 'manual';
   lensDistortionAmount: number;
   lensVignetteAmount: number;
@@ -513,6 +514,7 @@ export const INITIAL_ADJUSTMENTS: Adjustments = {
     reds: { hue: 0, saturation: 0, luminance: 0 },
     yellows: { hue: 0, saturation: 0, luminance: 0 },
   },
+  hue: 0,
   lensCorrectionMode: 'manual',
   lensDistortionAmount: 100,
   lensVignetteAmount: 100,

--- a/src/utils/adjustments.ts
+++ b/src/utils/adjustments.ts
@@ -319,7 +319,6 @@ export interface MaskAdjustments {
   structure: number;
   temperature: number;
   tint: number;
-  useFineAdjustment: boolean;
   vibrance: number;
   whites: number;
 }
@@ -462,7 +461,6 @@ export const INITIAL_MASK_ADJUSTMENTS: MaskAdjustments = {
   structure: 0,
   temperature: 0,
   tint: 0,
-  useFineAdjustment: false,
   vibrance: 0,
   whites: 0,
 };
@@ -622,7 +620,6 @@ export const normalizeLoadedAdjustments = (loadedAdjustments: Adjustments): any 
         glowAmount: containerAdjustments.glowAmount ?? INITIAL_MASK_ADJUSTMENTS.glowAmount,
         halationAmount: containerAdjustments.halationAmount ?? INITIAL_MASK_ADJUSTMENTS.halationAmount,
         hue: containerAdjustments.hue ?? INITIAL_MASK_ADJUSTMENTS.hue,
-        useFineAdjustment: containerAdjustments.useFineAdjustment ?? INITIAL_MASK_ADJUSTMENTS.useFineAdjustment,
         colorGrading: { ...INITIAL_MASK_ADJUSTMENTS.colorGrading, ...(containerAdjustments.colorGrading || {}) },
         hsl: { ...INITIAL_MASK_ADJUSTMENTS.hsl, ...(containerAdjustments.hsl || {}) },
         curves: containerAdjustments.curves ? deepCloneCurves(containerAdjustments.curves) : getDefaultCurves(),
@@ -826,7 +823,6 @@ export const ADJUSTMENT_SECTIONS: Sections = {
     ColorAdjustment.ColorGrading,
     'colorCalibration',
     ColorAdjustment.Hue,
-    'useFineAdjustment',
   ],
   details: [
     DetailsAdjustment.Clarity,

--- a/src/utils/adjustments.ts
+++ b/src/utils/adjustments.ts
@@ -308,6 +308,7 @@ export interface MaskAdjustments {
   halationAmount: number;
   highlights: number;
   hsl: Hsl;
+  hue: number;
   id?: string;
   lumaNoiseReduction: number;
   saturation: number;
@@ -318,6 +319,7 @@ export interface MaskAdjustments {
   structure: number;
   temperature: number;
   tint: number;
+  useFineAdjustment: boolean;
   vibrance: number;
   whites: number;
 }
@@ -444,6 +446,7 @@ export const INITIAL_MASK_ADJUSTMENTS: MaskAdjustments = {
     reds: { hue: 0, saturation: 0, luminance: 0 },
     yellows: { hue: 0, saturation: 0, luminance: 0 },
   },
+  hue: 0,
   lumaNoiseReduction: 0,
   saturation: 0,
   sectionVisibility: {
@@ -459,6 +462,7 @@ export const INITIAL_MASK_ADJUSTMENTS: MaskAdjustments = {
   structure: 0,
   temperature: 0,
   tint: 0,
+  useFineAdjustment: false,
   vibrance: 0,
   whites: 0,
 };
@@ -617,6 +621,8 @@ export const normalizeLoadedAdjustments = (loadedAdjustments: Adjustments): any 
         flareAmount: containerAdjustments.flareAmount ?? INITIAL_MASK_ADJUSTMENTS.flareAmount,
         glowAmount: containerAdjustments.glowAmount ?? INITIAL_MASK_ADJUSTMENTS.glowAmount,
         halationAmount: containerAdjustments.halationAmount ?? INITIAL_MASK_ADJUSTMENTS.halationAmount,
+        hue: containerAdjustments.hue ?? INITIAL_MASK_ADJUSTMENTS.hue,
+        useFineAdjustment: containerAdjustments.useFineAdjustment ?? INITIAL_MASK_ADJUSTMENTS.useFineAdjustment,
         colorGrading: { ...INITIAL_MASK_ADJUSTMENTS.colorGrading, ...(containerAdjustments.colorGrading || {}) },
         hsl: { ...INITIAL_MASK_ADJUSTMENTS.hsl, ...(containerAdjustments.hsl || {}) },
         curves: containerAdjustments.curves ? deepCloneCurves(containerAdjustments.curves) : getDefaultCurves(),
@@ -819,6 +825,8 @@ export const ADJUSTMENT_SECTIONS: Sections = {
     ColorAdjustment.Hsl,
     ColorAdjustment.ColorGrading,
     'colorCalibration',
+    ColorAdjustment.Hue,
+    'useFineAdjustment',
   ],
   details: [
     DetailsAdjustment.Clarity,


### PR DESCRIPTION
## Description
This PR adds a local hue slider to the masks adjustments

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Add global hue slider

## Screenshots/Videos
<img width="296" height="306" alt="Screenshot from 2026-06-07 22-53-26" src="https://github.com/user-attachments/assets/900f48fb-b005-42be-92bf-593fbb4b7132" />

https://github.com/user-attachments/assets/3d9d0b24-1d83-4886-a49e-2bbf98e16f53

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
