### PR TITLE
Versions (virtual copies): multiple saved looks per photo

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -2260,7 +2260,16 @@ pub async fn reset_adjustments_for_paths(
 
             let mut existing_metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
+            // Saved versions ("virtual copies") survive a reset of the working state.
+            let preserved_versions = existing_metadata
+                .adjustments
+                .get("versions")
+                .filter(|v| v.as_array().is_some_and(|a| !a.is_empty()))
+                .cloned();
             existing_metadata.adjustments = serde_json::json!({});
+            if let Some(versions) = preserved_versions {
+                existing_metadata.adjustments["versions"] = versions;
+            }
 
             if let Ok(json_string) = serde_json::to_string_pretty(&existing_metadata) {
                 let _ = std::fs::write(&sidecar_path, json_string);

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -39,6 +39,7 @@ import CreateFolderModal from '../../modals/CreateFolderModal';
 import RenameFolderModal from '../../modals/RenameFolderModal';
 import Button from '../../ui/Button';
 import Text from '../../ui/Text';
+import VersionsSection from './VersionsSection';
 import Slider from '../../ui/Slider';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
 import { Adjustments, INITIAL_ADJUSTMENTS, ADJUSTMENT_GROUPS } from '../../../utils/adjustments';
@@ -1179,6 +1180,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
           onContextMenu={handleBackgroundContextMenu}
           ref={setRootNodeRef}
         >
+          <VersionsSection />
           {isLoading && presets.length === 0 && (
             <Text
               as="div"

--- a/src/components/panel/right/VersionsSection.tsx
+++ b/src/components/panel/right/VersionsSection.tsx
@@ -1,0 +1,162 @@
+import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { useTranslation } from 'react-i18next';
+import { Check, FileEdit, History, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { useEditorStore } from '../../../store/useEditorStore';
+import { useEditorActions } from '../../../hooks/useEditorActions';
+import { useContextMenu } from '../../../context/ContextMenuContext';
+import { OPTION_SEPARATOR } from '../../ui/AppProperties';
+import { Adjustments, AdjustmentVersion, INITIAL_ADJUSTMENTS } from '../../../utils/adjustments';
+import Text from '../../ui/Text';
+import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
+
+// Named edit states ("virtual copies") stored inside the sidecar, so one RAW can
+// carry several looks. Applying, renaming and deleting all go through
+// setAdjustments and are therefore undoable and auto-saved like any other edit.
+export default function VersionsSection() {
+  const adjustments = useEditorStore((s) => s.adjustments);
+  const selectedImage = useEditorStore((s) => s.selectedImage);
+  const { setAdjustments } = useEditorActions();
+  const { showContextMenu } = useContextMenu();
+  const { t } = useTranslation();
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [tempName, setTempName] = useState('');
+
+  if (!selectedImage) {
+    return null;
+  }
+  const versions: AdjustmentVersion[] = adjustments.versions || [];
+
+  const snapshotState = (adj: Adjustments): Partial<Adjustments> => {
+    const { versions: _versions, ...state } = adj;
+    return structuredClone(state);
+  };
+
+  const handleSave = () => {
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      versions: [
+        ...(prev.versions || []),
+        {
+          id: uuidv4(),
+          name: t('editor.presets.versions.defaultName', { count: (prev.versions?.length || 0) + 1 }),
+          createdAt: Date.now(),
+          state: snapshotState(prev),
+        },
+      ],
+    }));
+  };
+
+  const handleApply = (version: AdjustmentVersion) => {
+    setAdjustments((prev: Adjustments) => ({
+      ...INITIAL_ADJUSTMENTS,
+      ...version.state,
+      versions: prev.versions,
+    }));
+  };
+
+  const handleOverwrite = (version: AdjustmentVersion) => {
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      versions: (prev.versions || []).map((v) =>
+        v.id === version.id ? { ...v, state: snapshotState(prev), createdAt: Date.now() } : v,
+      ),
+    }));
+  };
+
+  const handleDelete = (version: AdjustmentVersion) => {
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      versions: (prev.versions || []).filter((v) => v.id !== version.id),
+    }));
+  };
+
+  const commitRename = () => {
+    const name = tempName.trim();
+    if (name && renamingId) {
+      setAdjustments((prev: Adjustments) => ({
+        ...prev,
+        versions: (prev.versions || []).map((v) => (v.id === renamingId ? { ...v, name } : v)),
+      }));
+    }
+    setRenamingId(null);
+  };
+
+  const handleRowContextMenu = (event: React.MouseEvent, version: AdjustmentVersion) => {
+    event.preventDefault();
+    event.stopPropagation();
+    showContextMenu(event.clientX, event.clientY, [
+      { label: t('editor.presets.versions.apply'), icon: Check, onClick: () => handleApply(version) },
+      { label: t('editor.presets.versions.overwrite'), icon: RefreshCw, onClick: () => handleOverwrite(version) },
+      {
+        label: t('editor.presets.versions.rename'),
+        icon: FileEdit,
+        onClick: () => {
+          setRenamingId(version.id);
+          setTempName(version.name);
+        },
+      },
+      { type: OPTION_SEPARATOR },
+      { label: t('editor.presets.versions.delete'), icon: Trash2, onClick: () => handleDelete(version) },
+    ]);
+  };
+
+  return (
+    <div className="mb-4 pb-4 border-b border-surface">
+      <div className="flex items-center justify-between mb-2">
+        <Text variant={TextVariants.heading} className="flex items-center gap-2">
+          <History size={16} />
+          {t('editor.presets.versions.title')}
+        </Text>
+        <button
+          className="p-1.5 rounded-full hover:bg-surface transition-colors"
+          onClick={handleSave}
+          data-tooltip={t('editor.presets.versions.saveTooltip')}
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+      {versions.length === 0 ? (
+        <Text color={TextColors.secondary} className="text-sm">
+          {t('editor.presets.versions.empty')}
+        </Text>
+      ) : (
+        <div className="space-y-1">
+          {versions.map((version) => (
+            <button
+              key={version.id}
+              className="w-full flex items-center justify-between p-2 rounded-md bg-surface hover:bg-card-active cursor-pointer transition-colors group text-left"
+              onClick={() => handleApply(version)}
+              onContextMenu={(e) => handleRowContextMenu(e, version)}
+            >
+              {renamingId === version.id ? (
+                <input
+                  autoFocus
+                  className="bg-transparent border-b border-text-secondary outline-none text-sm w-full mr-2"
+                  value={tempName}
+                  onChange={(e) => setTempName(e.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename();
+                    if (e.key === 'Escape') setRenamingId(null);
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              ) : (
+                <Text weight={TextWeights.medium} className="truncate text-sm">
+                  {version.name}
+                </Text>
+              )}
+              <Text color={TextColors.secondary} className="text-xs shrink-0 ml-2">
+                {new Date(version.createdAt).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </Text>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -642,6 +642,16 @@
     },
     "presets": {
       "amount": "Amount",
+      "versions": {
+        "title": "Versions",
+        "saveTooltip": "Save current edit as a new version",
+        "empty": "Save the current edit as a version to try multiple looks on this photo.",
+        "defaultName": "Version {{count}}",
+        "apply": "Apply Version",
+        "overwrite": "Overwrite with Current Edit",
+        "rename": "Rename",
+        "delete": "Delete Version"
+      },
       "dialog": {
         "allPresetFiles": "All Preset Files",
         "exportAllTitle": "Export All Presets",

--- a/src/utils/adjustments.ts
+++ b/src/utils/adjustments.ts
@@ -146,9 +146,19 @@ export interface ParametricCurve {
   red: ParametricCurveSettings;
 }
 
+// A saved edit state ("virtual copy") stored inside the sidecar. `state` is a full
+// Adjustments snapshot minus the versions list itself.
+export interface AdjustmentVersion {
+  id: string;
+  name: string;
+  createdAt: number;
+  state: Partial<Adjustments>;
+}
+
 export interface Adjustments {
   [index: string]: any;
   aiPatches: Array<AiPatch>;
+  versions: Array<AdjustmentVersion>;
   aspectRatio: number | null;
   blacks: number;
   brightness: number;
@@ -477,6 +487,7 @@ export const INITIAL_MASK_CONTAINER: MaskContainer = {
 
 export const INITIAL_ADJUSTMENTS: Adjustments = {
   aiPatches: [],
+  versions: [],
   aspectRatio: null,
   blacks: 0,
   brightness: 0,


### PR DESCRIPTION
## What

Adds **Versions** — named snapshots of the complete edit state, stored inside the sidecar — so one RAW can carry several looks ("client picks", color vs. B&W, subtle vs. bold retouch) and switch between them with one click.

![Version switching](https://raw.githubusercontent.com/SandeepSubba/RapidRAW/pr-assets/versions-ab.jpg)

## How it works

A **Versions** section at the top of the Presets panel:

- **+** saves the current edit as a new version (full snapshot: adjustments, masks, AI edits, crop)
- **click** a version to apply it
- right-click for **Apply / Overwrite with Current Edit / Rename / Delete**

<img src="https://raw.githubusercontent.com/SandeepSubba/RapidRAW/pr-assets/versions-menu.jpg" width="440" alt="Version context menu" />

## Design notes

- **No backend schema change.** Versions live in `adjustments.versions[]` (`{id, name, createdAt, state}`); the sidecar already stores adjustments as raw JSON, so they round-trip untouched.
- **Undoable + auto-saved.** Every version operation goes through `setAdjustments`, so it participates in history and the normal save path like any other edit.
- **Isolated.** Versions are excluded from copy/paste and multi-select sync (they're not in the copyable-key whitelist), so pasting adjustments to other photos never drags snapshots along.
- **Reset-safe.** `reset_adjustments_for_paths` now preserves the `versions` key — clearing the working edit can't destroy saved looks.

## Testing

- Full round-trip verified in-app: save two versions with different looks, switch between them repeatedly, restart-persistence via sidecar confirmed; version operations undo cleanly
- `cargo check`, `cargo fmt --check` clean; `tsc` introduces no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)