### PR TITLE
Native File Transfer for Thumbnails

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2557,6 +2557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6353,6 +6359,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni 0.21.1",
  "libc",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -10,7 +10,7 @@ name = "rapidraw_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
-tauri = { version = "2.11", features = [ "macos-private-api", "rustls-tls" ] }
+tauri = { version = "2.11", features = [ "macos-private-api", "rustls-tls", "protocol-asset" ] }
 tauri-plugin-dialog = "2.7.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src-tauri/src/android_integration.rs
+++ b/src-tauri/src/android_integration.rs
@@ -39,17 +39,12 @@ pub fn initialize_android(window: &tauri::WebviewWindow) {
                     .with_env(|env_22| {
                         let verifier_context =
                             unsafe { VerifierJObject::from_raw(env_22, raw_context) };
-                        rustls_platform_verifier::android::init_with_env(
-                            env_22,
-                            verifier_context,
-                        )
+                        rustls_platform_verifier::android::init_with_env(env_22, verifier_context)
                     })
                     .into_outcome()
                 {
                     jni22::Outcome::Ok(()) => {
-                        log::info!(
-                            "Successfully initialized rustls-platform-verifier on Android."
-                        );
+                        log::info!("Successfully initialized rustls-platform-verifier on Android.");
                     }
                     jni22::Outcome::Err(error) => {
                         log::error!(

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -12,7 +12,6 @@ use std::sync::Arc;
 use std::thread;
 
 use anyhow::Result;
-use base64::{Engine as _, engine::general_purpose};
 use chrono::{DateTime, Utc};
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, GenericImageView, ImageBuffer, Luma};
@@ -1410,11 +1409,9 @@ fn generate_single_thumbnail_and_cache(
 
     if !force_regenerate
         && cache_path.exists()
-        && let Ok(data) = fs::read(&cache_path)
     {
-        let base64_str = general_purpose::STANDARD.encode(&data);
         return Some((
-            format!("data:image/jpeg;base64,{}", base64_str),
+            cache_path.to_string_lossy().into_owned(),
             rating,
             is_edited,
         ));
@@ -1427,9 +1424,8 @@ fn generate_single_thumbnail_and_cache(
         && let Ok(thumb_data) = encode_thumbnail(&thumb_image, target_width)
     {
         let _ = fs::write(&cache_path, &thumb_data);
-        let base64_str = general_purpose::STANDARD.encode(&thumb_data);
         return Some((
-            format!("data:image/jpeg;base64,{}", base64_str),
+            cache_path.to_string_lossy().into_owned(),
             rating,
             is_edited,
         ));
@@ -1482,16 +1478,8 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                         &worker_settings,
                     );
 
-                    if let Some((thumbnail_data, rating, is_edited)) = result {
-                        let _ = app_clone.emit(
-                            "thumbnail-generated",
-                            serde_json::json!({
-                                "path": path_to_process,
-                                "data": thumbnail_data,
-                                "rating": rating,
-                                "is_edited": is_edited
-                            }),
-                        );
+                    if let Some((thumbnail_path, rating, is_edited)) = result {
+                        emit_thumbnail_generated(&app_clone, &path_to_process, &thumbnail_path, rating, is_edited);
                     }
                     increment_thumbnail_progress(&state, &app_clone);
                 }
@@ -1602,6 +1590,13 @@ pub fn increment_thumbnail_progress(state: &AppState, app_handle: &AppHandle) {
             serde_json::json!({ "current": current, "total": total }),
         );
     }
+}
+
+fn emit_thumbnail_generated(app_handle: &AppHandle, path: &str, thumbnail_path: &str, rating: u8, is_edited: bool) {
+    let _ = app_handle.emit(
+        "thumbnail-generated",
+        serde_json::json!({ "path": path, "thumbnailPath": thumbnail_path, "rating": rating, "is_edited": is_edited }),
+    );
 }
 
 pub fn resolve_lens_params_in_adjustments(
@@ -2130,11 +2125,8 @@ pub fn save_metadata_and_update_thumbnail(
             &settings,
         );
 
-        if let Some((thumbnail_data, rating, is_edited)) = result {
-            let _ = app_handle_clone.emit(
-                "thumbnail-generated",
-                serde_json::json!({ "path": path_clone, "data": thumbnail_data, "rating": rating, "is_edited": is_edited }),
-            );
+        if let Some((thumbnail_path, rating, is_edited)) = result {
+            emit_thumbnail_generated(&app_handle_clone, &path_clone, &thumbnail_path, rating, is_edited);
         }
 
         increment_thumbnail_progress(&state, &app_handle_clone);
@@ -2228,11 +2220,8 @@ pub async fn apply_adjustments_to_paths(
                 &settings,
             );
 
-            if let Some((thumbnail_data, rating, is_edited)) = result {
-                let _ = app_handle.emit(
-                    "thumbnail-generated",
-                    serde_json::json!({ "path": path_str, "data": thumbnail_data, "rating": rating, "is_edited": is_edited  }),
-                );
+            if let Some((thumbnail_path, rating, is_edited)) = result {
+                emit_thumbnail_generated(&app_handle, path_str, &thumbnail_path, rating, is_edited);
             }
 
             increment_thumbnail_progress(&state, &app_handle);
@@ -2300,11 +2289,8 @@ pub async fn reset_adjustments_for_paths(
                 &settings,
             );
 
-            if let Some((thumbnail_data, rating, is_edited)) = result {
-                let _ = app_handle.emit(
-                    "thumbnail-generated",
-                    serde_json::json!({ "path": path_str, "data": thumbnail_data, "rating": rating, "is_edited": is_edited }),
-                );
+            if let Some((thumbnail_path, rating, is_edited)) = result {
+                emit_thumbnail_generated(&app_handle, path_str, &thumbnail_path, rating, is_edited);
             }
 
             increment_thumbnail_progress(&state, &app_handle);
@@ -2413,11 +2399,8 @@ pub async fn apply_auto_adjustments_to_paths(
                 &settings,
             );
 
-            if let Some((thumbnail_data, rating, is_edited)) = result {
-                let _ = app_handle.emit(
-                    "thumbnail-generated",
-                    serde_json::json!({ "path": path, "data": thumbnail_data, "rating": rating, "is_edited": is_edited  }),
-                );
+            if let Some((thumbnail_path, rating, is_edited)) = result {
+                emit_thumbnail_generated(&app_handle, &path, &thumbnail_path, rating, is_edited);
             }
 
             increment_thumbnail_progress(&state, &app_handle);

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -1407,14 +1407,8 @@ fn generate_single_thumbnail_and_cache(
     let cache_filename = format!("{}.jpg", cache_hash);
     let cache_path = thumb_cache_dir.join(cache_filename);
 
-    if !force_regenerate
-        && cache_path.exists()
-    {
-        return Some((
-            cache_path.to_string_lossy().into_owned(),
-            rating,
-            is_edited,
-        ));
+    if !force_regenerate && cache_path.exists() {
+        return Some((cache_path.to_string_lossy().into_owned(), rating, is_edited));
     }
 
     let target_width = settings.thumbnail_resolution.unwrap_or(720);
@@ -1424,11 +1418,7 @@ fn generate_single_thumbnail_and_cache(
         && let Ok(thumb_data) = encode_thumbnail(&thumb_image, target_width)
     {
         let _ = fs::write(&cache_path, &thumb_data);
-        return Some((
-            cache_path.to_string_lossy().into_owned(),
-            rating,
-            is_edited,
-        ));
+        return Some((cache_path.to_string_lossy().into_owned(), rating, is_edited));
     }
     None
 }
@@ -1479,7 +1469,13 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                     );
 
                     if let Some((thumbnail_path, rating, is_edited)) = result {
-                        emit_thumbnail_generated(&app_clone, &path_to_process, &thumbnail_path, rating, is_edited);
+                        emit_thumbnail_generated(
+                            &app_clone,
+                            &path_to_process,
+                            &thumbnail_path,
+                            rating,
+                            is_edited,
+                        );
                     }
                     increment_thumbnail_progress(&state, &app_clone);
                 }
@@ -1592,7 +1588,13 @@ pub fn increment_thumbnail_progress(state: &AppState, app_handle: &AppHandle) {
     }
 }
 
-fn emit_thumbnail_generated(app_handle: &AppHandle, path: &str, thumbnail_path: &str, rating: u8, is_edited: bool) {
+fn emit_thumbnail_generated(
+    app_handle: &AppHandle,
+    path: &str,
+    thumbnail_path: &str,
+    rating: u8,
+    is_edited: bool,
+) {
     let _ = app_handle.emit(
         "thumbnail-generated",
         serde_json::json!({ "path": path, "thumbnailPath": thumbnail_path, "rating": rating, "is_edited": is_edited }),
@@ -2126,7 +2128,13 @@ pub fn save_metadata_and_update_thumbnail(
         );
 
         if let Some((thumbnail_path, rating, is_edited)) = result {
-            emit_thumbnail_generated(&app_handle_clone, &path_clone, &thumbnail_path, rating, is_edited);
+            emit_thumbnail_generated(
+                &app_handle_clone,
+                &path_clone,
+                &thumbnail_path,
+                rating,
+                is_edited,
+            );
         }
 
         increment_thumbnail_progress(&state, &app_handle_clone);

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -2408,7 +2408,7 @@ pub async fn apply_auto_adjustments_to_paths(
             );
 
             if let Some((thumbnail_path, rating, is_edited)) = result {
-                emit_thumbnail_generated(&app_handle, &path, &thumbnail_path, rating, is_edited);
+                emit_thumbnail_generated(&app_handle, path, &thumbnail_path, rating, is_edited);
             }
 
             increment_thumbnail_progress(&state, &app_handle);

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -330,8 +330,7 @@ pub fn parse_lut_file(path_str: &str) -> anyhow::Result<Lut> {
                     .and_then(|s| s.to_str())
                     .unwrap_or("cube")
                     .to_lowercase();
-                let uri_bytes =
-                    read_android_content_uri(path_str).map_err(|e| anyhow!("{}", e))?;
+                let uri_bytes = read_android_content_uri(path_str).map_err(|e| anyhow!("{}", e))?;
                 (ext, Some(uri_bytes))
             }
             #[cfg(not(target_os = "android"))]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,7 +23,11 @@
     ],
     "security": {
       "csp": null,
-      "capabilities": ["default"]
+      "capabilities": ["default"],
+      "assetProtocol": {
+        "enable": true,
+        "scope": ["$APPCACHE/thumbnails/*"]
+      }
     },
     "macOSPrivateApi": true
   },

--- a/src/hooks/useTauriListeners.ts
+++ b/src/hooks/useTauriListeners.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { listen } from '@tauri-apps/api/event';
+import { convertFileSrc } from '@tauri-apps/api/core';
 import { Status } from '../components/ui/ExportImportProperties';
 import { useProcessStore } from '../store/useProcessStore';
 import { useEditorStore } from '../store/useEditorStore';
@@ -100,9 +101,12 @@ export function useTauriListeners({
       }),
       listen('thumbnail-generated', (event: any) => {
         if (!isEffectActive) return;
-        const { path, data, rating, is_edited } = event.payload;
+        const { path, thumbnailPath, rating, is_edited, data } = event.payload;
 
-        if (data) {
+        if (thumbnailPath) {
+          thumbnailBuffer.current[path] = convertFileSrc(thumbnailPath);
+          refs.current.markGenerated(path);
+        } else if (data) {
           thumbnailBuffer.current[path] = data;
           refs.current.markGenerated(path);
         }
@@ -112,7 +116,7 @@ export function useTauriListeners({
         if (is_edited !== undefined) {
           editStatusBuffer.current[path] = is_edited;
         }
-        if (data || rating !== undefined || is_edited !== undefined) {
+        if (thumbnailPath || data || rating !== undefined || is_edited !== undefined) {
           scheduleFlush();
         }
       }),


### PR DESCRIPTION
## Description
This gets rid of the Base64 file transfer for the thumbnails and instead uses a native path. While the savings are miniscule we still save 33% overhead in transferred bits and the CPU cycles for encoding and decoding the data. In my testing I saw savings in RAM usage in the range of tens of MBs. While the impact is relatively small I still think this change is worth it in the name of efficiency, since it doesn't really introduce additional complexity.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [X] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
<!-- List the specific changes made in this PR -->
- Allow Tauri to access the thumbnail cache location
- Enable `protocol-asset` feature for Tauri
- Pass around thumbnails by path instead of Base64 string
- Refactor some duplicated code into a function

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 7, AMD Graphics, 32 GB RAM

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [X] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)