### PR TITLE
Snapshots: in-editor checkpoints of the full edit state

### DIFF
--- a/src-tauri/src/android_integration.rs
+++ b/src-tauri/src/android_integration.rs
@@ -39,17 +39,12 @@ pub fn initialize_android(window: &tauri::WebviewWindow) {
                     .with_env(|env_22| {
                         let verifier_context =
                             unsafe { VerifierJObject::from_raw(env_22, raw_context) };
-                        rustls_platform_verifier::android::init_with_env(
-                            env_22,
-                            verifier_context,
-                        )
+                        rustls_platform_verifier::android::init_with_env(env_22, verifier_context)
                     })
                     .into_outcome()
                 {
                     jni22::Outcome::Ok(()) => {
-                        log::info!(
-                            "Successfully initialized rustls-platform-verifier on Android."
-                        );
+                        log::info!("Successfully initialized rustls-platform-verifier on Android.");
                     }
                     jni22::Outcome::Err(error) => {
                         log::error!(

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -2260,7 +2260,16 @@ pub async fn reset_adjustments_for_paths(
 
             let mut existing_metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
+            // Saved snapshots survive a reset of the working state.
+            let preserved_snapshots = existing_metadata
+                .adjustments
+                .get("snapshots")
+                .filter(|v| v.as_array().is_some_and(|a| !a.is_empty()))
+                .cloned();
             existing_metadata.adjustments = serde_json::json!({});
+            if let Some(snapshots) = preserved_snapshots {
+                existing_metadata.adjustments["snapshots"] = snapshots;
+            }
 
             if let Ok(json_string) = serde_json::to_string_pretty(&existing_metadata) {
                 let _ = std::fs::write(&sidecar_path, json_string);

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -330,8 +330,7 @@ pub fn parse_lut_file(path_str: &str) -> anyhow::Result<Lut> {
                     .and_then(|s| s.to_str())
                     .unwrap_or("cube")
                     .to_lowercase();
-                let uri_bytes =
-                    read_android_content_uri(path_str).map_err(|e| anyhow!("{}", e))?;
+                let uri_bytes = read_android_content_uri(path_str).map_err(|e| anyhow!("{}", e))?;
                 (ext, Some(uri_bytes))
             }
             #[cfg(not(target_os = "android"))]

--- a/src/components/panel/right/PresetItemDisplay.tsx
+++ b/src/components/panel/right/PresetItemDisplay.tsx
@@ -16,10 +16,8 @@ export interface PresetItemDisplayProps {
   intensity?: number;
   onIntensityChange?: (val: number) => void;
   onDragStateChange?: (isDragging: boolean) => void;
-  // When set (snapshots), this replaces the preset type row and hides the
-  // preset-only feature badges, so snapshots reuse the card without its preset chrome.
+  // Snapshot mode: replaces the type row and hides preset-only feature badges.
   subtitle?: ReactNode;
-  // When set, replaces the name with this node (used to edit the name in place).
   nameSlot?: ReactNode;
 }
 

--- a/src/components/panel/right/PresetItemDisplay.tsx
+++ b/src/components/panel/right/PresetItemDisplay.tsx
@@ -1,0 +1,140 @@
+import { useMemo, ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Crop, Layers, Loader2, Palette, Wrench } from 'lucide-react';
+import Text from '../../ui/Text';
+import Slider from '../../ui/Slider';
+import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
+import { ADJUSTMENT_GROUPS } from '../../../utils/adjustments';
+import { Preset } from '../../ui/AppProperties';
+
+export interface PresetItemDisplayProps {
+  isGeneratingPreviews: boolean;
+  preset: Preset;
+  previewUrl: string;
+  isActive?: boolean;
+  intensity?: number;
+  onIntensityChange?: (val: number) => void;
+  onDragStateChange?: (isDragging: boolean) => void;
+  // When set (snapshots), this replaces the preset type row and hides the
+  // preset-only feature badges, so snapshots reuse the card without its preset chrome.
+  subtitle?: ReactNode;
+  // When set, replaces the name with this node (used to edit the name in place).
+  nameSlot?: ReactNode;
+}
+
+export default function PresetItemDisplay({
+  preset,
+  previewUrl,
+  isGeneratingPreviews,
+  isActive,
+  intensity,
+  onIntensityChange,
+  onDragStateChange,
+  subtitle,
+  nameSlot,
+}: PresetItemDisplayProps) {
+  const { t } = useTranslation();
+  const geometryKeys = ADJUSTMENT_GROUPS.geometry.flatMap((g) => g.keys);
+
+  const supportsMasks = preset.includeMasks ?? (preset.adjustments?.masks && preset.adjustments.masks.length > 0);
+  const supportsGeometry =
+    preset.includeCropTransform ?? geometryKeys.some((key) => preset.adjustments?.[key] !== undefined);
+  const isTool = preset.presetType === 'tool';
+  const showBadges = !subtitle && (supportsMasks || supportsGeometry);
+  const tooltipContent = useMemo(() => {
+    const features = [];
+    if (supportsMasks) features.push(t('editor.presets.supports.masks'));
+    if (supportsGeometry) features.push(t('editor.presets.supports.cropTransform'));
+
+    if (features.length === 0) return undefined;
+    return t('editor.presets.supports.label', { features: features.join(' + ') });
+  }, [supportsMasks, supportsGeometry, t]);
+
+  return (
+    <div className="flex flex-col p-2 rounded-lg bg-surface cursor-grabbing">
+      <div className="flex items-center gap-3">
+        <div
+          className="w-20 h-14 bg-bg-tertiary rounded-md flex items-center justify-center shrink-0 relative overflow-hidden"
+          data-tooltip={subtitle ? undefined : tooltipContent}
+        >
+          {isGeneratingPreviews && !previewUrl ? (
+            <Loader2 size={20} className="animate-spin text-text-secondary" />
+          ) : previewUrl ? (
+            <img
+              src={previewUrl}
+              alt={`${preset.name} preview`}
+              className="w-full h-full object-cover rounded-md pointer-events-none"
+            />
+          ) : (
+            <Loader2 size={20} className="animate-spin text-text-secondary" />
+          )}
+
+          {showBadges && (
+            <>
+              <div className="absolute top-0 right-0 w-1/2 h-1/2 bg-linear-to-bl from-black/30 via-black/0 to-transparent pointer-events-none z-0" />
+
+              <div className="absolute top-1 right-1 bg-primary rounded-full px-1.5 py-0.5 flex items-center gap-1.5 backdrop-blur-xs shadow-xs z-10 pointer-events-none">
+                {supportsMasks && <Layers size={11} className="text-white" />}
+                {supportsGeometry && <Crop size={11} className="text-white" />}
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="grow min-w-0 flex flex-col justify-center">
+          {nameSlot ?? (
+            <Text color={TextColors.primary} weight={TextWeights.medium} className="truncate">
+              {preset.name}
+            </Text>
+          )}
+          <div className="flex items-center gap-1.5 mt-0.5">
+            {subtitle ?? (
+              <>
+                {isTool ? (
+                  <Wrench size={12} className="text-text-secondary" />
+                ) : (
+                  <Palette size={12} className="text-text-secondary" />
+                )}
+                <Text
+                  variant={TextVariants.small}
+                  color={TextColors.secondary}
+                  className="text-[10px] uppercase tracking-wider"
+                >
+                  {isTool ? t('editor.presets.types.tool') : t('editor.presets.types.style')}
+                </Text>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <AnimatePresence initial={false}>
+        {isActive && onIntensityChange && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.25, ease: 'easeInOut' }}
+            className="w-full cursor-auto overflow-hidden"
+            onClick={(e: any) => e.stopPropagation()}
+            onPointerDown={(e: any) => e.stopPropagation()}
+          >
+            <div className="mt-3 px-1 pb-1">
+              <Slider
+                min={0}
+                max={200}
+                defaultValue={100}
+                value={intensity ?? 100}
+                onChange={(e: any) => onIntensityChange(Number(e.target.value))}
+                onDragStateChange={onDragStateChange}
+                label={t('editor.presets.amount')}
+                step={1}
+              />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -39,6 +39,7 @@ import CreateFolderModal from '../../modals/CreateFolderModal';
 import RenameFolderModal from '../../modals/RenameFolderModal';
 import Button from '../../ui/Button';
 import Text from '../../ui/Text';
+import SnapshotsSection from './SnapshotsSection';
 import Slider from '../../ui/Slider';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
 import { Adjustments, INITIAL_ADJUSTMENTS, ADJUSTMENT_GROUPS } from '../../../utils/adjustments';
@@ -1179,6 +1180,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
           onContextMenu={handleBackgroundContextMenu}
           ref={setRootNodeRef}
         >
+          <SnapshotsSection />
           {isLoading && presets.length === 0 && (
             <Text
               as="div"

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -418,8 +418,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
         item.folder.children.forEach((p: Preset) => allPresetIds.add(p.id));
       }
     });
-    // Keep live snapshot previews too; the id embeds createdAt, so an overwritten
-    // snapshot's stale preview falls out of the set here and gets revoked.
+    // Keep live snapshot previews; a stale (overwritten) one falls out and gets revoked.
     snapshots.forEach((s: AdjustmentSnapshot) => allPresetIds.add(snapshotPreviewId(s)));
 
     const currentPreviews = previewsRef.current;
@@ -655,18 +654,14 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
     }
   }, [selectedImage?.isReady, presets, enqueuePreviews]);
 
-  // Snapshots reuse the preset preview pipeline: each is fed in as a preset-shaped
-  // item ({ id, adjustments: state }) so it gets the same rendered thumbnail.
+  // Feed snapshots through the preset preview pipeline as { id, adjustments } items.
   const generateSnapshotPreviews = useCallback(() => {
     if (!selectedImage?.isReady) {
       return;
     }
-    const toGenerate = snapshots
-      .map((s: AdjustmentSnapshot) => ({ id: snapshotPreviewId(s), name: s.name, adjustments: s.state }))
-      .filter((p: any) => !previewsRef.current[p.id]);
-    if (toGenerate.length > 0) {
-      enqueuePreviews(toGenerate as any);
-    }
+    enqueuePreviews(
+      snapshots.map((s: AdjustmentSnapshot) => ({ id: snapshotPreviewId(s), name: s.name, adjustments: s.state })) as any,
+    );
   }, [selectedImage?.isReady, snapshots, enqueuePreviews]);
 
   useEffect(() => {

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -26,11 +26,7 @@ import {
   SortAsc,
   Trash2,
   Users,
-  Layers,
-  Crop,
   Save,
-  Wrench,
-  Palette,
   Settings2,
 } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -39,10 +35,10 @@ import CreateFolderModal from '../../modals/CreateFolderModal';
 import RenameFolderModal from '../../modals/RenameFolderModal';
 import Button from '../../ui/Button';
 import Text from '../../ui/Text';
-import SnapshotsSection from './SnapshotsSection';
-import Slider from '../../ui/Slider';
+import SnapshotsSection, { snapshotPreviewId } from './SnapshotsSection';
+import PresetItemDisplay from './PresetItemDisplay';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
-import { Adjustments, INITIAL_ADJUSTMENTS, ADJUSTMENT_GROUPS } from '../../../utils/adjustments';
+import { Adjustments, AdjustmentSnapshot, INITIAL_ADJUSTMENTS } from '../../../utils/adjustments';
 import { Invokes, OPTION_SEPARATOR, Panel, Preset, SelectedImage } from '../../ui/AppProperties';
 import { useEditorStore } from '../../../store/useEditorStore';
 import { useUIStore } from '../../../store/useUIStore';
@@ -80,16 +76,6 @@ interface FolderState {
 interface ModalState {
   isOpen: boolean;
   preset: Preset | null;
-}
-
-interface PresetItemDisplayProps {
-  isGeneratingPreviews: boolean;
-  preset: Preset;
-  previewUrl: string;
-  isActive?: boolean;
-  intensity?: number;
-  onIntensityChange?: (val: number) => void;
-  onDragStateChange?: (isDragging: boolean) => void;
 }
 
 interface PresetsPanelProps {
@@ -198,113 +184,6 @@ const mixAdjustments = (presetObj: any, intensity: number, initialObj: any = INI
   }
   return result;
 };
-
-function PresetItemDisplay({
-  preset,
-  previewUrl,
-  isGeneratingPreviews,
-  isActive,
-  intensity,
-  onIntensityChange,
-  onDragStateChange,
-}: PresetItemDisplayProps) {
-  const { t } = useTranslation();
-  const geometryKeys = ADJUSTMENT_GROUPS.geometry.flatMap((g) => g.keys);
-
-  const supportsMasks = preset.includeMasks ?? (preset.adjustments?.masks && preset.adjustments.masks.length > 0);
-  const supportsGeometry =
-    preset.includeCropTransform ?? geometryKeys.some((key) => preset.adjustments?.[key] !== undefined);
-  const isTool = preset.presetType === 'tool';
-  const tooltipContent = useMemo(() => {
-    const features = [];
-    if (supportsMasks) features.push(t('editor.presets.supports.masks'));
-    if (supportsGeometry) features.push(t('editor.presets.supports.cropTransform'));
-
-    if (features.length === 0) return undefined;
-    return t('editor.presets.supports.label', { features: features.join(' + ') });
-  }, [supportsMasks, supportsGeometry, t]);
-
-  return (
-    <div className="flex flex-col p-2 rounded-lg bg-surface cursor-grabbing">
-      <div className="flex items-center gap-3">
-        <div
-          className="w-20 h-14 bg-bg-tertiary rounded-md flex items-center justify-center shrink-0 relative overflow-hidden"
-          data-tooltip={tooltipContent}
-        >
-          {isGeneratingPreviews && !previewUrl ? (
-            <Loader2 size={20} className="animate-spin text-text-secondary" />
-          ) : previewUrl ? (
-            <img
-              src={previewUrl}
-              alt={`${preset.name} preview`}
-              className="w-full h-full object-cover rounded-md pointer-events-none"
-            />
-          ) : (
-            <Loader2 size={20} className="animate-spin text-text-secondary" />
-          )}
-
-          {(supportsMasks || supportsGeometry) && (
-            <>
-              <div className="absolute top-0 right-0 w-1/2 h-1/2 bg-linear-to-bl from-black/30 via-black/0 to-transparent pointer-events-none z-0" />
-
-              <div className="absolute top-1 right-1 bg-primary rounded-full px-1.5 py-0.5 flex items-center gap-1.5 backdrop-blur-xs shadow-xs z-10 pointer-events-none">
-                {supportsMasks && <Layers size={11} className="text-white" />}
-                {supportsGeometry && <Crop size={11} className="text-white" />}
-              </div>
-            </>
-          )}
-        </div>
-
-        <div className="grow min-w-0 flex flex-col justify-center">
-          <Text color={TextColors.primary} weight={TextWeights.medium} className="truncate">
-            {preset.name}
-          </Text>
-          <div className="flex items-center gap-1.5 mt-0.5">
-            {isTool ? (
-              <Wrench size={12} className="text-text-secondary" />
-            ) : (
-              <Palette size={12} className="text-text-secondary" />
-            )}
-            <Text
-              variant={TextVariants.small}
-              color={TextColors.secondary}
-              className="text-[10px] uppercase tracking-wider"
-            >
-              {isTool ? t('editor.presets.types.tool') : t('editor.presets.types.style')}
-            </Text>
-          </div>
-        </div>
-      </div>
-
-      <AnimatePresence initial={false}>
-        {isActive && onIntensityChange && (
-          <motion.div
-            initial={{ height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={{ height: 0, opacity: 0 }}
-            transition={{ duration: 0.25, ease: 'easeInOut' }}
-            className="w-full cursor-auto overflow-hidden"
-            onClick={(e: any) => e.stopPropagation()}
-            onPointerDown={(e: any) => e.stopPropagation()}
-          >
-            <div className="mt-3 px-1 pb-1">
-              <Slider
-                min={0}
-                max={200}
-                defaultValue={100}
-                value={intensity ?? 100}
-                onChange={(e: any) => onIntensityChange(Number(e.target.value))}
-                onDragStateChange={onDragStateChange}
-                label={t('editor.presets.amount')}
-                step={1}
-              />
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
-}
 
 function FolderItemDisplay({ folder }: FolderProps) {
   return (
@@ -481,6 +360,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
   const activePanel = useUIStore((s) => s.activeRightPanel);
   const setEditor = useEditorStore((s) => s.setEditor);
   const { setAdjustments } = useEditorActions();
+  const snapshots = useMemo<AdjustmentSnapshot[]>(() => adjustments.snapshots || [], [adjustments.snapshots]);
 
   const {
     addFolder,
@@ -538,6 +418,9 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
         item.folder.children.forEach((p: Preset) => allPresetIds.add(p.id));
       }
     });
+    // Keep live snapshot previews too; the id embeds createdAt, so an overwritten
+    // snapshot's stale preview falls out of the set here and gets revoked.
+    snapshots.forEach((s: AdjustmentSnapshot) => allPresetIds.add(snapshotPreviewId(s)));
 
     const currentPreviews = previewsRef.current;
     const previewsToDelete = Object.keys(currentPreviews).filter((id) => !allPresetIds.has(id));
@@ -555,7 +438,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
         return newPreviews;
       });
     }
-  }, [presets]);
+  }, [presets, snapshots]);
 
   useEffect(() => {
     return () => {
@@ -772,6 +655,20 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
     }
   }, [selectedImage?.isReady, presets, enqueuePreviews]);
 
+  // Snapshots reuse the preset preview pipeline: each is fed in as a preset-shaped
+  // item ({ id, adjustments: state }) so it gets the same rendered thumbnail.
+  const generateSnapshotPreviews = useCallback(() => {
+    if (!selectedImage?.isReady) {
+      return;
+    }
+    const toGenerate = snapshots
+      .map((s: AdjustmentSnapshot) => ({ id: snapshotPreviewId(s), name: s.name, adjustments: s.state }))
+      .filter((p: any) => !previewsRef.current[p.id]);
+    if (toGenerate.length > 0) {
+      enqueuePreviews(toGenerate as any);
+    }
+  }, [selectedImage?.isReady, snapshots, enqueuePreviews]);
+
   useEffect(() => {
     const isPathChanged = selectedImage?.path !== currentImagePathRef.current;
 
@@ -796,11 +693,14 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
       }
     }
 
-    if (activePanel === Panel.Presets && selectedImage?.isReady && presets.length > 0) {
-      generateRootPreviews();
-      expandedFolders.forEach((folderId: string) => {
-        generateFolderPreviews(folderId);
-      });
+    if (activePanel === Panel.Presets && selectedImage?.isReady) {
+      if (presets.length > 0) {
+        generateRootPreviews();
+        expandedFolders.forEach((folderId: string) => {
+          generateFolderPreviews(folderId);
+        });
+      }
+      generateSnapshotPreviews();
     }
   }, [
     activePanel,
@@ -809,6 +709,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
     presets.length,
     generateRootPreviews,
     generateFolderPreviews,
+    generateSnapshotPreviews,
     expandedFolders,
   ]);
 
@@ -1180,7 +1081,10 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
           onContextMenu={handleBackgroundContextMenu}
           ref={setRootNodeRef}
         >
-          <SnapshotsSection />
+          <SnapshotsSection previews={previews} isGeneratingPreviews={isGeneratingPreviews} />
+          <Text variant={TextVariants.heading} className="flex items-center gap-2 mb-2">
+            {t('editor.presets.title')}
+          </Text>
           {isLoading && presets.length === 0 && (
             <Text
               as="div"

--- a/src/components/panel/right/SnapshotsSection.tsx
+++ b/src/components/panel/right/SnapshotsSection.tsx
@@ -5,16 +5,24 @@ import { Check, FileEdit, History, Plus, RefreshCw, Trash2 } from 'lucide-react'
 import { useEditorStore } from '../../../store/useEditorStore';
 import { useEditorActions } from '../../../hooks/useEditorActions';
 import { useContextMenu } from '../../../context/ContextMenuContext';
-import { OPTION_SEPARATOR } from '../../ui/AppProperties';
+import { OPTION_SEPARATOR, Preset } from '../../ui/AppProperties';
 import { Adjustments, AdjustmentSnapshot, INITIAL_ADJUSTMENTS } from '../../../utils/adjustments';
+import PresetItemDisplay from './PresetItemDisplay';
 import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
 
-// In-editor checkpoints of the full edit state, stored inside the sidecar. They
-// complement library-level Virtual Copies: snapshots switch looks in place while
-// you work, without creating new library entries. Applying, renaming and deleting all go through
-// setAdjustments and are therefore undoable and auto-saved like any other edit.
-export default function SnapshotsSection() {
+// Preview id for a snapshot thumbnail. Embeds createdAt so an overwrite (which bumps
+// createdAt) produces a fresh id, and the pipeline revokes the stale one.
+export const snapshotPreviewId = (s: AdjustmentSnapshot) => `snapshot-${s.id}-${s.createdAt}`;
+
+interface SnapshotsSectionProps {
+  previews: Record<string, string | null>;
+  isGeneratingPreviews: boolean;
+}
+
+// In-editor checkpoints of the full edit state, stored in the sidecar. Rendered as
+// preset-style cards (reusing PresetItemDisplay) so they read as part of the panel.
+export default function SnapshotsSection({ previews, isGeneratingPreviews }: SnapshotsSectionProps) {
   const adjustments = useEditorStore((s) => s.adjustments);
   const selectedImage = useEditorStore((s) => s.selectedImage);
   const { setAdjustments } = useEditorActions();
@@ -72,6 +80,11 @@ export default function SnapshotsSection() {
     }));
   };
 
+  const startRename = (version: AdjustmentSnapshot) => {
+    setRenamingId(version.id);
+    setTempName(version.name);
+  };
+
   const commitRename = () => {
     const name = tempName.trim();
     if (name && renamingId) {
@@ -92,15 +105,15 @@ export default function SnapshotsSection() {
       {
         label: t('editor.presets.snapshots.rename'),
         icon: FileEdit,
-        onClick: () => {
-          setRenamingId(version.id);
-          setTempName(version.name);
-        },
+        onClick: () => startRename(version),
       },
       { type: OPTION_SEPARATOR },
       { label: t('editor.presets.snapshots.delete'), icon: Trash2, onClick: () => handleDelete(version) },
     ]);
   };
+
+  const dateLabel = (createdAt: number) =>
+    new Date(createdAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
 
   return (
     <div className="mb-4 pb-4 border-b border-surface">
@@ -123,48 +136,60 @@ export default function SnapshotsSection() {
         </Text>
       ) : (
         <div className="space-y-2">
-          {snapshots.map((version) => (
-            <button
-              key={version.id}
-              className="w-full flex items-center justify-between gap-2 p-2 rounded-lg bg-surface hover:bg-surface-hover cursor-pointer transition-colors group text-left"
-              onClick={() => handleApply(version)}
-              onContextMenu={(e) => handleRowContextMenu(e, version)}
-            >
-              {renamingId === version.id ? (
-                <input
-                  autoFocus
-                  className="bg-transparent border-b border-text-secondary outline-none text-sm w-full mr-2"
-                  value={tempName}
-                  onChange={(e) => setTempName(e.target.value)}
-                  onBlur={commitRename}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') commitRename();
-                    if (e.key === 'Escape') setRenamingId(null);
-                  }}
-                  onClick={(e) => e.stopPropagation()}
-                />
-              ) : (
-                <Text
-                  color={TextColors.primary}
-                  weight={TextWeights.medium}
-                  className="grow truncate select-none"
-                >
-                  {version.name}
-                </Text>
-              )}
-              <Text
-                as="span"
-                variant={TextVariants.small}
-                color={TextColors.secondary}
-                className="ml-auto pr-1 shrink-0"
+          {snapshots.map((version) => {
+            const isRenaming = renamingId === version.id;
+            return (
+              <div
+                key={version.id}
+                className="relative group cursor-pointer"
+                style={{ borderRadius: '10px' }}
+                onClick={() => !isRenaming && handleApply(version)}
+                onContextMenu={(e) => handleRowContextMenu(e, version)}
               >
-                {new Date(version.createdAt).toLocaleDateString(undefined, {
-                  month: 'short',
-                  day: 'numeric',
-                })}
-              </Text>
-            </button>
-          ))}
+                <PresetItemDisplay
+                  preset={{ id: version.id, name: version.name, adjustments: version.state } as Preset}
+                  previewUrl={previews[snapshotPreviewId(version)] || ''}
+                  isGeneratingPreviews={isGeneratingPreviews}
+                  subtitle={
+                    <>
+                      <History size={12} className="text-text-secondary" />
+                      <Text variant={TextVariants.small} color={TextColors.secondary} weight={TextWeights.normal}>
+                        {dateLabel(version.createdAt)}
+                      </Text>
+                    </>
+                  }
+                  nameSlot={
+                    isRenaming ? (
+                      <input
+                        autoFocus
+                        className="bg-transparent border-b border-text-secondary outline-none text-sm w-full"
+                        value={tempName}
+                        onChange={(e) => setTempName(e.target.value)}
+                        onBlur={commitRename}
+                        onClick={(e) => e.stopPropagation()}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') commitRename();
+                          if (e.key === 'Escape') setRenamingId(null);
+                        }}
+                      />
+                    ) : undefined
+                  }
+                />
+                {!isRenaming && (
+                  <button
+                    className="absolute top-2 right-2 p-1 rounded-md bg-bg-tertiary text-text-secondary opacity-0 group-hover:opacity-100 hover:text-primary transition-opacity"
+                    data-tooltip={t('editor.presets.snapshots.rename')}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      startRename(version);
+                    }}
+                  >
+                    <FileEdit size={14} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/panel/right/SnapshotsSection.tsx
+++ b/src/components/panel/right/SnapshotsSection.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { useTranslation } from 'react-i18next';
+import { Check, FileEdit, History, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { useEditorStore } from '../../../store/useEditorStore';
+import { useEditorActions } from '../../../hooks/useEditorActions';
+import { useContextMenu } from '../../../context/ContextMenuContext';
+import { OPTION_SEPARATOR } from '../../ui/AppProperties';
+import { Adjustments, AdjustmentSnapshot, INITIAL_ADJUSTMENTS } from '../../../utils/adjustments';
+import Text from '../../ui/Text';
+import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
+
+// In-editor checkpoints of the full edit state, stored inside the sidecar. They
+// complement library-level Virtual Copies: snapshots switch looks in place while
+// you work, without creating new library entries. Applying, renaming and deleting all go through
+// setAdjustments and are therefore undoable and auto-saved like any other edit.
+export default function SnapshotsSection() {
+  const adjustments = useEditorStore((s) => s.adjustments);
+  const selectedImage = useEditorStore((s) => s.selectedImage);
+  const { setAdjustments } = useEditorActions();
+  const { showContextMenu } = useContextMenu();
+  const { t } = useTranslation();
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [tempName, setTempName] = useState('');
+
+  if (!selectedImage) {
+    return null;
+  }
+  const snapshots: AdjustmentSnapshot[] = adjustments.snapshots || [];
+
+  const snapshotState = (adj: Adjustments): Partial<Adjustments> => {
+    const { snapshots: _snapshots, ...state } = adj;
+    return structuredClone(state);
+  };
+
+  const handleSave = () => {
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      snapshots: [
+        ...(prev.snapshots || []),
+        {
+          id: uuidv4(),
+          name: t('editor.presets.snapshots.defaultName', { count: (prev.snapshots?.length || 0) + 1 }),
+          createdAt: Date.now(),
+          state: snapshotState(prev),
+        },
+      ],
+    }));
+  };
+
+  const handleApply = (version: AdjustmentSnapshot) => {
+    setAdjustments((prev: Adjustments) => ({
+      ...INITIAL_ADJUSTMENTS,
+      ...version.state,
+      snapshots: prev.snapshots,
+    }));
+  };
+
+  const handleOverwrite = (version: AdjustmentSnapshot) => {
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      snapshots: (prev.snapshots || []).map((v) =>
+        v.id === version.id ? { ...v, state: snapshotState(prev), createdAt: Date.now() } : v,
+      ),
+    }));
+  };
+
+  const handleDelete = (version: AdjustmentSnapshot) => {
+    setAdjustments((prev: Adjustments) => ({
+      ...prev,
+      snapshots: (prev.snapshots || []).filter((v) => v.id !== version.id),
+    }));
+  };
+
+  const commitRename = () => {
+    const name = tempName.trim();
+    if (name && renamingId) {
+      setAdjustments((prev: Adjustments) => ({
+        ...prev,
+        snapshots: (prev.snapshots || []).map((v) => (v.id === renamingId ? { ...v, name } : v)),
+      }));
+    }
+    setRenamingId(null);
+  };
+
+  const handleRowContextMenu = (event: React.MouseEvent, version: AdjustmentSnapshot) => {
+    event.preventDefault();
+    event.stopPropagation();
+    showContextMenu(event.clientX, event.clientY, [
+      { label: t('editor.presets.snapshots.apply'), icon: Check, onClick: () => handleApply(version) },
+      { label: t('editor.presets.snapshots.overwrite'), icon: RefreshCw, onClick: () => handleOverwrite(version) },
+      {
+        label: t('editor.presets.snapshots.rename'),
+        icon: FileEdit,
+        onClick: () => {
+          setRenamingId(version.id);
+          setTempName(version.name);
+        },
+      },
+      { type: OPTION_SEPARATOR },
+      { label: t('editor.presets.snapshots.delete'), icon: Trash2, onClick: () => handleDelete(version) },
+    ]);
+  };
+
+  return (
+    <div className="mb-4 pb-4 border-b border-surface">
+      <div className="flex items-center justify-between mb-2">
+        <Text variant={TextVariants.heading} className="flex items-center gap-2">
+          <History size={16} />
+          {t('editor.presets.snapshots.title')}
+        </Text>
+        <button
+          className="p-1.5 rounded-full hover:bg-surface transition-colors"
+          onClick={handleSave}
+          data-tooltip={t('editor.presets.snapshots.saveTooltip')}
+        >
+          <Plus size={16} />
+        </button>
+      </div>
+      {snapshots.length === 0 ? (
+        <Text color={TextColors.secondary} className="text-sm">
+          {t('editor.presets.snapshots.empty')}
+        </Text>
+      ) : (
+        <div className="space-y-1">
+          {snapshots.map((version) => (
+            <button
+              key={version.id}
+              className="w-full flex items-center justify-between p-2 rounded-md bg-surface hover:bg-card-active cursor-pointer transition-colors group text-left"
+              onClick={() => handleApply(version)}
+              onContextMenu={(e) => handleRowContextMenu(e, version)}
+            >
+              {renamingId === version.id ? (
+                <input
+                  autoFocus
+                  className="bg-transparent border-b border-text-secondary outline-none text-sm w-full mr-2"
+                  value={tempName}
+                  onChange={(e) => setTempName(e.target.value)}
+                  onBlur={commitRename}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') commitRename();
+                    if (e.key === 'Escape') setRenamingId(null);
+                  }}
+                  onClick={(e) => e.stopPropagation()}
+                />
+              ) : (
+                <Text weight={TextWeights.medium} className="truncate text-sm">
+                  {version.name}
+                </Text>
+              )}
+              <Text color={TextColors.secondary} className="text-xs shrink-0 ml-2">
+                {new Date(version.createdAt).toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                })}
+              </Text>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/panel/right/SnapshotsSection.tsx
+++ b/src/components/panel/right/SnapshotsSection.tsx
@@ -11,8 +11,7 @@ import PresetItemDisplay from './PresetItemDisplay';
 import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
 
-// Preview id for a snapshot thumbnail. Embeds createdAt so an overwrite (which bumps
-// createdAt) produces a fresh id, and the pipeline revokes the stale one.
+// Keyed by createdAt so overwriting a snapshot invalidates its cached thumbnail.
 export const snapshotPreviewId = (s: AdjustmentSnapshot) => `snapshot-${s.id}-${s.createdAt}`;
 
 interface SnapshotsSectionProps {
@@ -20,8 +19,6 @@ interface SnapshotsSectionProps {
   isGeneratingPreviews: boolean;
 }
 
-// In-editor checkpoints of the full edit state, stored in the sidecar. Rendered as
-// preset-style cards (reusing PresetItemDisplay) so they read as part of the panel.
 export default function SnapshotsSection({ previews, isGeneratingPreviews }: SnapshotsSectionProps) {
   const adjustments = useEditorStore((s) => s.adjustments);
   const selectedImage = useEditorStore((s) => s.selectedImage);
@@ -41,44 +38,30 @@ export default function SnapshotsSection({ previews, isGeneratingPreviews }: Sna
     return structuredClone(state);
   };
 
-  const handleSave = () => {
-    setAdjustments((prev: Adjustments) => ({
-      ...prev,
-      snapshots: [
-        ...(prev.snapshots || []),
-        {
-          id: uuidv4(),
-          name: t('editor.presets.snapshots.defaultName', { count: (prev.snapshots?.length || 0) + 1 }),
-          createdAt: Date.now(),
-          state: snapshotState(prev),
-        },
-      ],
-    }));
-  };
+  const updateSnapshots = (fn: (list: AdjustmentSnapshot[], adj: Adjustments) => AdjustmentSnapshot[]) =>
+    setAdjustments((prev: Adjustments) => ({ ...prev, snapshots: fn(prev.snapshots || [], prev) }));
 
-  const handleApply = (version: AdjustmentSnapshot) => {
-    setAdjustments((prev: Adjustments) => ({
-      ...INITIAL_ADJUSTMENTS,
-      ...version.state,
-      snapshots: prev.snapshots,
-    }));
-  };
+  const handleSave = () =>
+    updateSnapshots((list, adj) => [
+      ...list,
+      {
+        id: uuidv4(),
+        name: t('editor.presets.snapshots.defaultName', { count: list.length + 1 }),
+        createdAt: Date.now(),
+        state: snapshotState(adj),
+      },
+    ]);
 
-  const handleOverwrite = (version: AdjustmentSnapshot) => {
-    setAdjustments((prev: Adjustments) => ({
-      ...prev,
-      snapshots: (prev.snapshots || []).map((v) =>
-        v.id === version.id ? { ...v, state: snapshotState(prev), createdAt: Date.now() } : v,
-      ),
-    }));
-  };
+  const handleApply = (version: AdjustmentSnapshot) =>
+    setAdjustments((prev: Adjustments) => ({ ...INITIAL_ADJUSTMENTS, ...version.state, snapshots: prev.snapshots }));
 
-  const handleDelete = (version: AdjustmentSnapshot) => {
-    setAdjustments((prev: Adjustments) => ({
-      ...prev,
-      snapshots: (prev.snapshots || []).filter((v) => v.id !== version.id),
-    }));
-  };
+  const handleOverwrite = (version: AdjustmentSnapshot) =>
+    updateSnapshots((list, adj) =>
+      list.map((v) => (v.id === version.id ? { ...v, state: snapshotState(adj), createdAt: Date.now() } : v)),
+    );
+
+  const handleDelete = (version: AdjustmentSnapshot) =>
+    updateSnapshots((list) => list.filter((v) => v.id !== version.id));
 
   const startRename = (version: AdjustmentSnapshot) => {
     setRenamingId(version.id);
@@ -88,10 +71,7 @@ export default function SnapshotsSection({ previews, isGeneratingPreviews }: Sna
   const commitRename = () => {
     const name = tempName.trim();
     if (name && renamingId) {
-      setAdjustments((prev: Adjustments) => ({
-        ...prev,
-        snapshots: (prev.snapshots || []).map((v) => (v.id === renamingId ? { ...v, name } : v)),
-      }));
+      updateSnapshots((list) => list.map((v) => (v.id === renamingId ? { ...v, name } : v)));
     }
     setRenamingId(null);
   };

--- a/src/components/panel/right/SnapshotsSection.tsx
+++ b/src/components/panel/right/SnapshotsSection.tsx
@@ -122,11 +122,11 @@ export default function SnapshotsSection() {
           {t('editor.presets.snapshots.empty')}
         </Text>
       ) : (
-        <div className="space-y-1">
+        <div className="space-y-2">
           {snapshots.map((version) => (
             <button
               key={version.id}
-              className="w-full flex items-center justify-between p-2 rounded-md bg-surface hover:bg-card-active cursor-pointer transition-colors group text-left"
+              className="w-full flex items-center justify-between gap-2 p-2 rounded-lg bg-surface hover:bg-surface-hover cursor-pointer transition-colors group text-left"
               onClick={() => handleApply(version)}
               onContextMenu={(e) => handleRowContextMenu(e, version)}
             >
@@ -144,11 +144,20 @@ export default function SnapshotsSection() {
                   onClick={(e) => e.stopPropagation()}
                 />
               ) : (
-                <Text weight={TextWeights.medium} className="truncate text-sm">
+                <Text
+                  color={TextColors.primary}
+                  weight={TextWeights.medium}
+                  className="grow truncate select-none"
+                >
                   {version.name}
                 </Text>
               )}
-              <Text color={TextColors.secondary} className="text-xs shrink-0 ml-2">
+              <Text
+                as="span"
+                variant={TextVariants.small}
+                color={TextColors.secondary}
+                className="ml-auto pr-1 shrink-0"
+              >
                 {new Date(version.createdAt).toLocaleDateString(undefined, {
                   month: 'short',
                   day: 'numeric',

--- a/src/hooks/useImageProcessing.ts
+++ b/src/hooks/useImageProcessing.ts
@@ -123,7 +123,13 @@ export function useImageProcessing(
       const currentPath = selectedImage?.path;
       if (!currentPath) return;
 
-      const payload = structuredClone(currentAdjustments);
+      // Snapshots are in-editor checkpoints persisted through the sidecar save
+      // path; the renderer never reads them. Drop them before cloning so a
+      // growing snapshots list — each a full edit state, potentially carrying
+      // base64 mask/patch data — isn't structuredClone'd and shipped over IPC on
+      // every interactive tick.
+      const { snapshots: _snapshots, ...renderAdjustments } = currentAdjustments;
+      const payload = structuredClone(renderAdjustments);
       const { patchesSentToBackend } = useEditorStore.getState();
       const newlySentPatches = new Set<string>();
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -642,6 +642,16 @@
     },
     "presets": {
       "amount": "Amount",
+      "snapshots": {
+        "title": "Snapshots",
+        "saveTooltip": "Save a snapshot of the current edit",
+        "empty": "Save checkpoints of your edit and switch between looks without leaving the editor.",
+        "defaultName": "Snapshot {{count}}",
+        "apply": "Apply Snapshot",
+        "overwrite": "Overwrite with Current Edit",
+        "rename": "Rename",
+        "delete": "Delete Snapshot"
+      },
       "dialog": {
         "allPresetFiles": "All Preset Files",
         "exportAllTitle": "Export All Presets",

--- a/src/utils/adjustments.ts
+++ b/src/utils/adjustments.ts
@@ -146,9 +146,20 @@ export interface ParametricCurve {
   red: ParametricCurveSettings;
 }
 
+// An in-editor checkpoint of the edit state, stored inside the sidecar. `state` is
+// a full Adjustments snapshot minus the snapshots list itself. Complements
+// library-level Virtual Copies (Duplicate Image > Virtual Copy).
+export interface AdjustmentSnapshot {
+  id: string;
+  name: string;
+  createdAt: number;
+  state: Partial<Adjustments>;
+}
+
 export interface Adjustments {
   [index: string]: any;
   aiPatches: Array<AiPatch>;
+  snapshots: Array<AdjustmentSnapshot>;
   aspectRatio: number | null;
   blacks: number;
   brightness: number;
@@ -477,6 +488,7 @@ export const INITIAL_MASK_CONTAINER: MaskContainer = {
 
 export const INITIAL_ADJUSTMENTS: Adjustments = {
   aiPatches: [],
+  snapshots: [],
   aspectRatio: null,
   blacks: 0,
   brightness: 0,


### PR DESCRIPTION
## What

Adds **Snapshots** — named checkpoints of the complete edit state, stored inside the sidecar — so you can save a look, keep editing, and flip between looks **without leaving the editor**.

![Snapshot switching](https://raw.githubusercontent.com/SandeepSubba/RapidRAW/pr-assets/snapshots-ab.jpg)

## How this relates to Virtual Copies

RapidRAW already has **Virtual Copies** (Duplicate Image → Virtual Copy), which create a parallel *library entry* with its own sidecar — great for deliverables you want side by side in the grid, rated and exported independently:

<img src="https://raw.githubusercontent.com/SandeepSubba/RapidRAW/pr-assets/virtualcopy-menu.jpg" width="360" alt="Existing Duplicate Image menu with Physical Copy / Virtual Copy" />

Snapshots cover the other half of that workflow (Lightroom ships both concepts for the same reason): **checkpoints while working on one entry**. Try a bolder grade, keep the safe state one click away, overwrite a checkpoint as the edit evolves — no extra grid entries, and the looks travel *inside* the one sidecar. An earlier draft of this PR (#1334) was withdrawn because it didn't make this distinction clear.

## UI

A **Snapshots** section at the top of the Presets panel:

- **+** saves the current edit as a snapshot (full state: adjustments, masks, AI edits, crop)
- **click** a snapshot to apply it
- right-click for **Apply / Overwrite with Current Edit / Rename / Delete**

<img src="https://raw.githubusercontent.com/SandeepSubba/RapidRAW/pr-assets/snapshots-menu.jpg" width="440" alt="Snapshot context menu" />

## Design notes

- **No backend schema change.** Snapshots live in `adjustments.snapshots[]` (`{id, name, createdAt, state}`); the sidecar stores adjustments as raw JSON, so they round-trip untouched.
- **Undoable + auto-saved.** Every snapshot operation goes through `setAdjustments`, participating in history and the normal save path.
- **Isolated.** Snapshots are excluded from copy/paste and multi-select sync (not in the copyable-key whitelist), so pasting adjustments to other photos never drags checkpoints along.
- **Reset-safe.** `reset_adjustments_for_paths` preserves the `snapshots` key — clearing the working edit can't destroy checkpoints.

## Testing

- Full round-trip verified in-app: save two snapshots with different looks, switch repeatedly, persistence via sidecar confirmed; snapshot operations undo cleanly
- `cargo check`, `cargo fmt --check`, and clippy on the touched code clean; `tsc` introduces no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)