### PR TITLE
[Android] re-enable left panel when in landscape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -607,7 +607,7 @@ function App() {
     );
   };
 
-  const shouldHideFolderTree = isAndroid;
+  const shouldHideFolderTree = isAndroid && isPortraitViewport;
   const isWgpuActive = appSettings?.useWgpuRenderer !== false && selectedImage?.isReady && hasRenderedFirstFrame;
   const useMacWindowShell = osPlatform === 'macos' && !appSettings?.decorations && !isWindowFullScreen && !isFullScreen;
 


### PR DESCRIPTION
## Description
Enables the left panel on Android when in Landscape. Currently there is no way to access the left panel functions on Android.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

## Screenshots/Videos

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** (Ubuntu 24.04, Android 16)
- **Hardware:** (e.g. Intel i5, Xiaomi Pad 7)

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

