### PR TITLE
fix(exif): correct mirrored orientation transforms

### DIFF
--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -1195,9 +1195,9 @@ pub fn apply_orientation(image: DynamicImage, orientation: Orientation) -> Dynam
         Orientation::HorizontalFlip => image.fliph(),
         Orientation::Rotate180 => image.rotate180(),
         Orientation::VerticalFlip => image.flipv(),
-        Orientation::Transpose => image.rotate90().flipv(),
+        Orientation::Transpose => image.rotate90().fliph(),
         Orientation::Rotate90 => image.rotate90(),
-        Orientation::Transverse => image.rotate90().fliph(),
+        Orientation::Transverse => image.rotate270().fliph(),
         Orientation::Rotate270 => image.rotate270(),
     }
 }


### PR DESCRIPTION
## Description

Fixes the mirrored transforms for EXIF orientation 5 (transpose) and orientation 7 (transverse).

**Root cause:** The existing transform combinations used the wrong flip and rotation axes, so images carrying these uncommon EXIF orientation values could render with the wrong mirrored layout.

**Impact:** Images tagged with orientation 5 or 7 now render in the expected visual orientation. Other orientation values and the rest of the processing pipeline are unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Correct orientation 5 by rotating 90 degrees clockwise and flipping horizontally.
- Correct orientation 7 by rotating 270 degrees clockwise and flipping horizontally.

## Screenshots/Videos

N/A. No screenshot assets are included in this PR.

## Testing

- [x] I have tested these changes locally and confirmed that they work as expected without issues

- `cargo +1.96.1 fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo +1.96.1 test --locked --manifest-path src-tauri/Cargo.toml -- --nocapture`
- `git diff --check origin/main...HEAD`
- Pixel-layout validation with asymmetric orientation 5 and 7 fixtures: 2 passed, 0 failed. The test code is not included in the PR.
- Manual RapidRAW UI regression with synthetic orientation 5 and 7 JPEG fixtures; both rendered in the expected upright layout.

**Test Configuration:**

- **OS:** macOS 26.5.2 (arm64)
- **Hardware:** Apple M4 Pro
- **Rust/Cargo:** 1.96.1

## Checklist

- [x] My code follows the project code style
- [x] I have not added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The final PR contains one commit and changes only two transform expressions in `src-tauri/src/image_processing.rs`. Cargo reports only the repository existing warnings in unchanged files.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
