### PR TITLE
Add external editor protocol (--edit/--output) and fix OS open-with handling

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -17,6 +17,15 @@ use crate::image_processing::GpuContext;
 use crate::lens_correction::LensDatabase;
 use crate::lut_processing::Lut;
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalEditSession {
+    pub source: String,
+    pub output: String,
+    pub format: String,
+    pub jpeg_quality: u8,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct WindowState {
     pub width: u32,
@@ -123,6 +132,7 @@ pub struct AppState {
     pub indexing_task_handle: Mutex<Option<JoinHandle<()>>>,
     pub lut_cache: Mutex<HashMap<String, Arc<Lut>>>,
     pub initial_file_path: Mutex<Option<String>>,
+    pub pending_edit_session: Mutex<Option<ExternalEditSession>>,
     pub thumbnail_cancellation_token: Arc<AtomicBool>,
     pub thumbnail_progress: Mutex<ThumbnailProgressTracker>,
     pub preview_worker_tx: Mutex<Option<Sender<PreviewJob>>>,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1769,17 +1769,91 @@ fn handle_file_open(app_handle: &tauri::AppHandle, path: PathBuf) {
     }
 }
 
+enum LaunchRequest {
+    None,
+    OpenFile(String),
+    EditSession(ExternalEditSession),
+}
+
+fn parse_launch_args(args: &[String]) -> LaunchRequest {
+    let mut edit: Option<String> = None;
+    let mut output: Option<String> = None;
+    let mut format: Option<String> = None;
+    let mut quality: Option<u8> = None;
+    let mut plain: Option<String> = None;
+
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--edit" => edit = iter.next().cloned(),
+            "--output" => output = iter.next().cloned(),
+            "--format" => format = iter.next().cloned(),
+            "--quality" => quality = iter.next().and_then(|q| q.parse().ok()),
+            s if !s.starts_with('-') && plain.is_none() => plain = Some(s.to_string()),
+            _ => {}
+        }
+    }
+
+    match (edit, output) {
+        (Some(source), Some(output)) => {
+            let format = format.unwrap_or_else(|| {
+                std::path::Path::new(&output)
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .map(|e| e.to_lowercase())
+                    .unwrap_or_else(|| "jpg".to_string())
+            });
+            let format = match format.as_str() {
+                "tif" => "tiff".to_string(),
+                _ => format,
+            };
+            LaunchRequest::EditSession(ExternalEditSession {
+                source,
+                output,
+                format,
+                jpeg_quality: quality.unwrap_or(90),
+            })
+        }
+        (Some(source), None) => LaunchRequest::OpenFile(source),
+        _ => match plain {
+            Some(path) => LaunchRequest::OpenFile(path),
+            None => LaunchRequest::None,
+        },
+    }
+}
+
+fn emit_launch_request(app_handle: &tauri::AppHandle, request: LaunchRequest) {
+    match request {
+        LaunchRequest::EditSession(session) => {
+            if let Err(e) = app_handle.emit("external-edit-session", &session) {
+                log::error!("Failed to emit external-edit-session event: {}", e);
+            }
+        }
+        LaunchRequest::OpenFile(path) => {
+            handle_file_open(app_handle, PathBuf::from(path));
+        }
+        LaunchRequest::None => {}
+    }
+}
+
+#[derive(serde::Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct LaunchPayload {
+    open_with_file: Option<String>,
+    edit_session: Option<ExternalEditSession>,
+}
+
 #[tauri::command]
 fn frontend_ready(
     app_handle: tauri::AppHandle,
     window: tauri::Window,
     state: tauri::State<AppState>,
-) -> Result<(), String> {
+) -> Result<LaunchPayload, String> {
     let is_first_run = !state
         .window_setup_complete
         .swap(true, std::sync::atomic::Ordering::Relaxed);
     #[cfg(target_os = "android")]
-    let _ = (is_first_run, &window);
+    let _ = (is_first_run, &window, &app_handle);
 
     #[cfg(not(target_os = "android"))]
     {
@@ -1844,14 +1918,21 @@ fn frontend_ready(
         }
     }
 
-    if let Some(path) = state.initial_file_path.lock().unwrap().take() {
-        log::info!(
-            "Frontend is ready, emitting open-with-file for initial path: {}",
-            &path
-        );
-        handle_file_open(&app_handle, PathBuf::from(path));
+    let open_with_file = state.initial_file_path.lock().unwrap().take();
+    let edit_session = state.pending_edit_session.lock().unwrap().take();
+    if let Some(path) = &open_with_file {
+        log::info!("Frontend is ready, returning initial path: {}", path);
     }
-    Ok(())
+    if let Some(session) = &edit_session {
+        log::info!(
+            "Frontend is ready, returning external edit session for: {}",
+            &session.source
+        );
+    }
+    Ok(LaunchPayload {
+        open_with_file,
+        edit_session,
+    })
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -1874,15 +1955,8 @@ pub fn run() {
                 }
             }
 
-            if argv.len() > 1 {
-                let path_str = &argv[1];
-                if let Err(e) = app.emit("open-with-file", path_str) {
-                    log::error!(
-                        "Failed to emit open-with-file from single-instance handler: {}",
-                        e
-                    );
-                }
-            }
+            let forwarded_args = argv.get(1..).unwrap_or(&[]);
+            emit_launch_request(app, parse_launch_args(forwarded_args));
         }));
     }
 
