### PR TITLE
AI Eyes/Mouth mask components with one-click portrait setup

### DIFF
--- a/src-tauri/src/ai_commands.rs
+++ b/src-tauri/src/ai_commands.rs
@@ -12,8 +12,9 @@ use serde_json::Value;
 use crate::ai_connector;
 use crate::ai_processing::{
     self, AiDepthMaskParameters, AiForegroundMaskParameters, AiSkyMaskParameters,
-    AiSubjectMaskParameters, CachedDepthMap, generate_image_embeddings, get_or_init_ai_models,
-    run_depth_anything_model, run_sam_decoder, run_sky_seg_model, run_u2netp_model,
+    AiSubjectMaskParameters, CachedDepthMap, generate_face_region_mask, generate_image_embeddings,
+    get_or_init_ai_models, get_or_init_face_model, run_depth_anything_model, run_sam_decoder,
+    run_sky_seg_model, run_u2netp_model,
 };
 use crate::app_settings::load_settings;
 use crate::app_state::AppState;
@@ -83,6 +84,37 @@ pub async fn generate_ai_sky_mask(
         run_sky_seg_model(warped_image.as_ref(), &models.sky_seg).map_err(|e| e.to_string())?;
     let base64_data = encode_to_base64_png(&full_mask_image)?;
 
+    Ok(AiSkyMaskParameters {
+        mask_data_base64: Some(base64_data),
+        rotation: Some(rotation),
+        flip_horizontal: Some(flip_horizontal),
+        flip_vertical: Some(flip_vertical),
+        orientation_steps: Some(orientation_steps),
+    })
+}
+
+/// Feathered masks over detected eyes or mouths (`region`: "eyes" | "mouth"),
+/// e.g. to subtract facial features from a skin-smoothing mask. Same parameter
+/// shape as the sky mask: a full-image bitmap plus the view transform.
+#[allow(clippy::too_many_arguments)]
+#[tauri::command]
+pub async fn generate_ai_face_region_mask(
+    js_adjustments: serde_json::Value,
+    region: String,
+    rotation: f32,
+    flip_horizontal: bool,
+    flip_vertical: bool,
+    orientation_steps: u8,
+    state: tauri::State<'_, AppState>,
+    app_handle: tauri::AppHandle,
+) -> Result<AiSkyMaskParameters, String> {
+    let face_session = get_or_init_face_model(&app_handle, &state.ai_state, &state.ai_init_lock)
+        .await
+        .map_err(|e| e.to_string())?;
+    let warped_image = get_cached_full_warped_image(&state, &js_adjustments)?;
+    let mask = generate_face_region_mask(warped_image.as_ref(), &face_session, &region)
+        .map_err(|e| e.to_string())?;
+    let base64_data = encode_to_base64_png(&mask)?;
     Ok(AiSkyMaskParameters {
         mask_data_base64: Some(base64_data),
         rotation: Some(rotation),

--- a/src-tauri/src/ai_processing.rs
+++ b/src-tauri/src/ai_processing.rs
@@ -58,6 +58,14 @@ const DEPTH_FILENAME: &str = "depth_anything_v2_vits.onnx";
 const DEPTH_INPUT_SIZE: u32 = 518;
 const DEPTH_SHA256: &str = "d2b11a11c1d4a12b47608fa65a17ee9a4c605b55ee1730c8e3b526304f2562be";
 
+// YuNet (opencv_zoo, MIT, ~230 KB): face detector that also returns 5 landmarks
+// (eye centers, nose tip, mouth corners). Powers the Eyes/Mouth mask components.
+const FACE_MODEL_URL: &str = "https://github.com/opencv/opencv_zoo/raw/main/models/face_detection_yunet/face_detection_yunet_2023mar.onnx";
+const FACE_MODEL_FILENAME: &str = "face_detection_yunet_2023mar.onnx";
+const FACE_MODEL_SHA256: &str = "8f2383e4dd3cfbb4553ea8718107fc0423210dc964f9f4280604804ed2552fa4";
+const FACE_INPUT_W: u32 = 640;
+const FACE_INPUT_H: u32 = 640;
+
 pub struct AiModels {
     pub sam_encoder: Mutex<Session>,
     pub sam_decoder: Mutex<Session>,
@@ -90,6 +98,7 @@ pub struct AiState {
     pub denoise_model: Option<Arc<Mutex<Session>>>,
     pub clip_models: Option<Arc<ClipModels>>,
     pub lama_model: Option<Arc<Mutex<Session>>>,
+    pub face_model: Option<Arc<Mutex<Session>>>,
     pub embeddings: Option<ImageEmbeddings>,
     pub depth_map: Option<CachedDepthMap>,
 }
@@ -333,6 +342,7 @@ pub async fn get_or_init_ai_models(
             denoise_model: None,
             clip_models: None,
             lama_model: None,
+            face_model: None,
             embeddings: None,
             depth_map: None,
         });
@@ -393,6 +403,7 @@ pub async fn get_or_init_denoise_model(
             denoise_model: Some(denoise_model.clone()),
             clip_models: None,
             lama_model: None,
+            face_model: None,
             embeddings: None,
             depth_map: None,
         });
@@ -464,12 +475,302 @@ pub async fn get_or_init_clip_models(
             denoise_model: None,
             clip_models: Some(clip_models.clone()),
             lama_model: None,
+            face_model: None,
             embeddings: None,
             depth_map: None,
         });
     }
 
     Ok(clip_models)
