### PR TITLE
feat: metadata export-naming tokens + single-image file naming

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -3261,6 +3261,22 @@ pub async fn import_files(
     Ok(())
 }
 
+/// Make an EXIF text value safe to use as part of a filename: strip characters
+/// that are invalid on Windows/Unix or could escape the target directory,
+/// collapse whitespace, trim trailing dots, and cap the length.
+fn sanitize_filename_component(value: &str) -> String {
+    let cleaned: String = value
+        .chars()
+        .map(|c| match c {
+            '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*' => ' ',
+            c if c.is_control() => ' ',
+            c => c,
+        })
+        .collect();
+    let collapsed = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    collapsed.trim_matches('.').trim().chars().take(100).collect()
+}
+
 pub fn generate_filename_from_template(
     template: &str,
     original_path: &std::path::Path,
@@ -3288,7 +3304,56 @@ pub fn generate_filename_from_template(
     result = result.replace("{hh}", &local_date.format("%H").to_string());
     result = result.replace("{mm}", &local_date.format("%M").to_string());
 
+    // Metadata tokens, named to match the Metadata panel's editable fields
+    // (Title / Author / Copyright / Comments). Read lazily (only when used) from
+    // the image's cached EXIF in the .rrdata sidecar, so unrelated callers pay no
+    // I/O cost.
+    if result.contains("{title}")
+        || result.contains("{author}")
+        || result.contains("{copyright}")
+        || result.contains("{comments}")
+    {
+        let exif = original_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .map(|n| original_path.with_file_name(format!("{}.rrdata", n)))
+            .map(|sidecar| crate::exif_processing::load_sidecar(&sidecar).exif)
+            .unwrap_or_default()
+            .unwrap_or_default();
+        let lookup = |keys: &[&str]| -> String {
+            keys.iter()
+                .find_map(|k| exif.get(*k))
+                .map(|v| sanitize_filename_component(v))
+                .unwrap_or_default()
+        };
+        result = result.replace("{title}", &lookup(&["ImageDescription", "XPTitle"]));
+        result = result.replace("{author}", &lookup(&["Artist"]));
+        result = result.replace("{copyright}", &lookup(&["Copyright"]));
+        result = result.replace("{comments}", &lookup(&["UserComment", "XPComment"]));
+    }
+
     result
+}
+
+/// Resolve a single export filename stem from a template for one image. Used by
+/// the export panel to build the suggested name shown in the save dialog, so the
+/// same tokens (dates, metadata, original filename) work for single-image export
+/// as for batch export. Falls back to the original stem if the result is empty.
+#[tauri::command]
+pub fn generate_export_filename(path: String, template: String) -> String {
+    let (source_path, _) = parse_virtual_path(&path);
+    let file_date = crate::exif_processing::get_creation_date_from_path(&source_path);
+    let stem = generate_filename_from_template(&template, &source_path, 1, 1, &file_date);
+    let trimmed = stem.trim();
+    if trimmed.is_empty() {
+        source_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("image")
+            .to_string()
+    } else {
+        trimmed.to_string()
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2279,6 +2279,7 @@ pub fn run() {
             file_management::move_files,
             file_management::rename_folder,
             file_management::rename_files,
+            file_management::generate_export_filename,
             file_management::duplicate_file,
             file_management::show_in_finder,
             file_management::delete_files_from_disk,

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -475,9 +475,19 @@ export default function ExportPanel({
 
       let outputFolderOrFile = '';
       if (numImages === 1) {
-        const originalFilename = pathsToExport[0].split(/[\\/]/).pop() || '';
-        const stem = originalFilename.substring(0, originalFilename.lastIndexOf('.')) || originalFilename;
-        const suggestedName = finalFilenameTemplate.replace('{original_filename}', stem);
+        let suggestedName: string;
+        try {
+          // Resolve the template (dates, metadata tokens, original filename) in the
+          // backend so single-image export supports the same tokens as batch.
+          suggestedName = await invoke<string>(Invokes.GenerateExportFilename, {
+            path: pathsToExport[0],
+            template: finalFilenameTemplate,
+          });
+        } catch {
+          const originalFilename = pathsToExport[0].split(/[\\/]/).pop() || '';
+          const stem = originalFilename.substring(0, originalFilename.lastIndexOf('.')) || originalFilename;
+          suggestedName = finalFilenameTemplate.replace('{original_filename}', stem);
+        }
         const outputFileName = `${suggestedName}.${selectedFormat.extensions[0]}`;
 
         outputFolderOrFile = isAndroid
@@ -607,18 +617,18 @@ export default function ExportPanel({
               )}
             </Section>
 
-            {numImages > 1 && (
-              <Section title={t('export.sections.fileNaming')}>
-                <input
-                  className="w-full bg-surface border border-surface rounded-md p-2 text-sm text-text-primary focus:ring-accent focus:border-accent"
-                  disabled={isExporting}
-                  onChange={(e) => setFilenameTemplate(e.target.value)}
-                  ref={filenameInputRef}
-                  type="text"
-                  value={filenameTemplate}
-                />
-                <div className="flex flex-wrap gap-2 mt-2">
-                  {FILENAME_VARIABLES.map((variable: string) => (
+            <Section title={t('export.sections.fileNaming')}>
+              <input
+                className="w-full bg-surface border border-surface rounded-md p-2 text-sm text-text-primary focus:ring-accent focus:border-accent"
+                disabled={isExporting}
+                onChange={(e) => setFilenameTemplate(e.target.value)}
+                ref={filenameInputRef}
+                type="text"
+                value={filenameTemplate}
+              />
+              <div className="flex flex-wrap gap-2 mt-2">
+                {FILENAME_VARIABLES.filter((variable: string) => numImages > 1 || variable !== '{sequence}').map(
+                  (variable: string) => (
                     <button
                       className="px-2 py-1 bg-surface text-text-secondary text-xs rounded-md hover:bg-card-active transition-colors disabled:opacity-50"
                       disabled={isExporting}
@@ -627,10 +637,10 @@ export default function ExportPanel({
                     >
                       {variable}
                     </button>
-                  ))}
-                </div>
-              </Section>
-            )}
+                  ),
+                )}
+              </div>
+            </Section>
 
             {fileFormat !== FileFormats.Cube && (
               <>

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -54,6 +54,7 @@ export enum Invokes {
   GenerateAiForegroundMask = 'generate_ai_foreground_mask',
   GenerateAiSkyMask = 'generate_ai_sky_mask',
   GenerateAiSubjectMask = 'generate_ai_subject_mask',
+  GenerateExportFilename = 'generate_export_filename',
   GenerateFullscreenPreview = 'generate_fullscreen_preview',
   GeneratePreviewForPath = 'generate_preview_for_path',
   GenerateMaskOverlay = 'generate_mask_overlay',

--- a/src/components/ui/ExportImportProperties.tsx
+++ b/src/components/ui/ExportImportProperties.tsx
@@ -26,12 +26,33 @@ export const FILE_FORMATS: Array<FileFormat> = [
 export const FILENAME_VARIABLES: Array<string> = [
   '{original_filename}',
   '{sequence}',
+  '{title}',
+  '{author}',
+  '{copyright}',
+  '{comments}',
   '{YYYY}',
   '{MM}',
   '{DD}',
   '{hh}',
   '{mm}',
 ];
+
+// The original author's default export filename template.
+export const DEFAULT_FILENAME_TEMPLATE = '{original_filename}_edited';
+
+// Guards against a persisted/imported template that references an unknown token
+// (e.g. a stray "{dcp_title}" saved into the last-used preset): an unrecognized
+// {token} never gets substituted and would leak into the output filename, so we
+// fall back to the default instead.
+export function sanitizeFilenameTemplate(template: string | null | undefined): string {
+  if (!template || !template.trim()) {
+    return DEFAULT_FILENAME_TEMPLATE;
+  }
+  const knownTokens = new Set(FILENAME_VARIABLES);
+  const usedTokens = template.match(/\{[^}]+\}/g) ?? [];
+  const hasUnknownToken = usedTokens.some((token) => !knownTokens.has(token));
+  return hasUnknownToken ? DEFAULT_FILENAME_TEMPLATE : template;
+}
 
 export interface ExportSettings {
   filenameTemplate: string | null;

--- a/src/hooks/useExportSettings.ts
+++ b/src/hooks/useExportSettings.ts
@@ -1,5 +1,10 @@
 import { useState, useMemo, useCallback } from 'react';
-import { ExportPreset, WatermarkAnchor } from '../components/ui/ExportImportProperties';
+import {
+  DEFAULT_FILENAME_TEMPLATE,
+  ExportPreset,
+  sanitizeFilenameTemplate,
+  WatermarkAnchor,
+} from '../components/ui/ExportImportProperties';
 
 export function useExportSettings() {
   const [fileFormat, setFileFormat] = useState('jpeg');
@@ -13,7 +18,7 @@ export function useExportSettings() {
   const [stripGps, setStripGps] = useState(true);
   const [exportMasks, setExportMasks] = useState(false);
   const [preserveFolders, setPreserveFolders] = useState(false);
-  const [filenameTemplate, setFilenameTemplate] = useState('{original_filename}_edited');
+  const [filenameTemplate, setFilenameTemplate] = useState(DEFAULT_FILENAME_TEMPLATE);
   const [enableWatermark, setEnableWatermark] = useState(false);
   const [watermarkPath, setWatermarkPath] = useState<string | null>(null);
   const [watermarkAnchor, setWatermarkAnchor] = useState<WatermarkAnchor>(WatermarkAnchor.BottomRight);
@@ -33,7 +38,7 @@ export function useExportSettings() {
     setStripGps(preset.stripGps);
     setExportMasks(preset.exportMasks ?? false);
     setPreserveFolders(preset.preserveFolders ?? false);
-    setFilenameTemplate(preset.filenameTemplate);
+    setFilenameTemplate(sanitizeFilenameTemplate(preset.filenameTemplate));
     setEnableWatermark(preset.enableWatermark);
     setWatermarkPath(preset.watermarkPath);
     setWatermarkAnchor(preset.watermarkAnchor as WatermarkAnchor);


### PR DESCRIPTION
## Description
Adds image-metadata tokens to export filename templates, and shows the File
Naming section for single-image export (previously it only appeared when
multiple images were selected).

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Filename templates now support metadata tokens matching the Metadata panel's
  editable fields: `{title}` (ImageDescription), `{author}` (Artist),
  `{copyright}` (Copyright), `{comments}` (UserComment). Values are read lazily
  from the image's cached EXIF and sanitized so they're safe in a filename.
- The File Naming section now appears for single-image export too; `{sequence}`
  stays hidden for single images. Single-image export resolves the template via a
  new `generate_export_filename` command, so it supports the same tokens (dates,
  metadata, original filename) as batch export.
- A saved/imported template that references an unknown token falls back to the
  default `{original_filename}_edited` instead of leaking the literal token into
  the output filename.

## Screenshots/Videos
<!-- Export panel → File Naming, with a single image selected, showing the new
     {title}/{author}/{copyright}/{comments} tokens. -->

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

Built and ran via `tauri dev`. Verified the File Naming section now shows for a
single image, the metadata/date tokens resolve into the suggested filename, and
an unknown token falls back to the default. `cargo check` and the Vite build are
clean.

**Test Configuration:**
- **OS:** Windows 11 Home
- **Hardware:** Intel Core i5-12400, NVIDIA GeForce GTX 1660 SUPER

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
- Metadata tokens are read only when used, from the `.rrdata` sidecar's cached
  EXIF, so unrelated callers pay no extra I/O. Batch export and the rename/import
  tools get the same tokens for free since they share the template function.
- For RAW files (e.g. Canon CR2) that lack an ImageDescription, `{title}` may be
  empty; `{author}`/`{copyright}` come through.
- Note: `npm run typecheck` surfaces pre-existing strict-`tsc` errors in the repo
  unrelated to this PR; the Vite/esbuild build does not gate on them.

## AI Disclaimer:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