@@ -1907,10 +1981,18 @@ pub fn run() {
         .setup(|app| {
             #[cfg(any(windows, target_os = "linux"))]
             {
-                if let Some(arg) = std::env::args().nth(1) {
-                     let state = app.state::<AppState>();
-                     log::info!("Windows/Linux initial open: Storing path {} for later.", &arg);
-                     *state.initial_file_path.lock().unwrap() = Some(arg);
+                let args: Vec<String> = std::env::args().skip(1).collect();
+                let state = app.state::<AppState>();
+                match parse_launch_args(&args) {
+                    LaunchRequest::EditSession(session) => {
+                        log::info!("Initial launch with external edit session for: {}", &session.source);
+                        *state.pending_edit_session.lock().unwrap() = Some(session);
+                    }
+                    LaunchRequest::OpenFile(path) => {
+                        log::info!("Windows/Linux initial open: Storing path {} for later.", &path);
+                        *state.initial_file_path.lock().unwrap() = Some(path);
+                    }
+                    LaunchRequest::None => {}
                 }
             }
 
@@ -2172,6 +2254,7 @@ pub fn run() {
             indexing_task_handle: Mutex::new(None),
             lut_cache: Mutex::new(HashMap::new()),
             initial_file_path: Mutex::new(None),
+            pending_edit_session: Mutex::new(None),
             thumbnail_cancellation_token: Arc::new(AtomicBool::new(false)),
             thumbnail_progress: Mutex::new(ThumbnailProgressTracker { total: 0, completed: 0 }),
             preview_worker_tx: Mutex::new(None),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,9 @@ import { useFileOperations } from './hooks/useFileOperations';
 import { useAppContextMenus } from './hooks/useAppContextMenus';
 import { useSortedLibrary } from './hooks/useSortedLibrary';
 import { useAppNavigation } from './hooks/useAppNavigation';
+import { useExternalEditSession } from './hooks/useExternalEditSession';
+import ExternalEditBar from './components/ui/ExternalEditBar';
+import { Status } from './components/ui/ExportImportProperties';
 
 import { useEditorActions } from './hooks/useEditorActions';
 import { useLibraryActions } from './hooks/useLibraryActions';
@@ -269,6 +272,12 @@ function App() {
     clearThumbnailQueue,
     refs: navigationRefs,
   });
+
+  const {
+    externalEditSession,
+    isFinishing: isExternalEditFinishing,
+    finishExternalEdit,
+  } = useExternalEditSession(handleImageSelect);
 
   const {
     handleRate,
@@ -637,7 +646,15 @@ function App() {
         >
           <div className="flex flex-row grow h-full min-h-0">
             {!shouldHideFolderTree && renderFolderTree()}
-            <div className="flex-1 flex flex-col min-w-0">
+            <div className="relative flex-1 flex flex-col min-w-0">
+              {selectedImage && externalEditSession && (
+                <ExternalEditBar
+                  session={externalEditSession}
+                  isFinishing={isExternalEditFinishing}
+                  errorMessage={exportState.status === Status.Error ? exportState.errorMessage : ''}
+                  onDone={finishExternalEdit}
+                />
+              )}
               {selectedImage ? (
                 <EditorView
                   transformWrapperRef={transformWrapperRef}

--- a/src/components/ui/ExternalEditBar.tsx
+++ b/src/components/ui/ExternalEditBar.tsx
@@ -1,0 +1,30 @@
+import { Check, Loader } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import Button from './Button';
+import { ExternalEditSession } from '../../store/useProcessStore';
+
+interface ExternalEditBarProps {
+  session: ExternalEditSession;
+  isFinishing: boolean;
+  errorMessage: string;
+  onDone: () => void;
+}
+
+export default function ExternalEditBar({ session, isFinishing, errorMessage, onDone }: ExternalEditBarProps) {
+  const { t } = useTranslation();
+  const outputName = session.output.split(/[\\/]/).pop() || session.output;
+
+  return (
+    <div className="absolute bottom-6 left-1/2 -translate-x-1/2 z-40 flex items-center gap-3 bg-bg-secondary border border-surface rounded-lg shadow-lg px-4 py-2">
+      <span className="text-sm text-text-secondary whitespace-nowrap">
+        {t('editor.externalEdit.savesTo')} <span className="text-text-primary">{outputName}</span>
+      </span>
+      {errorMessage && <span className="text-sm text-red-400 max-w-xs truncate">{errorMessage}</span>}
+      <Button onClick={onDone} disabled={isFinishing} className="py-1.5">
+        {isFinishing ? <Loader size={16} className="animate-spin" /> : <Check size={16} />}
+        {isFinishing ? t('editor.externalEdit.exporting') : t('editor.externalEdit.done')}
+      </Button>
+    </div>
+  );
+}

--- a/src/hooks/useAppInitialization.ts
+++ b/src/hooks/useAppInitialization.ts
@@ -5,6 +5,7 @@ import { useSettingsStore } from '../store/useSettingsStore';
 import { useUIStore } from '../store/useUIStore';
 import { useLibraryStore } from '../store/useLibraryStore';
 import { useEditorStore } from '../store/useEditorStore';
+import { useProcessStore } from '../store/useProcessStore';
 import { THEMES, DEFAULT_THEME_ID, ThemeProps } from '../utils/themes';
 import { COPYABLE_ADJUSTMENT_KEYS } from '../utils/adjustments';
 import {
@@ -221,7 +222,15 @@ export const useAppInitialization = ({
           });
         }
 
-        invoke('frontend_ready').catch((e) => console.error('Failed to notify backend of readiness:', e));
+        invoke('frontend_ready')
+          .then((launch: any) => {
+            if (launch?.editSession) {
+              useProcessStore.getState().setProcess({ externalEditSession: launch.editSession });
+            } else if (launch?.openWithFile) {
+              useProcessStore.getState().setProcess({ initialFileToOpen: launch.openWithFile });
+            }
+          })
+          .catch((e) => console.error('Failed to notify backend of readiness:', e));
       })
       .catch((err) => {
         console.error('Failed to load settings:', err);

--- a/src/hooks/useExternalEditSession.ts
+++ b/src/hooks/useExternalEditSession.ts
@@ -1,0 +1,96 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { exit } from '@tauri-apps/plugin-process';
+
+import { useProcessStore } from '../store/useProcessStore';
+import { useEditorStore } from '../store/useEditorStore';
+import { Invokes } from '../components/ui/AppProperties';
+import { ExportSettings, Status } from '../components/ui/ExportImportProperties';
+import { debouncedSave } from './useEditorActions';
+
+/**
+ * Handles files handed to the app from outside (OS "open with" and the
+ * external editor protocol: rapidraw --edit <file> --output <file>).
+ * Opens the requested image in the editor and, for edit sessions, exports
+ * the result to the caller-provided output path and exits the app.
+ */
+export function useExternalEditSession(handleImageSelect: (path: string) => void) {
+  const initialFileToOpen = useProcessStore((state) => state.initialFileToOpen);
+  const externalEditSession = useProcessStore((state) => state.externalEditSession);
+  const exportStatus = useProcessStore((state) => state.exportState.status);
+  const [isFinishing, setIsFinishing] = useState(false);
+
+  const handleImageSelectRef = useRef(handleImageSelect);
+  useEffect(() => {
+    handleImageSelectRef.current = handleImageSelect;
+  });
+
+  useEffect(() => {
+    if (!initialFileToOpen) return;
+    useProcessStore.getState().setProcess({ initialFileToOpen: null });
+    handleImageSelectRef.current(initialFileToOpen);
+  }, [initialFileToOpen]);
+
+  useEffect(() => {
+    if (!externalEditSession) return;
+    setIsFinishing(false);
+    handleImageSelectRef.current(externalEditSession.source);
+  }, [externalEditSession]);
+
+  useEffect(() => {
+    if (!isFinishing) return;
+    if (exportStatus === Status.Success) {
+      exit(0);
+    } else if (exportStatus === Status.Error || exportStatus === Status.Cancelled) {
+      setIsFinishing(false);
+    }
+  }, [isFinishing, exportStatus]);
+
+  const finishExternalEdit = useCallback(async () => {
+    const session = useProcessStore.getState().externalEditSession;
+    const { selectedImage, adjustments } = useEditorStore.getState();
+    if (!session || !selectedImage) return;
+
+    debouncedSave.flush();
+
+    const exportSettings: ExportSettings = {
+      filenameTemplate: null,
+      jpegQuality: session.jpegQuality,
+      keepMetadata: true,
+      preserveTimestamps: false,
+      preserveFolders: false,
+      resize: null,
+      stripGps: false,
+      exportMasks: false,
+      watermark: null,
+    };
+
+    setIsFinishing(true);
+    useProcessStore.getState().setExportState({
+      status: Status.Exporting,
+      progress: { current: 0, total: 1 },
+      errorMessage: '',
+    });
+
+    try {
+      await invoke(Invokes.ExportImages, {
+        paths: [session.source],
+        outputFolderOrFile: session.output,
+        isExplicitFilePath: true,
+        baseOriginFolders: [],
+        exportSettings,
+        outputFormat: session.format,
+        currentEditPath: selectedImage.path,
+        currentEditAdjustments: adjustments || null,
+      });
+    } catch (error) {
+      setIsFinishing(false);
+      useProcessStore.getState().setExportState({
+        status: Status.Error,
+        errorMessage: typeof error === 'string' ? error : 'Export failed',
+      });
+    }
+  }, []);
+
+  return { externalEditSession, isFinishing, finishExternalEdit };
+}

--- a/src/hooks/useTauriListeners.ts
+++ b/src/hooks/useTauriListeners.ts
@@ -81,6 +81,9 @@ export function useTauriListeners({
       listen('open-with-file', (event: any) => {
         if (isEffectActive) useProcessStore.getState().setProcess({ initialFileToOpen: event.payload as string });
       }),
+      listen('external-edit-session', (event: any) => {
+        if (isEffectActive) useProcessStore.getState().setProcess({ externalEditSession: event.payload });
+      }),
       listen('waveform-update', (event: any) => {
         if (isEffectActive && event.payload.path === useEditorStore.getState().selectedImage?.path) {
           useEditorStore.getState().setEditor({ waveform: event.payload.data });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -498,6 +498,11 @@
         "transform": "Perspective and keystone correction"
       }
     },
+    "externalEdit": {
+      "done": "Done",
+      "exporting": "Exporting…",
+      "savesTo": "External edit — saves to"
+    },
     "masks": {
       "actions": {
         "addNewComponent": "Add New Component",

--- a/src/store/useProcessStore.ts
+++ b/src/store/useProcessStore.ts
@@ -2,6 +2,13 @@ import { create } from 'zustand';
 import { Progress } from '../components/ui/AppProperties';
 import { ExportState, ImportState, Status } from '../components/ui/ExportImportProperties';
 
+export interface ExternalEditSession {
+  source: string;
+  output: string;
+  format: string;
+  jpegQuality: number;
+}
+
 interface ProcessState {
   exportState: ExportState;
   importState: ImportState;
@@ -14,6 +21,7 @@ interface ProcessState {
   isCopied: boolean;
   isPasted: boolean;
   initialFileToOpen: string | null;
+  externalEditSession: ExternalEditSession | null;
 
   setProcess: (state: Partial<ProcessState> | ((state: ProcessState) => Partial<ProcessState>)) => void;
   setExportState: (updater: Partial<ExportState> | ((state: ExportState) => Partial<ExportState>)) => void;
@@ -37,6 +45,7 @@ export const useProcessStore = create<ProcessState>((set, get) => ({
   isCopied: false,
   isPasted: false,
   initialFileToOpen: null,
+  externalEditSession: null,
 
   setProcess: (updater) => {
     set((prev) => {


### PR DESCRIPTION
## Description
Lets other applications round-trip a photo through RapidRAW, Lightroom→Photoshop style:

```
rapidraw --edit <file> --output <path> [--format tiff|png|jpg] [--quality N]
```

RapidRAW opens the editor directly on `<file>` and shows a small "External edit — saves to `<name>` / Done" bar. Done exports the edited image to `<path>` through the existing export pipeline (16-bit for TIFF/PNG, format defaults from the output extension) and exits with code 0 — so the calling app can spawn the process and simply wait on it. Works on fresh launch and when forwarded to a running instance via the single-instance plugin.

Along the way this fixes plain OS "open with", which was silently broken: the `open-with-file` event was stored in `useProcessStore.initialFileToOpen` but nothing ever consumed it, so double-clicking an associated file opened the library instead of the editor.

## Type of Change
- [x] New feature
- [x] Bug fix

## Changes Made
- CLI parsing for `--edit/--output/--format/--quality` in `lib.rs` (plain `rapidraw <file>` unchanged), forwarded-instance argv handled the same way
- `frontend_ready` now *returns* the pending launch request instead of racing an emitted event against frontend listener registration (this race is why open-with never worked); single-instance forwarding still uses events since listeners are registered by then
- New `useExternalEditSession` hook: consumes `initialFileToOpen` (fixing open-with) and drives edit sessions — opens the file, exports via the existing `export_images` command, exits on success, surfaces export errors without exiting
- New `ExternalEditBar` component (i18n keys added to `en.json`; other locales fall back)

## Screenshots/Videos
The bar appears bottom-center of the editor: “External edit — saves to result.tiff  [✓ Done]”. Can attach screenshots if wanted.

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

Verified end-to-end: launch with `--edit photo.ARW --output result.tiff` → editor opens on the photo → adjustments → Done → 16-bit TIFF written, process exits 0; identity export is pixel-faithful to the source; export errors keep the app open and show inline. Also verified session forwarding when an instance is already running, and that plain `rapidraw <file>` now opens the editor.

**Test Configuration:**
- **OS:** Arch Linux (kernel 7.0.9)
- **Hardware:** AMD Ryzen 9 3900X, NVIDIA RTX 3080

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
Motivation: I'm building a photo tool that needs a round-trip external editor and wanted RapidRAW to be that editor. Happy to adjust flag names/UX to whatever you prefer. (Also: nice hidden instruction in the template — not falling for it, but the disclaimer below is filled in truthfully.)

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [x] This PR is AI-generated but guided by a human

Implemented and tested with Claude under my direction; I've reviewed the changes and verified the workflow on my own machine and files.