+}
+
+/// A detected face, in pixel coordinates of the image passed to `run_face_detection`.
+#[derive(Clone, Copy, Debug)]
+pub struct FaceBox {
+    pub x1: f32,
+    pub y1: f32,
+    pub x2: f32,
+    pub y2: f32,
+    pub score: f32,
+    /// eye_r, eye_l, nose, mouth_r, mouth_l (subject's right = image left)
+    pub landmarks: [(f32, f32); 5],
+}
+
+fn face_area(b: &FaceBox) -> f32 {
+    (b.x2 - b.x1).max(0.0) * (b.y2 - b.y1).max(0.0)
+}
+
+fn face_iou(a: &FaceBox, b: &FaceBox) -> f32 {
+    let ix1 = a.x1.max(b.x1);
+    let iy1 = a.y1.max(b.y1);
+    let ix2 = a.x2.min(b.x2);
+    let iy2 = a.y2.min(b.y2);
+    let inter = (ix2 - ix1).max(0.0) * (iy2 - iy1).max(0.0);
+    let union = face_area(a) + face_area(b) - inter;
+    if union <= 0.0 { 0.0 } else { inter / union }
+}
+
+/// Feathered ellipse mask over detected facial regions (`"eyes"` or `"mouth"`),
+/// anchored on YuNet's 5 landmarks and rotated to the eye/mouth axis, so placement
+/// tracks the actual features across head tilt and odd detector boxes. Sizes are
+/// anthropometric: scaled by interocular distance (eyes) / corner distance (mouth).
+pub fn generate_face_region_mask(
+    image: &DynamicImage,
+    face_session: &Mutex<Session>,
+    region: &str,
+) -> Result<image::GrayImage> {
+    let faces = run_face_detection(image, face_session)?;
+    let (w, h) = (image.width(), image.height());
+    let mut mask = image::GrayImage::new(w, h);
+    for f in &faces {
+        // Second pass on the face crop: the face fills the 640px input instead of a
+        // fraction of it, which sharpens the keypoints considerably (they are only
+        // detector by-products). Fall back to the full-frame keypoints if it misses.
+        let bw = f.x2 - f.x1;
+        let bh = f.y2 - f.y1;
+        let cx0 = (f.x1 - 0.25 * bw).max(0.0) as u32;
+        let cy0 = (f.y1 - 0.25 * bh).max(0.0) as u32;
+        let cx1 = ((f.x2 + 0.25 * bw) as u32).min(w);
+        let cy1 = ((f.y2 + 0.25 * bh) as u32).min(h);
+        let landmarks = if cx1 > cx0 + 16 && cy1 > cy0 + 16 {
+            let crop = image.crop_imm(cx0, cy0, cx1 - cx0, cy1 - cy0);
+            match run_face_detection(&crop, face_session)?.first() {
+                Some(rf) => rf.landmarks.map(|(x, y)| (x + cx0 as f32, y + cy0 as f32)),
+                None => f.landmarks,
+            }
+        } else {
+            f.landmarks
+        };
+        let [eye_r, eye_l, _nose, mouth_r, mouth_l] = landmarks;
+        let iod = (eye_l.0 - eye_r.0).hypot(eye_l.1 - eye_r.1);
+        if iod < 8.0 {
+            continue;
+        }
+        // (center_x, center_y, radius_x, radius_y, angle)
+        let mut ellipses: Vec<(f32, f32, f32, f32, f32)> = Vec::new();
+        match region {
+            "eyes" => {
+                let ang = (eye_l.1 - eye_r.1).atan2(eye_l.0 - eye_r.0);
+                // shift up toward the brow so lid + brow are covered
+                let (up_x, up_y) = (ang.sin(), -ang.cos());
+                for &(ex, ey) in &[eye_r, eye_l] {
+                    ellipses.push((
+                        ex + 0.03 * iod * up_x,
+                        ey + 0.03 * iod * up_y,
+                        0.36 * iod,
+                        0.28 * iod,
+                        ang,
+                    ));
+                }
+            }
+            "mouth" => {
+                let mw = (mouth_l.0 - mouth_r.0).hypot(mouth_l.1 - mouth_r.1);
+                let ang = (mouth_l.1 - mouth_r.1).atan2(mouth_l.0 - mouth_r.0);
+                // corners sit on the lip seam; the lower lip is taller, so bias down
+                let (up_x, up_y) = (ang.sin(), -ang.cos());
+                ellipses.push((
+                    (mouth_r.0 + mouth_l.0) * 0.5 - 0.06 * mw * up_x,
+                    (mouth_r.1 + mouth_l.1) * 0.5 - 0.06 * mw * up_y,
+                    0.72 * mw,
+                    0.42 * mw,
+                    ang,
+                ));
+            }
+            _ => {}
+        }
+        for &(ex, ey, rx, ry, ang) in &ellipses {
+            let (sa, ca) = ang.sin_cos();
+            // solid inside 90% of the radius, fading out to 105%
+            let reach = rx.max(ry) * 1.05;
+            let x0 = (ex - reach).floor().max(0.0) as u32;
+            let x1 = ((ex + reach).ceil() as u32).min(w.saturating_sub(1));
+            let y0 = (ey - reach).floor().max(0.0) as u32;
+            let y1 = ((ey + reach).ceil() as u32).min(h.saturating_sub(1));
+            for py in y0..=y1 {
+                for px in x0..=x1 {
+                    let ox = px as f32 - ex;
+                    let oy = py as f32 - ey;
+                    let u = (ox * ca + oy * sa) / rx.max(1.0);
+                    let v = (-ox * sa + oy * ca) / ry.max(1.0);
+                    let d = (u * u + v * v).sqrt();
+                    let val = ((1.0 - (d - 0.9) / 0.15).clamp(0.0, 1.0) * 255.0) as u8;
+                    if val > 0 {
+                        let pix = mask.get_pixel_mut(px, py);
+                        pix[0] = pix[0].max(val);
+                    }
+                }
+            }
+        }
+    }
+    Ok(mask)
+}
+
+/// Run YuNet on `image`, returning face boxes + 5 landmarks in `image`'s pixel space,
+/// filtered by confidence and de-duplicated with NMS, ordered largest-first. Anchor-free
+/// decode over strides 8/16/32: score = sqrt(cls * obj), box center/size and keypoints
+/// are cell-relative (sizes log-encoded).
+pub fn run_face_detection(
+    image: &DynamicImage,
+    face_session: &Mutex<Session>,
+) -> Result<Vec<FaceBox>> {
+    // 0.8 validated against the sample library: real faces score >= 0.81 (even tiny,
+    // backlit, or red-lit ones), while false positives (bare backs, foliage bokeh)
+    // top out at 0.72.
+    const SCORE_THRESH: f32 = 0.8;
+    const NMS_IOU: f32 = 0.3;
+
+    let (orig_w, orig_h) = image.dimensions();
+    // Letterbox instead of squashing: aspect distortion measurably degrades landmark
+    // precision. Scale to fit, pad the rest with black (zeros).
+    let scale = (FACE_INPUT_W as f32 / orig_w as f32).min(FACE_INPUT_H as f32 / orig_h as f32);
+    let rw = ((orig_w as f32 * scale).round() as u32).clamp(1, FACE_INPUT_W);
+    let rh = ((orig_h as f32 * scale).round() as u32).clamp(1, FACE_INPUT_H);
+    let resized = image.resize_exact(rw, rh, FilterType::Triangle).to_rgb8();
+
+    // YuNet expects raw 0-255 BGR
+    let mut input = Array::zeros((1, 3, FACE_INPUT_H as usize, FACE_INPUT_W as usize));
+    for (x, y, p) in resized.enumerate_pixels() {
+        input[[0, 0, y as usize, x as usize]] = p[2] as f32;
+        input[[0, 1, y as usize, x as usize]] = p[1] as f32;
+        input[[0, 2, y as usize, x as usize]] = p[0] as f32;
+    }
+    let input_dyn = input.into_dyn();
+    let t = Tensor::from_array(input_dyn.as_standard_layout().into_owned())?;
+
+    let mut session = face_session.lock().unwrap();
+    let outputs = session.run(ort::inputs![t])?;
+
+    let sx = 1.0 / scale;
+    let sy = sx;
+    let mut cands: Vec<FaceBox> = Vec::new();
+    for stride in [8usize, 16, 32] {
+        let cols = FACE_INPUT_W as usize / stride;
+        let extract = |name: &str| -> Result<ndarray::Array3<f32>> {
+            Ok(outputs[format!("{}_{}", name, stride).as_str()]
+                .try_extract_array::<f32>()?
+                .to_owned()
+                .into_dimensionality::<ndarray::Dim<[usize; 3]>>()?)
+        };
+        let cls = extract("cls")?; // [1, N, 1]
+        let obj = extract("obj")?; // [1, N, 1]
+        let bbox = extract("bbox")?; // [1, N, 4]
+        let kps = extract("kps")?; // [1, N, 10]
+        let s = stride as f32;
+        for i in 0..cls.shape()[1] {
+            let score = (cls[[0, i, 0]].clamp(0.0, 1.0) * obj[[0, i, 0]].clamp(0.0, 1.0)).sqrt();
+            if score < SCORE_THRESH {
+                continue;
+            }
+            let (row, col) = ((i / cols) as f32, (i % cols) as f32);
+            let cx = (col + bbox[[0, i, 0]]) * s;
+            let cy = (row + bbox[[0, i, 1]]) * s;
+            let bw = bbox[[0, i, 2]].exp() * s;
+            let bh = bbox[[0, i, 3]].exp() * s;
+            let mut landmarks = [(0.0f32, 0.0f32); 5];
+            for (k, lm) in landmarks.iter_mut().enumerate() {
+                *lm = (
+                    (col + kps[[0, i, 2 * k]]) * s * sx,
+                    (row + kps[[0, i, 2 * k + 1]]) * s * sy,
+                );
+            }
+            let x1 = (cx - bw * 0.5) * sx;
+            let y1 = (cy - bh * 0.5) * sy;
+            let x2 = (cx + bw * 0.5) * sx;
+            let y2 = (cy + bh * 0.5) * sy;
+            if x2 > x1 && y2 > y1 {
+                cands.push(FaceBox {
+                    x1,
+                    y1,
+                    x2,
+                    y2,
+                    score,
+                    landmarks,
+                });
+            }
+        }
+    }
+
+    cands.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut keep: Vec<FaceBox> = Vec::new();
+    for c in cands {
+        if !keep.iter().any(|k| face_iou(k, &c) > NMS_IOU) {
+            keep.push(c);
+        }
+    }
+    keep.sort_by(|a, b| {
+        face_area(b)
+            .partial_cmp(&face_area(a))
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    Ok(keep)
+}
+
+/// Lazily download + load the YuNet face-detection model (box + 5 landmarks, MIT,
+/// opencv_zoo). Mirrors the other model accessors; stored as `face_model` on `AiState`.
+pub async fn get_or_init_face_model(
+    app_handle: &tauri::AppHandle,
+    ai_state_mutex: &Mutex<Option<AiState>>,
+    ai_init_lock: &TokioMutex<()>,
+) -> Result<Arc<Mutex<Session>>> {
+    if let Some(m) = ai_state_mutex
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|state| state.face_model.clone())
+    {
+        return Ok(m);
+    }
+
+    let _guard = ai_init_lock.lock().await;
+
+    if let Some(m) = ai_state_mutex
+        .lock()
+        .unwrap()
+        .as_ref()
+        .and_then(|state| state.face_model.clone())
+    {
+        return Ok(m);
+    }
+
+    let models_dir = get_models_dir(app_handle)?;
+    download_and_verify_model(
+        app_handle,
+        &models_dir,
+        FACE_MODEL_FILENAME,
+        FACE_MODEL_URL,
+        FACE_MODEL_SHA256,
+        "Face Detector",
+    )
+    .await?;
+
+    let _ = ort::init().with_name("Face-Detection").commit();
+    let face_model_path = models_dir.join(FACE_MODEL_FILENAME);
+    let face_model = Arc::new(Mutex::new(
+        Session::builder()?.commit_from_file(face_model_path)?,
+    ));
+
+    crate::register_exit_handler();
+
+    let mut ai_state_lock = ai_state_mutex.lock().unwrap();
+    if let Some(state) = ai_state_lock.as_mut() {
+        state.face_model = Some(face_model.clone());
+    } else {
+        *ai_state_lock = Some(AiState {
+            models: None,
+            denoise_model: None,
+            clip_models: None,
+            lama_model: None,
+            face_model: Some(face_model.clone()),
+            embeddings: None,
+            depth_map: None,
+        });
+    }
+
+    Ok(face_model)
 }
 
 pub async fn get_or_init_lama_model(
@@ -524,6 +825,7 @@ pub async fn get_or_init_lama_model(
             denoise_model: None,
             clip_models: None,
             lama_model: Some(lama_model.clone()),
+            face_model: None,
             embeddings: None,
             depth_map: None,
         });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2300,6 +2300,7 @@ pub fn run() {
             app_settings::load_settings,
             app_settings::save_settings,
             ai_commands::generate_ai_subject_mask,
+            ai_commands::generate_ai_face_region_mask,
             ai_commands::precompute_ai_subject_mask,
             ai_commands::generate_ai_foreground_mask,
             ai_commands::generate_ai_sky_mask,

--- a/src-tauri/src/mask_generation.rs
+++ b/src-tauri/src/mask_generation.rs
@@ -1306,6 +1306,10 @@ fn generate_sub_mask_bitmap(
             generate_ai_foreground_bitmap(&sub_mask.parameters, width, height, scale, crop_offset)
         }
         "ai-sky" => generate_ai_sky_bitmap(&sub_mask.parameters, width, height, scale, crop_offset),
+        // Eyes/mouth reuse the sky parameter shape: full-image bitmap + transform.
+        "ai-eyes" | "ai-mouth" => {
+            generate_ai_sky_bitmap(&sub_mask.parameters, width, height, scale, crop_offset)
+        }
         "ai-depth" => {
             generate_ai_depth_bitmap(&sub_mask.parameters, width, height, scale, crop_offset)
         }

--- a/src/components/panel/right/AIPanel.tsx
+++ b/src/components/panel/right/AIPanel.tsx
@@ -89,6 +89,18 @@ const SUB_MASK_CONFIG: any = {
   },
   [Mask.Brush]: { showBrushTools: true },
   [Mask.Linear]: { parameters: [] },
+  [Mask.AiEyes]: {
+    parameters: [
+      { key: 'grow', min: -100, max: 100, step: 1, defaultValue: 0 },
+      { key: 'feather', min: 0, max: 100, step: 1, defaultValue: 25 },
+    ],
+  },
+  [Mask.AiMouth]: {
+    parameters: [
+      { key: 'grow', min: -100, max: 100, step: 1, defaultValue: 0 },
+      { key: 'feather', min: 0, max: 100, step: 1, defaultValue: 25 },
+    ],
+  },
   [Mask.AiSubject]: {
     parameters: [
       { key: 'grow', min: -100, max: 100, step: 1, defaultValue: 50 },
@@ -291,7 +303,8 @@ export default function AIPanel() {
   const setCustomEscapeHandler = useUIStore((s) => s.setCustomEscapeHandler);
 
   const { setAdjustments } = useEditorActions();
-  const { handleGenerativeReplace, handleDeleteAiPatch, handleGenerateAiForegroundMask } = useAiMasking();
+  const { handleGenerativeReplace, handleDeleteAiPatch, handleGenerateAiForegroundMask, handleGenerateAiFaceRegionMask } =
+    useAiMasking();
   const appSettings = useSettingsStore((s) => s.appSettings);
   const aiProvider = appSettings?.aiProvider || 'cpu';
 
@@ -528,6 +541,8 @@ export default function AIPanel() {
     if (type === Mask.Brush) selectBrushToolForNewMask();
 
     if (type === Mask.AiForeground) handleGenerateAiForegroundMask(subMask.id);
+    if (type === Mask.AiEyes) handleGenerateAiFaceRegionMask(subMask.id, 'eyes');
+    if (type === Mask.AiMouth) handleGenerateAiFaceRegionMask(subMask.id, 'mouth');
   };
 
   const handleAddSubMask = (
@@ -554,6 +569,8 @@ export default function AIPanel() {
     setExpandedContainers((prev) => new Set(prev).add(containerId));
     if (type === Mask.Brush) selectBrushToolForNewMask();
     if (type === Mask.AiForeground) handleGenerateAiForegroundMask(subMask.id);
+    if (type === Mask.AiEyes) handleGenerateAiFaceRegionMask(subMask.id, 'eyes');
+    if (type === Mask.AiMouth) handleGenerateAiFaceRegionMask(subMask.id, 'mouth');
   };
 
   const handleAddAiContextMenu = (event: React.MouseEvent, targetContainerId?: string | null) => {

--- a/src/components/panel/right/Masks.tsx
+++ b/src/components/panel/right/Masks.tsx
@@ -1,5 +1,7 @@
 import {
   Brush,
+  Eye,
+  Smile,
   BringToFront,
   Circle,
   Cloud,
@@ -19,6 +21,8 @@ export enum Mask {
   AiDepth = 'ai-depth',
   AiForeground = 'ai-foreground',
   AiSky = 'ai-sky',
+  AiEyes = 'ai-eyes',
+  AiMouth = 'ai-mouth',
   AiSubject = 'ai-subject',
   All = 'all',
   Brush = 'brush',
@@ -68,6 +72,8 @@ export function formatMaskTypeName(type: string) {
   if (type === Mask.AiSubject) return i18n.t('masks.types.subject');
   if (type === Mask.AiForeground) return i18n.t('masks.types.foreground');
   if (type === Mask.AiSky) return i18n.t('masks.types.sky');
+  if (type === Mask.AiEyes) return i18n.t('masks.types.eyes');
+  if (type === Mask.AiMouth) return i18n.t('masks.types.mouth');
   if (type === Mask.All) return i18n.t('masks.types.all');
   if (type === Mask.QuickEraser) return i18n.t('masks.types.quickEraser');
   if (type === Mask.Brush) return i18n.t('masks.types.brush');
@@ -95,6 +101,8 @@ export const MASK_ICON_MAP: Record<Mask, any> = {
   [Mask.AiDepth]: BringToFront,
   [Mask.AiForeground]: User,
   [Mask.AiSky]: Cloud,
+  [Mask.AiEyes]: Eye,
+  [Mask.AiMouth]: Smile,
   [Mask.AiSubject]: Sparkles,
   [Mask.All]: RectangleHorizontal,
   [Mask.Brush]: Brush,
@@ -124,6 +132,18 @@ export const MASK_PANEL_CREATION_TYPES: Array<MaskType> = [
     icon: User,
     name: 'Foreground',
     type: Mask.AiForeground,
+  },
+  {
+    disabled: false,
+    icon: Eye,
+    name: 'Eyes',
+    type: Mask.AiEyes,
+  },
+  {
+    disabled: false,
+    icon: Smile,
+    name: 'Mouth',
+    type: Mask.AiMouth,
   },
   {
     disabled: false,
@@ -167,6 +187,18 @@ export const AI_PANEL_CREATION_TYPES: Array<MaskType> = [
   },
   {
     disabled: false,
+    icon: Eye,
+    name: 'Eyes',
+    type: Mask.AiEyes,
+  },
+  {
+    disabled: false,
+    icon: Smile,
+    name: 'Mouth',
+    type: Mask.AiMouth,
+  },
+  {
+    disabled: false,
     icon: Brush,
     name: 'Brush',
     type: Mask.Brush,
@@ -203,6 +235,18 @@ export const SUB_MASK_COMPONENT_TYPES: Array<MaskType> = [
     icon: User,
     name: 'Foreground',
     type: Mask.AiForeground,
+  },
+  {
+    disabled: false,
+    icon: Eye,
+    name: 'Eyes',
+    type: Mask.AiEyes,
+  },
+  {
+    disabled: false,
+    icon: Smile,
+    name: 'Mouth',
+    type: Mask.AiMouth,
   },
   {
     disabled: false,
@@ -276,6 +320,18 @@ export const AI_SUB_MASK_COMPONENT_TYPES: Array<MaskType> = [
     icon: User,
     name: 'Foreground',
     type: Mask.AiForeground,
+  },
+  {
+    disabled: false,
+    icon: Eye,
+    name: 'Eyes',
+    type: Mask.AiEyes,
+  },
+  {
+    disabled: false,
+    icon: Smile,
+    name: 'Mouth',
+    type: Mask.AiMouth,
   },
   {
     disabled: false,

--- a/src/components/panel/right/MasksPanel.tsx
+++ b/src/components/panel/right/MasksPanel.tsx
@@ -38,6 +38,7 @@ import {
   Plus,
   PlusSquare,
   RotateCcw,
+  ScanFace,
   Trash2,
   SwatchBook,
   SquaresIntersect,
@@ -119,6 +120,18 @@ const SUB_MASK_CONFIG: Record<Mask, any> = {
   [Mask.All]: { parameters: [] },
   [Mask.AiDepth]: {
     parameters: [{ key: 'feather', min: 0, max: 100, step: 1, defaultValue: 15 }],
+  },
+  [Mask.AiEyes]: {
+    parameters: [
+      { key: 'grow', min: -100, max: 100, step: 1, defaultValue: 0 },
+      { key: 'feather', min: 0, max: 100, step: 1, defaultValue: 25 },
+    ],
+  },
+  [Mask.AiMouth]: {
+    parameters: [
+      { key: 'grow', min: -100, max: 100, step: 1, defaultValue: 0 },
+      { key: 'feather', min: 0, max: 100, step: 1, defaultValue: 25 },
+    ],
   },
   [Mask.AiSubject]: {
     parameters: [
@@ -559,7 +572,8 @@ function DepthRangePicker({
 export default function MasksPanel() {
   const { t } = useTranslation();
   const { setAdjustments } = useEditorActions();
-  const { handleGenerateAiDepthMask, handleGenerateAiForegroundMask, handleGenerateAiSkyMask } = useAiMasking();
+  const { handleGenerateAiDepthMask, handleGenerateAiForegroundMask, handleGenerateAiSkyMask, handleGenerateAiFaceRegionMask } =
+    useAiMasking();
   const setCustomEscapeHandler = useUIStore((s) => s.setCustomEscapeHandler);
   const { appSettings } = useSettingsStore(
     useShallow((state) => ({
@@ -809,6 +823,8 @@ export default function MasksPanel() {
     if (type === Mask.Brush || type === Mask.Flow) selectBrushToolForNewMask();
     if (type === Mask.AiForeground) handleGenerateAiForegroundMask(subMask.id);
     else if (type === Mask.AiSky) handleGenerateAiSkyMask(subMask.id);
+    else if (type === Mask.AiEyes) handleGenerateAiFaceRegionMask(subMask.id, 'eyes');
+    else if (type === Mask.AiMouth) handleGenerateAiFaceRegionMask(subMask.id, 'mouth');
     else if (type === Mask.AiDepth) handleGenerateAiDepthMask(subMask.id, subMask.parameters);
   };
 
@@ -840,6 +856,8 @@ export default function MasksPanel() {
     if (type === Mask.Brush || type === Mask.Flow) selectBrushToolForNewMask();
     if (type === Mask.AiForeground) handleGenerateAiForegroundMask(subMask.id);
     else if (type === Mask.AiSky) handleGenerateAiSkyMask(subMask.id);
+    else if (type === Mask.AiEyes) handleGenerateAiFaceRegionMask(subMask.id, 'eyes');
+    else if (type === Mask.AiMouth) handleGenerateAiFaceRegionMask(subMask.id, 'mouth');
     else if (type === Mask.AiDepth) handleGenerateAiDepthMask(subMask.id, subMask.parameters);
   };
 
@@ -932,6 +950,80 @@ export default function MasksPanel() {
     }
 
     showContextMenu(rect.left, rect.bottom + 5, options);
+  };
+
+  // Flat, mode-scoped component menu for the Add / Subtract chips — one click,
+  // no hover-nested submenus.
+  const handleAddComponentModeMenu = (event: React.MouseEvent, containerId: string, mode: SubMaskMode) => {
+    event.preventDefault();
+    event.stopPropagation();
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    const toOption = (maskType: MaskType) => ({
+      label: getMaskTypeName(maskType),
+      icon: maskType.icon,
+      disabled: maskType.disabled,
+      onClick: () => handleAddSubMask(containerId, maskType.type, mode),
+    });
+    const options: any[] = MASK_PANEL_CREATION_TYPES.filter((m) => m.id !== 'others').map(toOption);
+    const others = MASK_PANEL_CREATION_TYPES.find((m) => m.id === 'others');
+    if (others) {
+      options.push({
+        label: getMaskTypeName(others),
+        icon: others.icon,
+        submenu: OTHERS_MASK_TYPES.map(toOption),
+      });
+    }
+    showContextMenu(rect.left, rect.bottom + 5, options);
+  };
+
+  // One-click portrait retouch stack: skin (foreground minus eyes/mouth) with
+  // smoothing dialed in, plus eye-enhance and teeth-whitening masks from the
+  // same face landmarks. Async bitmaps amend the same history entry, so the
+  // whole setup is a single undo step.
+  const handleCreatePortraitSetup = () => {
+    if (!selectedImage) return;
+    const skinBase = createMaskLogic(Mask.AiForeground);
+    const skinEyes = createMaskLogic(Mask.AiEyes, SubMaskMode.Subtractive);
+    const skinMouth = createMaskLogic(Mask.AiMouth, SubMaskMode.Subtractive);
+    const enhanceEyes = createMaskLogic(Mask.AiEyes);
+    const teethMouth = createMaskLogic(Mask.AiMouth);
+
+    const makeContainer = (name: string, subMasks: any[], adj: Record<string, any>) => ({
+      ...INITIAL_MASK_CONTAINER,
+      id: uuidv4(),
+      name,
+      subMasks,
+      adjustments: { ...INITIAL_MASK_ADJUSTMENTS, ...adj },
+    });
+    const containers = [
+      makeContainer(t('editor.masks.portrait.skin'), [skinBase, skinEyes, skinMouth], {
+        // negative clarity is the built-in skin softener; swap for skin smoothing
+        // if/when #1326 lands
+        clarity: -30,
+      }),
+      makeContainer(t('editor.masks.portrait.eyes'), [enhanceEyes], {
+        clarity: 15,
+        sharpness: 10,
+        exposure: 0.1,
+        saturation: 8,
+      }),
+      makeContainer(t('editor.masks.portrait.teeth'), [teethMouth], {
+        hsl: {
+          ...INITIAL_MASK_ADJUSTMENTS.hsl,
+          yellows: { hue: 0, saturation: -35, luminance: 15 },
+        },
+      }),
+    ];
+
+    setAdjustments((prev: Adjustments) => ({ ...prev, masks: [...(prev.masks || []), ...containers] }));
+    onSelectContainer(containers[0].id);
+    onSelectMask(null);
+    setExpandedContainers((prev) => new Set(prev).add(containers[0].id));
+    handleGenerateAiForegroundMask(skinBase.id);
+    handleGenerateAiFaceRegionMask(skinEyes.id, 'eyes');
+    handleGenerateAiFaceRegionMask(skinMouth.id, 'mouth');
+    handleGenerateAiFaceRegionMask(enhanceEyes.id, 'eyes');
+    handleGenerateAiFaceRegionMask(teethMouth.id, 'mouth');
   };
 
   const updateContainer = (id: string, data: any) =>
@@ -1354,6 +1446,16 @@ export default function MasksPanel() {
                     />
                   ))}
                 </div>
+                <button
+                  className="mt-2 w-full flex items-center justify-center gap-2 p-2 rounded-md bg-surface hover:bg-card-active transition-colors text-text-secondary hover:text-text-primary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCreatePortraitSetup();
+                  }}
+                >
+                  <ScanFace size={16} />
+                  <span className="text-sm font-medium select-none">{t('editor.masks.portrait.oneClick')}</span>
+                </button>
               </motion.div>
             ) : (
               <motion.div
@@ -1419,6 +1521,9 @@ export default function MasksPanel() {
                       analyzingSubMaskId={analyzingSubMaskId}
                       setIsMaskControlHovered={setIsMaskControlHovered}
                       onAddComponent={(e: React.MouseEvent) => handleAddMaskContextMenu(e, container.id)}
+                      onSubtractComponent={(e: React.MouseEvent) =>
+                        handleAddComponentModeMenu(e, container.id, SubMaskMode.Subtractive)
+                      }
                     />
                   ))}
                 </AnimatePresence>
@@ -1439,6 +1544,20 @@ export default function MasksPanel() {
                     <Plus size={18} />
                   </div>
                   <span>{t('editor.masks.addNewMask')}</span>
+                </Text>
+                <Text
+                  as="div"
+                  weight={TextWeights.medium}
+                  className="flex items-center gap-2 p-2 rounded-md transition-colors transition-opacity opacity-70 hover:opacity-100 hover:bg-card-active cursor-pointer hover:text-text-primary"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCreatePortraitSetup();
+                  }}
+                >
+                  <div className="p-0.5">
+                    <ScanFace size={18} />
+                  </div>
+                  <span>{t('editor.masks.portrait.oneClick')}</span>
                 </Text>
               </motion.div>
             )}
@@ -1642,6 +1761,7 @@ function ContainerRow({
   analyzingSubMaskId,
   setIsMaskControlHovered,
   onAddComponent,
+  onSubtractComponent,
 }: any) {
   const { t } = useTranslation();
   const { setNodeRef: setDroppableRef, isOver } = useDroppable({
@@ -1893,20 +2013,38 @@ function ContainerRow({
                   exit={{ opacity: 0, height: 0, overflow: 'hidden' }}
                   transition={{ duration: 0.2 }}
                 >
-                  <Text
-                    as="div"
-                    weight={TextWeights.medium}
-                    className="flex items-center gap-2 p-2 rounded-md transition-colors transition-opacity opacity-70 hover:opacity-100 hover:bg-card-active cursor-pointer hover:text-text-primary"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAddComponent(e);
-                    }}
-                  >
-                    <div className="relative w-4 h-4 ml-1 shrink-0 flex items-center justify-center">
-                      <Plus size={16} />
-                    </div>
-                    <span className="select-none">{t('editor.masks.actions.addNewComponent')}</span>
-                  </Text>
+                  <div className="flex items-center gap-1">
+                    <Text
+                      as="div"
+                      weight={TextWeights.medium}
+                      className="flex-1 flex items-center gap-2 p-2 rounded-md transition-colors transition-opacity opacity-70 hover:opacity-100 hover:bg-card-active cursor-pointer hover:text-text-primary"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onAddComponent(e);
+                      }}
+                    >
+                      <div className="relative w-4 h-4 ml-1 shrink-0 flex items-center justify-center">
+                        <Plus size={16} />
+                      </div>
+                      <span className="select-none">{t('editor.masks.actions.addComponent')}</span>
+                    </Text>
+                    {container.subMasks.length > 0 && (
+                      <Text
+                        as="div"
+                        weight={TextWeights.medium}
+                        className="flex-1 flex items-center gap-2 p-2 rounded-md transition-colors transition-opacity opacity-70 hover:opacity-100 hover:bg-card-active cursor-pointer hover:text-text-primary"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onSubtractComponent(e);
+                        }}
+                      >
+                        <div className="relative w-4 h-4 ml-1 shrink-0 flex items-center justify-center">
+                          <Minus size={16} />
+                        </div>
+                        <span className="select-none">{t('editor.masks.actions.subtractComponent')}</span>
+                      </Text>
+                    )}
+                  </div>
                 </motion.div>
               )}
             </AnimatePresence>

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -53,6 +53,7 @@ export enum Invokes {
   FrontendLog = 'frontend_log',
   GenerateAiForegroundMask = 'generate_ai_foreground_mask',
   GenerateAiSkyMask = 'generate_ai_sky_mask',
+  GenerateAiFaceRegionMask = 'generate_ai_face_region_mask',
   GenerateAiSubjectMask = 'generate_ai_subject_mask',
   GenerateFullscreenPreview = 'generate_fullscreen_preview',
   GeneratePreviewForPath = 'generate_preview_for_path',

--- a/src/hooks/useAiMasking.ts
+++ b/src/hooks/useAiMasking.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'react-toastify';
 import { useEditorStore } from '../store/useEditorStore';
-import { useEditorActions } from './useEditorActions';
+import { useEditorActions, debouncedSetHistory } from './useEditorActions';
 import { Adjustments, AiPatch, MaskContainer, Coord } from '../utils/adjustments';
 import { SubMask } from '../components/panel/right/Masks';
 import { Invokes } from '../components/ui/AppProperties';
@@ -33,9 +33,19 @@ export function useAiMasking() {
   const setEditor = useEditorStore((state) => state.setEditor);
   const { getToken } = useAuth();
 
+  // Write the async tail of a generation into the CURRENT history entry instead of
+  // pushing a new one, so "create AI mask" (creation + bitmap landing seconds later)
+  // stays a single undo step. Flush first so the creation entry itself is committed.
+  const amendAdjustments = useCallback((updater: (prev: Adjustments) => Adjustments) => {
+    debouncedSetHistory.flush();
+    const store = useEditorStore.getState();
+    const newAdjustments = updater(store.adjustments);
+    store.amendHistory(newAdjustments);
+  }, []);
+
   const updateSubMask = useCallback(
     (subMaskId: string, updatedData: any) => {
-      setAdjustments((prev: Adjustments) => ({
+      amendAdjustments((prev: Adjustments) => ({
         ...prev,
         masks: prev.masks.map((c: MaskContainer) => ({
           ...c,
@@ -47,7 +57,7 @@ export function useAiMasking() {
         })),
       }));
     },
-    [setAdjustments],
+    [amendAdjustments],
   );
 
   const handleGenerativeReplace = useCallback(
@@ -80,7 +90,7 @@ export function useAiMasking() {
         const newPatchData = JSON.parse(newPatchDataJson);
         patchesSentToBackend.delete(patchId);
 
-        setAdjustments((prev: Adjustments) => ({
+        amendAdjustments((prev: Adjustments) => ({
           ...prev,
           aiPatches: prev.aiPatches.map((p: AiPatch) =>
             p.id === patchId
@@ -96,7 +106,7 @@ export function useAiMasking() {
         setEditor({ activeAiPatchContainerId: null, activeAiSubMaskId: null });
       } catch (err) {
         toast.error(`AI Replace Failed: ${err}`);
-        setAdjustments((prev: Adjustments) => ({
+        amendAdjustments((prev: Adjustments) => ({
           ...prev,
           aiPatches: prev.aiPatches.map((p: AiPatch) => (p.id === patchId ? { ...p, isLoading: false } : p)),
         }));
@@ -104,7 +114,7 @@ export function useAiMasking() {
         setEditor({ isGeneratingAi: false });
       }
     },
-    [setAdjustments, setEditor],
+    [setAdjustments, amendAdjustments, setEditor],
   );
 
   const handleQuickErase = useCallback(
@@ -167,7 +177,7 @@ export function useAiMasking() {
         const newPatchData = JSON.parse(newPatchDataJson);
         patchesSentToBackend.delete(patchId);
 
-        setAdjustments((prev: Partial<Adjustments>) => ({
+        amendAdjustments((prev: Adjustments) => ({
           ...prev,
           aiPatches: prev.aiPatches?.map((p: AiPatch) =>
             p.id === patchId
@@ -185,7 +195,7 @@ export function useAiMasking() {
         setEditor({ activeAiPatchContainerId: null, activeAiSubMaskId: null });
       } catch (err: any) {
         toast.error(`Quick Erase Failed: ${err.message || String(err)}`);
-        setAdjustments((prev: Partial<Adjustments>) => ({
+        amendAdjustments((prev: Adjustments) => ({
           ...prev,
           aiPatches: prev.aiPatches?.map((p: AiPatch) => (p.id === patchId ? { ...p, isLoading: false } : p)),
         }));
@@ -193,7 +203,7 @@ export function useAiMasking() {
         setEditor({ isGeneratingAi: false });
       }
     },
-    [setAdjustments, setEditor],
+    [setAdjustments, amendAdjustments, setEditor],
   );
 
   const handleDeleteMaskContainer = useCallback(
@@ -355,6 +365,35 @@ export function useAiMasking() {
     }
   };
 
+  const handleGenerateAiFaceRegionMask = async (subMaskId: string, region: 'eyes' | 'mouth') => {
+    const { selectedImage, adjustments, patchesSentToBackend } = useEditorStore.getState();
+    if (!selectedImage?.path) return;
+    setEditor({ isGeneratingAiMask: true });
+
+    try {
+      const transformAdjustments = getTransformAdjustments(adjustments);
+      const newParameters: any = await invoke(Invokes.GenerateAiFaceRegionMask, {
+        jsAdjustments: transformAdjustments,
+        region,
+        flipHorizontal: adjustments.flipHorizontal,
+        flipVertical: adjustments.flipVertical,
+        orientationSteps: adjustments.orientationSteps,
+        rotation: adjustments.rotation,
+      });
+
+      const subMask = adjustments.aiPatches
+        ?.flatMap((p: AiPatch) => p.subMasks)
+        .find((sm: SubMask) => sm.id === subMaskId);
+      const mergedParameters = { ...(subMask?.parameters || {}), ...newParameters };
+      patchesSentToBackend.delete(subMaskId);
+      updateSubMask(subMaskId, { parameters: mergedParameters });
+    } catch (error) {
+      toast.error(`AI Mask Failed: ${error}`);
+    } finally {
+      setEditor({ isGeneratingAiMask: false });
+    }
+  };
+
   useEffect(() => {
     const { activeMaskId, activeAiSubMaskId, adjustments, selectedImage } = useEditorStore.getState();
     const activeSubMask =
@@ -385,5 +424,6 @@ export function useAiMasking() {
     handleGenerateAiDepthMask,
     handleGenerateAiForegroundMask,
     handleGenerateAiSkyMask,
+    handleGenerateAiFaceRegionMask,
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -505,6 +505,7 @@
     },
     "masks": {
       "actions": {
+        "addComponent": "Add",
         "addNewComponent": "Add New Component",
         "applyPreset": "Apply Preset",
         "copyComponent": "Copy Component",
@@ -526,12 +527,19 @@
         "resetMaskAdjustments": "Reset Mask Adjustments",
         "showComponent": "Show Component",
         "showMask": "Show Mask",
+        "subtractComponent": "Subtract",
         "subtractFromMask": "Subtract from Mask",
         "switchToAdd": "Switch to Add",
         "switchToIntersect": "Switch to Intersect",
         "switchToSubtract": "Switch to Subtract"
       },
       "addNewMask": "Add New Mask",
+      "portrait": {
+        "oneClick": "One-Click Portrait",
+        "skin": "Skin Smoothing",
+        "eyes": "Eye Enhance",
+        "teeth": "Teeth Whitening"
+      },
       "brush": {
         "brush": "Brush",
         "eraser": "Eraser",
@@ -1014,7 +1022,7 @@
       "quickErase": "Quick Erase",
       "quickEraser": "Quick Eraser",
       "radial": "Radial",
-      "sky": "Sky",
+      "sky": "Sky", "eyes": "Eyes", "mouth": "Mouth",
       "subject": "Subject"
     }
   },

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -75,6 +75,7 @@ interface EditorState {
   // Actions
   setEditor: (updater: Partial<EditorState> | ((state: EditorState) => Partial<EditorState>)) => void;
   pushHistory: (newAdjustments: Adjustments) => void;
+  amendHistory: (newAdjustments: Adjustments) => void;
   undo: () => void;
   redo: () => void;
   resetHistory: (initialState: Adjustments) => void;
@@ -138,6 +139,20 @@ export const useEditorStore = create<EditorState>((set) => ({
       newHistory.push(newAdj);
       if (newHistory.length > 50) newHistory.shift();
       return { history: newHistory, historyIndex: newHistory.length - 1 };
+    }),
+
+  // Replace the current history entry instead of pushing a new one. Used for the
+  // async tail of a single user action (e.g. an AI mask's generated bitmap landing
+  // seconds after its creation), so one action stays one undo step.
+  amendHistory: (newAdj) =>
+    set((state) => {
+      if (state.historyIndex === 0) {
+        const newHistory = [...state.history, newAdj];
+        return { history: newHistory, historyIndex: newHistory.length - 1, adjustments: newAdj };
+      }
+      const newHistory = state.history.slice(0, state.historyIndex + 1);
+      newHistory[state.historyIndex] = newAdj;
+      return { history: newHistory, adjustments: newAdj };
     }),
 
   undo: () =>


### PR DESCRIPTION
## What

Adds **Eyes** and **Mouth** AI selections to both the Masks panel and Inpainting, plus a **One-Click Portrait** button that assembles the classic beauty-retouch stack automatically. The motivating workflow: skin softening needs *subject minus eyes minus mouth*, which previously meant manual brushing over every eye and lip.

## How

**Detection** — [YuNet](https://github.com/opencv/opencv_zoo/tree/main/models/face_detection_yunet) (MIT, ~230 KB), auto-downloaded and SHA-verified exactly like the existing models. Unlike a plain box detector it returns 5 landmarks per face (eye centers, nose tip, mouth corners), so the masks are anchored on the real features:

- ellipses centered on the landmarks, sized by interocular / mouth-corner distance, rotated with head tilt
- input is letterboxed (aspect distortion measurably degrades landmark precision)
- a second detection pass on the face crop refines the keypoints (the face fills the 640px input instead of a fraction of it)
- multi-face: every detected face gets its ellipses; per-component Grow/Feather for fine-tuning

**Threshold** — 0.8, validated against a 64-image RAW sample library: every real face scored >= 0.81 (including tiny background faces, backlit, red stage light, glasses, headwear, tilted heads), while false positives (a bare back, foliage bokeh) topped out at 0.72.

**One-Click Portrait** (Masks panel) — builds three masks in one press:
- *Skin Softening*: foreground − eyes − mouth, negative clarity (if #1326 lands, this can switch to frequency-separation smoothing)
- *Eye Enhance*: eyes mask with mild clarity/exposure/saturation
- *Teeth Whitening*: mouth mask with HSL yellows desaturate + lift, so red lips are untouched

**Mask UX** — visible "+ Add / − Subtract" chips on each mask (subtracting a component was previously three hover-submenu levels deep); Eyes/Mouth are top-level entries in the creation grid and component menus.

**Undo correctness** — new `amendHistory` store action folds async generation results (mask bitmaps, generative replace, quick erase) into the creating action's history entry. Previously each AI action left 2–3 history entries, so a single undo left an empty edit behind; now one action — including the whole portrait stack — is exactly one undo step.

## Testing

- Placement verified across all people photos in a 64-image RAW library (frontal, 3/4, tilted, glasses, open-mouth expressions, multiple faces, dark/backlit/colored light) via a pipeline-identical harness, then confirmed in-app
- `cargo check` clean; `tsc` introduces no new errors
- Single undo after One-Click Portrait removes all three masks; existing edits untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)