### PR TITLE
Fix UI freezing on mac 

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -113,6 +113,28 @@ impl ThumbnailManager {
     }
 }
 
+pub struct PendingMetadata {
+    pub virtual_path: String,
+    pub image_path: PathBuf,
+    pub sidecar_path: PathBuf,
+}
+
+pub struct MetadataManager {
+    pub queue: Mutex<VecDeque<PendingMetadata>>,
+    pub cvar: Condvar,
+    pub pending: Mutex<HashSet<PathBuf>>,
+}
+
+impl MetadataManager {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            queue: Mutex::new(VecDeque::new()),
+            cvar: Condvar::new(),
+            pending: Mutex::new(HashSet::new()),
+        })
+    }
+}
+
 pub type TransformedImageCache = (u64, Arc<DynamicImage>, (f32, f32));
 
 pub struct AppState {
@@ -147,4 +169,5 @@ pub struct AppState {
     pub full_transformed_cache: Mutex<Option<TransformedImageCache>>,
     pub decoded_image_cache: Mutex<DecodedImageCache>,
     pub thumbnail_manager: Arc<ThumbnailManager>,
+    pub metadata_manager: Arc<MetadataManager>,
 }

--- a/src-tauri/src/culling.rs
+++ b/src-tauri/src/culling.rs
@@ -4,6 +4,7 @@ use image_hasher::{HashAlg, HasherConfig};
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::VecDeque;
+use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tauri::{AppHandle, Emitter};
@@ -127,6 +128,11 @@ fn analyze_image(
     settings: &crate::app_settings::AppSettings,
 ) -> Result<ImageAnalysisData, String> {
     const ANALYSIS_DIM: u32 = 720; // FIXME: How should we calculate good focus if it's downscaled?!?
+
+    if crate::file_management::is_cloud_placeholder(Path::new(path)) {
+        return Err(format!("'{}' is stored in iCloud and not downloaded", path));
+    }
+
     let file_bytes = std::fs::read(path).map_err(|e| e.to_string())?;
 
     let img = image_loader::load_base_image_from_bytes(&file_bytes, path, true, settings, None)

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 use walkdir::WalkDir;
 
 use crate::AppState;
+use crate::PendingMetadata;
 #[cfg(target_os = "android")]
 use crate::android_integration::*;
 use crate::app_settings::*;
@@ -77,6 +78,104 @@ fn compute_thumbnail_cache_hash(path_str: &str, adjustments_bytes: &[u8]) -> Opt
     hasher.update(&img_mod_time.to_le_bytes());
     hasher.update(adjustments_bytes);
     Some(hasher.finalize().to_hex().to_string())
+}
+
+fn resolve_image_metadata(
+    image_path: &Path,
+    sidecar_path: &Path,
+    enable_xmp_sync: bool,
+    settings: &AppSettings,
+) -> (bool, Option<Vec<String>>, u8) {
+    let mut metadata = crate::exif_processing::load_sidecar(sidecar_path);
+
+    if enable_xmp_sync
+        && sync_metadata_from_xmp(image_path, &mut metadata)
+        && let Ok(json) = serde_json::to_string_pretty(&metadata)
+    {
+        let _ = fs::write(sidecar_path, json);
+    }
+
+    let is_raw = crate::formats::is_raw_file(image_path);
+    let tm_override = crate::image_processing::resolve_tonemapper_override(settings, is_raw);
+    let edited = crate::image_processing::is_image_edited(&metadata.adjustments, is_raw, tm_override);
+    (edited, metadata.tags, metadata.rating)
+}
+
+fn emit_image_metadata_loaded(
+    app_handle: &AppHandle,
+    path: &str,
+    rating: u8,
+    is_edited: bool,
+    tags: &Option<Vec<String>>,
+) {
+    let _ = app_handle.emit(
+        "image-metadata-loaded",
+        serde_json::json!({ "path": path, "rating": rating, "is_edited": is_edited, "tags": tags }),
+    );
+}
+
+fn enqueue_metadata(
+    app_handle: &AppHandle,
+    virtual_path: String,
+    image_path: PathBuf,
+    sidecar_path: PathBuf,
+) {
+    let state = app_handle.state::<crate::AppState>();
+    let manager = &state.metadata_manager;
+
+    let mut pending = manager.pending.lock().unwrap();
+    if !pending.insert(sidecar_path.clone()) {
+        return;
+    }
+    drop(pending);
+
+    manager.queue.lock().unwrap().push_back(PendingMetadata {
+        virtual_path,
+        image_path,
+        sidecar_path,
+    });
+    manager.cvar.notify_one();
+}
+
+// Not compute-heavy — these threads mostly block waiting on iCloud to
+// materialize a file, not burning CPU — so a small fixed pool is enough and
+// doesn't need a user-facing setting the way thumbnail_worker_threads does.
+const METADATA_WORKER_THREADS: usize = 4;
+
+pub fn start_metadata_workers(app_handle: tauri::AppHandle) {
+    let state = app_handle.state::<crate::AppState>();
+    let manager = state.metadata_manager.clone();
+
+    for _ in 0..METADATA_WORKER_THREADS {
+        let app_clone = app_handle.clone();
+        let manager_clone = manager.clone();
+
+        std::thread::spawn(move || {
+            loop {
+                let item = {
+                    let mut queue = manager_clone.queue.lock().unwrap();
+                    while queue.is_empty() {
+                        queue = manager_clone.cvar.wait(queue).unwrap();
+                    }
+                    queue.pop_front().unwrap()
+                };
+
+                let settings = load_settings(app_clone.clone()).unwrap_or_default();
+                let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
+
+                let (is_edited, tags, rating) = resolve_image_metadata(
+                    &item.image_path,
+                    &item.sidecar_path,
+                    enable_xmp_sync,
+                    &settings,
+                );
+
+                emit_image_metadata_loaded(&app_clone, &item.virtual_path, rating, is_edited, &tags);
+
+                manager_clone.pending.lock().unwrap().remove(&item.sidecar_path);
+            }
+        });
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -150,6 +249,7 @@ pub struct ImageFile {
     tags: Option<Vec<String>>,
     exif: Option<HashMap<String, String>>,
     is_virtual_copy: bool,
+    is_cloud_placeholder: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -208,6 +308,8 @@ pub async fn read_exif_for_paths(
                     crate::exif_processing::read_rrexif_sidecar(&source_path)
                 {
                     sidecar_exif
+                } else if is_cloud_placeholder(&source_path) {
+                    HashMap::new()
                 } else if let Ok(mmap) = read_file_mapped(&source_path) {
                     crate::exif_processing::read_exif_data(&source_path_str, &mmap)
                 } else if let Ok(bytes) = fs::read(&source_path) {
@@ -277,7 +379,7 @@ pub async fn update_exif_fields(
 
 #[tauri::command]
 pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<ImageFile>, String> {
-    let settings = load_settings(app_handle).unwrap_or_default();
+    let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
 
     let entries = fs::read_dir(&path).map_err(|e| e.to_string())?;
@@ -336,6 +438,8 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
 
+            let is_cloud_placeholder = is_cloud_placeholder(&path_buf);
+
             let mut file_results = Vec::with_capacity(sidecars.len());
 
             for copy_id_opt in sidecars {
@@ -350,25 +454,21 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
 
                 let sidecar_path = path_buf.with_file_name(sidecar_filename);
 
-                let (is_edited, tags, rating) = {
-                    let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
+                let xmp_is_placeholder = enable_xmp_sync
+                    && resolve_xmp_path(&path_buf).is_some_and(|p| crate::file_management::is_cloud_placeholder(&p));
 
-                    if enable_xmp_sync
-                        && sync_metadata_from_xmp(&path_buf, &mut metadata)
-                        && let Ok(json) = serde_json::to_string_pretty(&metadata)
-                    {
-                        let _ = fs::write(&sidecar_path, json);
-                    }
-
-                    let is_raw = crate::formats::is_raw_file(&path_str);
-                    let tm_override =
-                        crate::image_processing::resolve_tonemapper_override(&settings, is_raw);
-                    let edited = crate::image_processing::is_image_edited(
-                        &metadata.adjustments,
-                        is_raw,
-                        tm_override,
+                let (is_edited, tags, rating) = if crate::file_management::is_cloud_placeholder(&sidecar_path)
+                    || xmp_is_placeholder
+                {
+                    enqueue_metadata(
+                        &app_handle,
+                        virtual_path.clone(),
+                        path_buf.clone(),
+                        sidecar_path.clone(),
                     );
-                    (edited, metadata.tags, metadata.rating)
+                    (false, None, 0)
+                } else {
+                    resolve_image_metadata(&path_buf, &sidecar_path, enable_xmp_sync, &settings)
                 };
 
                 file_results.push(ImageFile {
@@ -379,6 +479,7 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
                     exif: None,
                     is_virtual_copy,
                     rating,
+                    is_cloud_placeholder,
                 });
             }
 
@@ -394,7 +495,7 @@ pub fn list_images_recursive(
     path: String,
     app_handle: AppHandle,
 ) -> Result<Vec<ImageFile>, String> {
-    let settings = load_settings(app_handle).unwrap_or_default();
+    let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
 
     let root_path = Path::new(&path);
@@ -459,6 +560,8 @@ pub fn list_images_recursive(
                 .map(|d| d.as_secs())
                 .unwrap_or(0);
 
+            let is_cloud_placeholder = is_cloud_placeholder(&path_buf);
+
             let mut file_results = Vec::with_capacity(sidecars.len());
 
             for copy_id_opt in sidecars {
@@ -473,25 +576,21 @@ pub fn list_images_recursive(
 
                 let sidecar_path = path_buf.with_file_name(sidecar_filename);
 
-                let (is_edited, tags, rating) = {
-                    let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
+                let xmp_is_placeholder = enable_xmp_sync
+                    && resolve_xmp_path(&path_buf).is_some_and(|p| crate::file_management::is_cloud_placeholder(&p));
 
-                    if enable_xmp_sync
-                        && sync_metadata_from_xmp(&path_buf, &mut metadata)
-                        && let Ok(json) = serde_json::to_string_pretty(&metadata)
-                    {
-                        let _ = fs::write(&sidecar_path, json);
-                    }
-
-                    let is_raw = crate::formats::is_raw_file(&path_str);
-                    let tm_override =
-                        crate::image_processing::resolve_tonemapper_override(&settings, is_raw);
-                    let edited = crate::image_processing::is_image_edited(
-                        &metadata.adjustments,
-                        is_raw,
-                        tm_override,
+                let (is_edited, tags, rating) = if crate::file_management::is_cloud_placeholder(&sidecar_path)
+                    || xmp_is_placeholder
+                {
+                    enqueue_metadata(
+                        &app_handle,
+                        virtual_path.clone(),
+                        path_buf.clone(),
+                        sidecar_path.clone(),
                     );
-                    (edited, metadata.tags, metadata.rating)
+                    (false, None, 0)
+                } else {
+                    resolve_image_metadata(&path_buf, &sidecar_path, enable_xmp_sync, &settings)
                 };
 
                 file_results.push(ImageFile {
@@ -502,6 +601,7 @@ pub fn list_images_recursive(
                     exif: None,
                     is_virtual_copy,
                     rating,
+                    is_cloud_placeholder,
                 });
             }
 
@@ -736,26 +836,23 @@ pub fn get_album_images(
                 .unwrap_or(0);
 
             let is_virtual_copy = virtual_path.contains("?vc=");
+            let is_cloud_placeholder = is_cloud_placeholder(&source_path);
 
-            let (is_edited, tags, rating) = {
-                let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
+            let xmp_is_placeholder = enable_xmp_sync
+                && resolve_xmp_path(&source_path).is_some_and(|p| crate::file_management::is_cloud_placeholder(&p));
 
-                if enable_xmp_sync
-                    && sync_metadata_from_xmp(&source_path, &mut metadata)
-                    && let Ok(json) = serde_json::to_string_pretty(&metadata)
-                {
-                    let _ = fs::write(&sidecar_path, json);
-                }
-
-                let is_raw = crate::formats::is_raw_file(&source_path);
-                let tm_override =
-                    crate::image_processing::resolve_tonemapper_override(&settings, is_raw);
-                let edited = crate::image_processing::is_image_edited(
-                    &metadata.adjustments,
-                    is_raw,
-                    tm_override,
+            let (is_edited, tags, rating) = if crate::file_management::is_cloud_placeholder(&sidecar_path)
+                || xmp_is_placeholder
+            {
+                enqueue_metadata(
+                    &app_handle,
+                    virtual_path.clone(),
+                    source_path.clone(),
+                    sidecar_path.clone(),
                 );
-                (edited, metadata.tags, metadata.rating)
+                (false, None, 0)
+            } else {
+                resolve_image_metadata(&source_path, &sidecar_path, enable_xmp_sync, &settings)
             };
 
             Some(ImageFile {
@@ -766,6 +863,7 @@ pub fn get_album_images(
                 exif: None,
                 is_virtual_copy,
                 rating,
+                is_cloud_placeholder,
             })
         })
         .collect();
@@ -1043,6 +1141,26 @@ pub async fn get_pinned_folder_trees(
     }
 }
 
+/// Checks if the given path exists and is an iCloud placeholder file on macOS.
+#[cfg(target_os = "macos")]
+pub fn is_cloud_placeholder(path: &Path) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+    const SF_DATALESS: u32 = 0x4000_0000;
+
+    let c_path = match std::ffi::CString::new(path.as_os_str().as_bytes()) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let mut stat_buf: libc::stat = unsafe { std::mem::zeroed() };
+    let ret = unsafe { libc::lstat(c_path.as_ptr(), &mut stat_buf) };
+    ret == 0 && (stat_buf.st_flags & SF_DATALESS) != 0
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn is_cloud_placeholder(_path: &Path) -> bool {
+    false
+}
+
 pub fn read_file_mapped(path: &Path) -> Result<Mmap, ReadFileError> {
     if !path.is_file() {
         return Err(ReadFileError::Invalid);
@@ -1076,9 +1194,19 @@ pub fn generate_thumbnail_data(
     let source_path_str = source_path.to_string_lossy().to_string();
     let is_raw = is_raw_file(&source_path_str);
 
-    let metadata: Option<ImageMetadata> = fs::read_to_string(sidecar_path)
-        .ok()
-        .and_then(|content| serde_json::from_str(&content).ok());
+    let metadata: Option<ImageMetadata> = if is_cloud_placeholder(&sidecar_path) {
+        enqueue_metadata(
+            app_handle,
+            path_str.to_string(),
+            source_path.clone(),
+            sidecar_path.clone(),
+        );
+        None
+    } else {
+        fs::read_to_string(&sidecar_path)
+            .ok()
+            .and_then(|content| serde_json::from_str(&content).ok())
+    };
 
     let adjustments = metadata
         .as_ref()
@@ -1382,25 +1510,32 @@ fn generate_single_thumbnail_and_cache(
     app_handle: &AppHandle,
     settings: &AppSettings,
 ) -> Option<(String, u8, bool)> {
-    let (_, sidecar_path) = parse_virtual_path(path_str);
+    let (source_path, sidecar_path) = parse_virtual_path(path_str);
 
-    let (rating, is_edited, adjustments_bytes) =
-        if let Ok(content) = fs::read_to_string(&sidecar_path) {
-            if let Ok(meta) = serde_json::from_str::<ImageMetadata>(&content) {
-                let is_raw = crate::formats::is_raw_file(path_str);
-                let tm = crate::image_processing::resolve_tonemapper_override(settings, is_raw);
+    let (rating, is_edited, adjustments_bytes) = if is_cloud_placeholder(&sidecar_path) {
+        enqueue_metadata(
+            app_handle,
+            path_str.to_string(),
+            source_path.clone(),
+            sidecar_path.clone(),
+        );
+        (0, false, Vec::new())
+    } else if let Ok(content) = fs::read_to_string(&sidecar_path) {
+        if let Ok(meta) = serde_json::from_str::<ImageMetadata>(&content) {
+            let is_raw = crate::formats::is_raw_file(path_str);
+            let tm = crate::image_processing::resolve_tonemapper_override(settings, is_raw);
 
-                (
-                    meta.rating,
-                    crate::image_processing::is_image_edited(&meta.adjustments, is_raw, tm),
-                    serde_json::to_vec(&meta.adjustments).unwrap_or_default(),
-                )
-            } else {
-                (0, false, Vec::new())
-            }
+            (
+                meta.rating,
+                crate::image_processing::is_image_edited(&meta.adjustments, is_raw, tm),
+                serde_json::to_vec(&meta.adjustments).unwrap_or_default(),
+            )
         } else {
             (0, false, Vec::new())
-        };
+        }
+    } else {
+        (0, false, Vec::new())
+    };
 
     let cache_hash = compute_thumbnail_cache_hash(path_str, &adjustments_bytes)?;
 
@@ -1409,6 +1544,10 @@ fn generate_single_thumbnail_and_cache(
 
     if !force_regenerate && cache_path.exists() {
         return Some((cache_path.to_string_lossy().into_owned(), rating, is_edited));
+    }
+
+    if is_cloud_placeholder(&source_path) {
+        return None;
     }
 
     let target_width = settings.thumbnail_resolution.unwrap_or(720);
@@ -3478,16 +3617,20 @@ pub fn extract_xmp_tags(content: &str) -> Vec<String> {
     tags
 }
 
-pub fn sync_metadata_from_xmp(source_path: &Path, metadata: &mut ImageMetadata) -> bool {
-    let xmp_path = source_path.with_extension("xmp");
-    let xmp_path_upper = source_path.with_extension("XMP");
-    let actual_xmp = if xmp_path.exists() {
+pub fn resolve_xmp_path(image_path: &Path) -> Option<PathBuf> {
+    let xmp_path = image_path.with_extension("xmp");
+    let xmp_path_upper = image_path.with_extension("XMP");
+    if xmp_path.exists() {
         Some(xmp_path)
     } else if xmp_path_upper.exists() {
         Some(xmp_path_upper)
     } else {
         None
-    };
+    }
+}
+
+pub fn sync_metadata_from_xmp(source_path: &Path, metadata: &mut ImageMetadata) -> bool {
+    let actual_xmp = resolve_xmp_path(source_path);
 
     let mut changed = false;
 

--- a/src-tauri/src/image_loader.rs
+++ b/src-tauri/src/image_loader.rs
@@ -511,6 +511,13 @@ pub async fn load_image(
     let (pristine_arc, exif_data) = if let Some((cached_img, cached_exif)) = cached_data {
         (cached_img, cached_exif)
     } else {
+        if crate::file_management::is_cloud_placeholder(&source_path) {
+            return Err(format!(
+                "'{}' is stored in iCloud and hasn't been downloaded yet. Download it in Finder, then try again.",
+                source_path_str
+            ));
+        }
+
         let (pristine_img, exif_data_loaded) = tokio::task::spawn_blocking(move || {
             if generation_tracker.load(Ordering::SeqCst) != my_generation {
                 return Err("Load cancelled".to_string());

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2086,6 +2086,7 @@ pub fn run() {
             start_preview_worker(app_handle.clone());
             start_analytics_worker(app_handle.clone());
             file_management::start_thumbnail_workers(app_handle.clone());
+            file_management::start_metadata_workers(app_handle.clone());
             jxl_oxide::integration::register_image_decoding_hook();
 
             let window_cfg = app.config().app.windows.first().unwrap().clone();
@@ -2280,6 +2281,7 @@ pub fn run() {
             full_transformed_cache: Mutex::new(None),
             decoded_image_cache: Mutex::new(DecodedImageCache::new(5)),
             thumbnail_manager: ThumbnailManager::new(),
+            metadata_manager: MetadataManager::new(),
         })
         .invoke_handler(tauri::generate_handler![
             apply_adjustments,

--- a/src/components/panel/library/LibraryItems.tsx
+++ b/src/components/panel/library/LibraryItems.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Image as ImageIcon, Folder, FolderOpen, Star as StarIcon, SlidersHorizontal } from 'lucide-react';
+import { Image as ImageIcon, Folder, FolderOpen, Star as StarIcon, SlidersHorizontal, CloudOff } from 'lucide-react';
 import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { COLOR_LABELS, Color } from '../../../utils/adjustments';
@@ -30,6 +30,7 @@ const ThumbnailComponent = ({
   aspectRatio: thumbnailAspectRatio,
   isEdited,
   exif,
+  isCloudPlaceholder,
 }: any) => {
   const { t } = useTranslation();
   const data = useProcessStore((s) => s.thumbnails[path]);
@@ -180,9 +181,27 @@ const ThumbnailComponent = ({
           </div>
         )}
 
-        {layers.length === 0 && showPlaceholder && (
-          <div className="absolute inset-0 w-full h-full flex items-center justify-center bg-surface">
-            <ImageIcon className="text-text-secondary animate-pulse" />
+        {layers.length === 0 &&
+          showPlaceholder &&
+          (isCloudPlaceholder ? (
+            <div
+              className="absolute inset-0 w-full h-full flex items-center justify-center bg-surface"
+              data-tooltip={t('library.items.cloudPlaceholder')}
+            >
+              <CloudOff className="text-text-secondary" />
+            </div>
+          ) : (
+            <div className="absolute inset-0 w-full h-full flex items-center justify-center bg-surface">
+              <ImageIcon className="text-text-secondary animate-pulse" />
+            </div>
+          ))}
+
+        {isCloudPlaceholder && layers.length > 0 && (
+          <div
+            className="absolute top-1.5 left-1.5 z-10 rounded-full h-5 w-5 flex items-center justify-center bg-black/40 shadow-md pointer-events-none"
+            data-tooltip={t('library.items.cloudPlaceholder')}
+          >
+            <CloudOff size={12} className="text-white" />
           </div>
         )}
       </div>
@@ -411,6 +430,7 @@ const ListItemComponent = ({
   aspectRatio: thumbnailAspectRatio,
   columnWidths,
   exif,
+  isCloudPlaceholder,
 }: any) => {
   const { t } = useTranslation();
   const data = useProcessStore((s) => s.thumbnails[path]);
@@ -568,9 +588,27 @@ const ListItemComponent = ({
             </div>
           )}
 
-          {layers.length === 0 && showPlaceholder && (
-            <div className="absolute inset-0 w-full h-full flex items-center justify-center">
-              <ImageIcon size={14} className="text-text-secondary animate-pulse" />
+          {layers.length === 0 &&
+            showPlaceholder &&
+            (isCloudPlaceholder ? (
+              <div
+                className="absolute inset-0 w-full h-full flex items-center justify-center"
+                data-tooltip={t('library.items.cloudPlaceholder')}
+              >
+                <CloudOff size={14} className="text-text-secondary" />
+              </div>
+            ) : (
+              <div className="absolute inset-0 w-full h-full flex items-center justify-center">
+                <ImageIcon size={14} className="text-text-secondary animate-pulse" />
+              </div>
+            ))}
+
+          {isCloudPlaceholder && layers.length > 0 && (
+            <div
+              className="absolute top-0.5 left-0.5 z-10 rounded-full h-3.5 w-3.5 flex items-center justify-center bg-black/40 pointer-events-none"
+              data-tooltip={t('library.items.cloudPlaceholder')}
+            >
+              <CloudOff size={9} className="text-white" />
             </div>
           )}
         </div>
@@ -684,11 +722,20 @@ const RowComponent = ({
   const row = rows[index];
 
   useEffect(() => {
-    if (row && row.type === 'images') {
-      row.images.forEach((img: ImageFile) => {
-        queueThumbnailRequest(img.path);
-      });
-    }
+    if (!row || row.type !== 'images') return;
+
+    row.images.forEach((img: ImageFile) => {
+      queueThumbnailRequest(img.path);
+    });
+
+    const cloudPaths = row.images.filter((img: ImageFile) => img.is_cloud_placeholder).map((img: ImageFile) => img.path);
+    if (cloudPaths.length === 0) return;
+
+    const interval = setInterval(() => {
+      cloudPaths.forEach((path: string) => queueThumbnailRequest(path));
+    }, 5000);
+
+    return () => clearInterval(interval);
   }, [row, queueThumbnailRequest]);
 
   if (row.type === 'footer') return null;
@@ -779,6 +826,7 @@ const RowComponent = ({
               aspectRatio={thumbnailAspectRatio}
               modified={imageFile.modified}
               columnWidths={columnWidths}
+              isCloudPlaceholder={imageFile.is_cloud_placeholder}
             />
           ) : (
             <Thumbnail
@@ -794,6 +842,7 @@ const RowComponent = ({
               exif={imageFile.exif}
               isEdited={imageFile.is_edited}
               aspectRatio={thumbnailAspectRatio}
+              isCloudPlaceholder={imageFile.is_cloud_placeholder}
             />
           )}
         </div>

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -253,6 +253,7 @@ export interface ImageFile {
   tags: Array<string> | null;
   exif: { [key: string]: string } | null;
   is_virtual_copy: boolean;
+  is_cloud_placeholder: boolean;
 }
 
 export interface Option {

--- a/src/hooks/useTauriListeners.ts
+++ b/src/hooks/useTauriListeners.ts
@@ -120,6 +120,17 @@ export function useTauriListeners({
           scheduleFlush();
         }
       }),
+      listen('image-metadata-loaded', (event: any) => {
+        if (!isEffectActive) return;
+        const { path, rating, is_edited, tags } = event.payload;
+
+        useLibraryStore.getState().setLibrary((state) => ({
+          imageRatings: { ...state.imageRatings, [path]: rating },
+          imageList: state.imageList.map((img) =>
+            img.path === path ? { ...img, is_edited, tags: tags ?? img.tags } : img,
+          ),
+        }));
+      }),
       listen('ai-model-download-start', (event: any) => {
         if (isEffectActive) useProcessStore.getState().setProcess({ aiModelDownloadStatus: event.payload });
       }),

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -930,6 +930,7 @@
       "progress": "Importing... ({{current}}/{{total}})"
     },
     "items": {
+      "cloudPlaceholder": "Stored in iCloud — not downloaded",
       "collapseFolder": "Collapse Folder",
       "currentFolder": "Current Folder",
       "expandFolder": "Expand Folder",


### PR DESCRIPTION
## Description

Fixes UI hanging/freezing when browsing a library folder synced through iCloud Drive with "Optimize Mac Storage" enabled. In this case, images (and their sidecars) can be `SF_DATALESS` placeholders (effectively empty files) that macOS only materializes on demand.

On my machine, opening a folder containing such files caused the UI to hang indefinitely.

## Type of Change
- [x] Bug fix
- [x] Performance improvement
- [x] UI/UX improvement

## Changes Made
- Detect iCloud placeholder files on macOS via the `SF_DATALESS` `st_flags` bit (`is_cloud_placeholder`), and show a cloud icon in the library grid/list instead of the usual loading spinner. The icon now also persists as a small badge over an already-cached preview, instead of disappearing once a thumbnail loads.

- Stop opening a folder from blocking on placeholder files:
  - `read_exif_for_paths` skips reading raw bytes for placeholder images instead of triggering a download attempt.
  - Thumbnail generation now checks the on-disk cache *before* bailing out on a placeholder, so previously-generated previews reappear correctly after a file gets evicted back to iCloud-only.
- Stop folder listing / thumbnail generation from blocking on placeholder **sidecar** files (`.rrdata`, and `.xmp` when XMP sync is enabled) — these live right next to the image and can be evicted just like the image itself:
  - Added a small dedicated background worker pool (`MetadataManager`, 4 threads) isolated from rayon's shared global pool, so a stuck iCloud download can never starve folder listing, EXIF fetching, or thumbnail generation elsewhere in the app — this was the main cause of the freeze reported when offline. Those tasks are I/O heavy, not compute heavy, so, constant size should be fine.
  - When a sidecar (or its `.xmp`) is a placeholder, listing returns immediately with default metadata and queues a background sync; the UI updates rating/tags/edit-status in place once the real data is available (`image-metadata-loaded` event).


## Screenshots/Videos
Not applicable

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** MacOs Tachoe.
- **Hardware:** Apple M5

Unfortunately, I do not have Windows or Ubuntu machines to check OS compatibility. However, on non-mac systems, it just fallbacks to the default sync strategy, so, I do not think it's gonna be a problem.

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
Thank you for creating such an amazing tool! That's exactly what I was looking for a very long time to replace the Lightroom.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

