### PR TITLE
Fix: Improve LensModel extraction and EXIF metadata serialization

### DIFF
--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -295,9 +295,6 @@ fn clean_undefined_field(
     fallback_display: impl FnOnce() -> String,
 ) -> Option<String> {
     if tag_name == "UserComment" {
-        // First 8 bytes are a character-code header (e.g. b"ASCII\0\0\0",
-        // b"UNICODE\0"). Strip it, then check whether what remains is
-        // meaningful text or just padding/zeros.
         let body = if bytes.len() > 8 { &bytes[8..] } else { &[][..] };
         let text = String::from_utf8_lossy(body)
             .trim_matches(char::from(0))

--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -132,6 +132,29 @@ fn parse_raw_creation_date(date_str: Option<&str>) -> Option<DateTime<Utc>> {
     parse_creation_datetime(date_str?).map(|dt| DateTime::from_naive_utc_and_offset(dt, Utc))
 }
 
+fn clean_ascii_value(value: &exif::Value) -> Option<String> {
+    let exif::Value::Ascii(ref components) = *value else {
+        return None;
+    };
+
+    let cleaned: Vec<String> = components
+        .iter()
+        .map(|c| {
+            String::from_utf8_lossy(c)
+                .trim_matches(char::from(0))
+                .trim()
+                .to_string()
+        })
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if cleaned.is_empty() {
+        None
+    } else {
+        Some(cleaned.join(" "))
+    }
+}
+
 pub fn read_exif(file_bytes: &[u8]) -> Option<Exif> {
     let exifreader = exif::Reader::new();
     exifreader
@@ -332,12 +355,19 @@ pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
                         fmt_date_str(field.display_value().to_string()),
                     );
                 }
-                _ => {
-                    let val = field.display_value().with_unit(&exif_obj).to_string();
-                    if !val.trim().is_empty() {
-                        map.insert(field.tag.to_string(), val);
+                _ => match &field.value {
+                    exif::Value::Ascii(_) => {
+                        if let Some(val) = clean_ascii_value(&field.value) {
+                            map.insert(field.tag.to_string(), val);
+                        }
                     }
-                }
+                    _ => {
+                        let val = field.display_value().with_unit(&exif_obj).to_string();
+                        if !val.trim().is_empty() {
+                            map.insert(field.tag.to_string(), val);
+                        }
+                    }
+                },
             }
         }
     }
@@ -1126,7 +1156,13 @@ pub fn read_exif_data_from_bytes(path: &str, file_bytes: &[u8]) -> HashMap<Strin
     let mut exif_data = HashMap::new();
     if let Some(exif) = read_exif(file_bytes) {
         for field in exif.fields() {
-            let raw_val = field.display_value().with_unit(&exif).to_string();
+            let raw_val = match &field.value {
+                exif::Value::Ascii(_) => match clean_ascii_value(&field.value) {
+                    Some(v) => v,
+                    None => continue,
+                },
+                _ => field.display_value().with_unit(&exif).to_string(),
+            };
             exif_data.insert(field.tag.to_string(), truncate_large_exif(&raw_val));
         }
     }

--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -248,75 +248,6 @@ pub fn read_iso(path: &str, file_bytes: &[u8]) -> Option<u32> {
     None
 }
 
-fn decode_cfa_pattern(bytes: &[u8]) -> Option<String> {
-    if bytes.len() < 4 {
-        return None;
-    }
-
-    let h_repeat = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
-    let v_repeat = u16::from_le_bytes([bytes[2], bytes[3]]) as usize;
-    let count = h_repeat * v_repeat;
-    if count == 0 || bytes.len() < 4 + count {
-        return None;
-    }
-
-    let pattern: String = bytes[4..4 + count]
-        .iter()
-        .map(|&b| match b {
-            0 => 'R',
-            1 => 'G',
-            2 => 'B',
-            3 => 'C',
-            4 => 'M',
-            5 => 'Y',
-            6 => 'W',
-            _ => '?',
-        })
-        .collect();
-
-    if pattern.is_empty() { None } else { Some(pattern) }
-}
-
-fn clean_ascii_field(components: &[Vec<u8>]) -> Option<String> {
-    components
-        .iter()
-        .map(|c| {
-            String::from_utf8_lossy(c)
-                .trim_matches(char::from(0))
-                .trim()
-                .to_string()
-        })
-        .find(|s| !s.is_empty())
-}
-
-fn clean_undefined_field(
-    tag_name: &str,
-    bytes: &[u8],
-    fallback_display: impl FnOnce() -> String,
-) -> Option<String> {
-    if tag_name == "UserComment" {
-        let body = if bytes.len() > 8 { &bytes[8..] } else { &[][..] };
-        let text = String::from_utf8_lossy(body)
-            .trim_matches(char::from(0))
-            .trim()
-            .to_string();
-        return if text.is_empty() { None } else { Some(text) };
-    }
-
-    let is_all_zero = bytes.iter().all(|&b| b == 0);
-    let is_meaningless_binary = tag_name == "MakerNote" || is_all_zero || bytes.is_empty();
-    if is_meaningless_binary {
-        return None;
-    }
-
-    let val = fallback_display();
-    if !val.trim().is_empty() && !val.trim_start().starts_with("0x") {
-        Some(val)
-    } else {
-        None
-    }
-}
-
 pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
     let mut map = HashMap::new();
 
@@ -401,101 +332,13 @@ pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
                         fmt_date_str(field.display_value().to_string()),
                     );
                 }
-                exif::Tag::CFAPattern => {
-                    if let exif::Value::Undefined(ref bytes, _) = field.value
-                        && let Some(pattern) = decode_cfa_pattern(bytes)
-                    {
-                        map.insert("CFAPattern".to_string(), pattern);
-                    }
-                }
-                exif::Tag::LensSpecification => {
-                    if let exif::Value::Rational(ref v) = field.value
-                        && v.len() == 4
-                    {
-                        let calc = |r: &exif::Rational| -> Option<f32> {
-                            if r.denom == 0 {
-                                None
-                            } else {
-                                Some(r.num as f32 / r.denom as f32)
-                            }
-                        };
-                        if let (Some(min_f), Some(max_f)) = (calc(&v[0]), calc(&v[1])) {
-                            let focal = if (min_f - max_f).abs() < f32::EPSILON {
-                                format!("{} mm", min_f)
-                            } else {
-                                format!("{}-{} mm", min_f, max_f)
-                            };
-                            let aperture = match (calc(&v[2]), calc(&v[3])) {
-                                (Some(min_a), Some(max_a))
-                                    if (min_a - max_a).abs() < f32::EPSILON =>
-                                {
-                                    format!(", f/{}", min_a)
-                                }
-                                (Some(min_a), Some(max_a)) => {
-                                    format!(", f/{}-{}", min_a, max_a)
-                                }
-                                _ => String::new(),
-                            };
-                            map.insert(
-                                "LensSpecification".to_string(),
-                                format!("{}{}", focal, aperture),
-                            );
-                        }
-                    }
-                }
                 _ => {
-                    if let exif::Value::Ascii(ref components) = field.value {
-                        if let Some(val) = clean_ascii_field(components) {
-                            map.insert(field.tag.to_string(), val);
-                        }
-                    } else if let exif::Value::Undefined(ref bytes, _) = field.value {
-                        let tag_name = field.tag.to_string();
-                        if let Some(val) = clean_undefined_field(&tag_name, bytes, || {
-                            field.display_value().with_unit(&exif_obj).to_string()
-                        }) {
-                            map.insert(tag_name, val);
-                        }
-                    } else {
-                        let val = field.display_value().with_unit(&exif_obj).to_string();
-                        if !val.trim().is_empty() {
-                            map.insert(field.tag.to_string(), val);
-                        }
+                    let val = field.display_value().with_unit(&exif_obj).to_string();
+                    if !val.trim().is_empty() {
+                        map.insert(field.tag.to_string(), val);
                     }
                 }
             }
-        }
-    }
-
-    let needs_lens_spec_patch = !map
-        .get("LensSpecification")
-        .is_some_and(|s| s.contains("f/"));
-
-    if needs_lens_spec_patch
-        && let Some(patch_meta) = read_raw_metadata(file_bytes)
-        && let Some(lens_desc) = &patch_meta.lens
-    {
-        let fmt_rat_patch = |r: &rawler::formats::tiff::Rational| -> f32 {
-            if r.d == 0 { 0.0 } else { r.n as f32 / r.d as f32 }
-        };
-        let focal_min = fmt_rat_patch(&lens_desc.focal_range[0]);
-        let focal_max = fmt_rat_patch(&lens_desc.focal_range[1]);
-        let focal = if (focal_min - focal_max).abs() < f32::EPSILON {
-            format!("{} mm", focal_min)
-        } else {
-            format!("{}-{} mm", focal_min, focal_max)
-        };
-        let aperture_min = fmt_rat_patch(&lens_desc.aperture_range[0]);
-        let aperture_max = fmt_rat_patch(&lens_desc.aperture_range[1]);
-        if aperture_min > 0.0 || aperture_max > 0.0 {
-            let aperture = if (aperture_min - aperture_max).abs() < f32::EPSILON {
-                format!(", f/{}", aperture_min)
-            } else {
-                format!(", f/{}-{}", aperture_min, aperture_max)
-            };
-            map.insert(
-                "LensSpecification".to_string(),
-                format!("{}{}", focal, aperture),
-            );
         }
     }
 
@@ -962,7 +805,15 @@ pub fn write_image_with_metadata(
 
             let get_string_val = |field: &exif::Field| -> String {
                 match &field.value {
-                    exif::Value::Ascii(components) => clean_ascii_field(components).unwrap_or_default(),
+                    exif::Value::Ascii(vec) => vec
+                        .iter()
+                        .map(|v| {
+                            String::from_utf8_lossy(v)
+                                .trim_matches(char::from(0))
+                                .to_string()
+                        })
+                        .collect::<Vec<String>>()
+                        .join(" "),
                     _ => field
                         .display_value()
                         .to_string()
@@ -1275,29 +1126,8 @@ pub fn read_exif_data_from_bytes(path: &str, file_bytes: &[u8]) -> HashMap<Strin
     let mut exif_data = HashMap::new();
     if let Some(exif) = read_exif(file_bytes) {
         for field in exif.fields() {
-            if field.tag == exif::Tag::CFAPattern {
-                if let exif::Value::Undefined(ref bytes, _) = field.value
-                    && let Some(pattern) = decode_cfa_pattern(bytes)
-                {
-                    exif_data.insert("CFAPattern".to_string(), pattern);
-                }
-                continue;
-            }
-            if let exif::Value::Ascii(ref components) = field.value {
-                if let Some(val) = clean_ascii_field(components) {
-                    exif_data.insert(field.tag.to_string(), truncate_large_exif(&val));
-                }
-            } else if let exif::Value::Undefined(ref bytes, _) = field.value {
-                let tag_name = field.tag.to_string();
-                if let Some(val) = clean_undefined_field(&tag_name, bytes, || {
-                    field.display_value().with_unit(&exif).to_string()
-                }) {
-                    exif_data.insert(tag_name, truncate_large_exif(&val));
-                }
-            } else {
-                let raw_val = field.display_value().with_unit(&exif).to_string();
-                exif_data.insert(field.tag.to_string(), truncate_large_exif(&raw_val));
-            }
+            let raw_val = field.display_value().with_unit(&exif).to_string();
+            exif_data.insert(field.tag.to_string(), truncate_large_exif(&raw_val));
         }
     }
     exif_data

--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -155,6 +155,53 @@ fn clean_ascii_value(value: &exif::Value) -> Option<String> {
     }
 }
 
+fn rational_to_f32_checked(r: &exif::Rational) -> Option<f32> {
+    if r.denom == 0 {
+        None
+    } else {
+        Some(r.num as f32 / r.denom as f32)
+    }
+}
+
+fn rawler_rational_to_f32_checked(r: &rawler::formats::tiff::Rational) -> Option<f32> {
+    if r.d == 0 {
+        None
+    } else {
+        Some(r.n as f32 / r.d as f32)
+    }
+}
+
+fn format_min_max(min: f32, max: f32, tolerance: f32) -> String {
+    if (min - max).abs() < tolerance {
+        format!("{min}")
+    } else {
+        format!("{min}-{max}")
+    }
+}
+
+fn format_lens_specification(components: &[exif::Rational]) -> Option<String> {
+    if components.len() < 4 {
+        return None;
+    }
+
+    let focal_min = rational_to_f32_checked(&components[0]);
+    let focal_max = rational_to_f32_checked(&components[1]);
+    let (focal_min, focal_max) = match (focal_min, focal_max) {
+        (Some(min), Some(max)) => (min, max),
+        _ => return None,
+    };
+
+    let mut spec = format!("{} mm", format_min_max(focal_min, focal_max, 0.01));
+
+    let aperture_min = rational_to_f32_checked(&components[2]);
+    let aperture_max = rational_to_f32_checked(&components[3]);
+    if let (Some(amin), Some(amax)) = (aperture_min, aperture_max) {
+        spec.push_str(&format!(", f/{}", format_min_max(amin, amax, 0.01)));
+    }
+
+    Some(spec)
+}
+
 pub fn read_exif(file_bytes: &[u8]) -> Option<Exif> {
     let exifreader = exif::Reader::new();
     exifreader
@@ -355,6 +402,45 @@ pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
                         fmt_date_str(field.display_value().to_string()),
                     );
                 }
+                exif::Tag::LensSpecification => {
+                    if let exif::Value::Rational(ref v) = field.value
+                        && v.len() >= 4
+                        && let (Some(focal_min), Some(focal_max)) = (
+                            rational_to_f32_checked(&v[0]),
+                            rational_to_f32_checked(&v[1]),
+                        )
+                    {
+                        let mut spec =
+                            format!("{} mm", format_min_max(focal_min, focal_max, 0.01));
+
+                        let aperture = match (
+                            rational_to_f32_checked(&v[2]),
+                            rational_to_f32_checked(&v[3]),
+                        ) {
+                            (Some(amin), Some(amax)) => Some((amin, amax)),
+                            _ => {
+                                read_raw_metadata(file_bytes).and_then(|meta| {
+                                    let lens_desc = meta.lens?;
+                                    let amin = rawler_rational_to_f32_checked(
+                                        &lens_desc.aperture_range[0],
+                                    )?;
+                                    let amax = rawler_rational_to_f32_checked(
+                                        &lens_desc.aperture_range[1],
+                                    )?;
+                                    Some((amin, amax))
+                                })
+                            }
+                        };
+
+                        if let Some((amin, amax)) = aperture
+                            && (amin > 0.0 || amax > 0.0)
+                        {
+                            spec.push_str(&format!(", f/{}", format_min_max(amin, amax, 0.01)));
+                        }
+
+                        map.insert("LensSpecification".to_string(), spec);
+                    }
+                }
                 _ => match &field.value {
                     exif::Value::Ascii(_) => {
                         if let Some(val) = clean_ascii_value(&field.value) {
@@ -468,6 +554,20 @@ pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
 
     if let Some(v) = exif.lens_serial_number {
         insert_if_present("LensSerialNumber", v);
+    }
+
+    if let Some(lens_desc) = &metadata.lens {
+        let focal_min = fmt_rat(&lens_desc.focal_range[0]);
+        let focal_max = fmt_rat(&lens_desc.focal_range[1]);
+        let mut spec = format!("{} mm", format_min_max(focal_min, focal_max, 0.01));
+
+        let aperture_min = fmt_rat(&lens_desc.aperture_range[0]);
+        let aperture_max = fmt_rat(&lens_desc.aperture_range[1]);
+        if aperture_min > 0.0 || aperture_max > 0.0 {
+            spec.push_str(&format!(", f/{}", format_min_max(aperture_min, aperture_max, 0.01)));
+        }
+
+        insert_if_present("LensSpecification", spec);
     }
 
     if let Some(v) = exif.orientation {
@@ -1161,6 +1261,12 @@ pub fn read_exif_data_from_bytes(path: &str, file_bytes: &[u8]) -> HashMap<Strin
                     Some(v) => v,
                     None => continue,
                 },
+                exif::Value::Rational(v) if field.tag == exif::Tag::LensSpecification => {
+                    match format_lens_specification(v) {
+                        Some(s) => s,
+                        None => continue,
+                    }
+                }
                 _ => field.display_value().with_unit(&exif).to_string(),
             };
             exif_data.insert(field.tag.to_string(), truncate_large_exif(&raw_val));

--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -248,6 +248,78 @@ pub fn read_iso(path: &str, file_bytes: &[u8]) -> Option<u32> {
     None
 }
 
+fn decode_cfa_pattern(bytes: &[u8]) -> Option<String> {
+    if bytes.len() < 4 {
+        return None;
+    }
+
+    let h_repeat = u16::from_le_bytes([bytes[0], bytes[1]]) as usize;
+    let v_repeat = u16::from_le_bytes([bytes[2], bytes[3]]) as usize;
+    let count = h_repeat * v_repeat;
+    if count == 0 || bytes.len() < 4 + count {
+        return None;
+    }
+
+    let pattern: String = bytes[4..4 + count]
+        .iter()
+        .map(|&b| match b {
+            0 => 'R',
+            1 => 'G',
+            2 => 'B',
+            3 => 'C',
+            4 => 'M',
+            5 => 'Y',
+            6 => 'W',
+            _ => '?',
+        })
+        .collect();
+
+    if pattern.is_empty() { None } else { Some(pattern) }
+}
+
+fn clean_ascii_field(components: &[Vec<u8>]) -> Option<String> {
+    components
+        .iter()
+        .map(|c| {
+            String::from_utf8_lossy(c)
+                .trim_matches(char::from(0))
+                .trim()
+                .to_string()
+        })
+        .find(|s| !s.is_empty())
+}
+
+fn clean_undefined_field(
+    tag_name: &str,
+    bytes: &[u8],
+    fallback_display: impl FnOnce() -> String,
+) -> Option<String> {
+    if tag_name == "UserComment" {
+        // First 8 bytes are a character-code header (e.g. b"ASCII\0\0\0",
+        // b"UNICODE\0"). Strip it, then check whether what remains is
+        // meaningful text or just padding/zeros.
+        let body = if bytes.len() > 8 { &bytes[8..] } else { &[][..] };
+        let text = String::from_utf8_lossy(body)
+            .trim_matches(char::from(0))
+            .trim()
+            .to_string();
+        return if text.is_empty() { None } else { Some(text) };
+    }
+
+    let is_all_zero = bytes.iter().all(|&b| b == 0);
+    let is_meaningless_binary = tag_name == "MakerNote" || is_all_zero || bytes.is_empty();
+    if is_meaningless_binary {
+        return None;
+    }
+
+    let val = fallback_display();
+    if !val.trim().is_empty() && !val.trim_start().starts_with("0x") {
+        Some(val)
+    } else {
+        None
+    }
+}
+
 pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
     let mut map = HashMap::new();
 
@@ -332,13 +404,101 @@ pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
                         fmt_date_str(field.display_value().to_string()),
                     );
                 }
+                exif::Tag::CFAPattern => {
+                    if let exif::Value::Undefined(ref bytes, _) = field.value
+                        && let Some(pattern) = decode_cfa_pattern(bytes)
+                    {
+                        map.insert("CFAPattern".to_string(), pattern);
+                    }
+                }
+                exif::Tag::LensSpecification => {
+                    if let exif::Value::Rational(ref v) = field.value
+                        && v.len() == 4
+                    {
+                        let calc = |r: &exif::Rational| -> Option<f32> {
+                            if r.denom == 0 {
+                                None
+                            } else {
+                                Some(r.num as f32 / r.denom as f32)
+                            }
+                        };
+                        if let (Some(min_f), Some(max_f)) = (calc(&v[0]), calc(&v[1])) {
+                            let focal = if (min_f - max_f).abs() < f32::EPSILON {
+                                format!("{} mm", min_f)
+                            } else {
+                                format!("{}-{} mm", min_f, max_f)
+                            };
+                            let aperture = match (calc(&v[2]), calc(&v[3])) {
+                                (Some(min_a), Some(max_a))
+                                    if (min_a - max_a).abs() < f32::EPSILON =>
+                                {
+                                    format!(", f/{}", min_a)
+                                }
+                                (Some(min_a), Some(max_a)) => {
+                                    format!(", f/{}-{}", min_a, max_a)
+                                }
+                                _ => String::new(),
+                            };
+                            map.insert(
+                                "LensSpecification".to_string(),
+                                format!("{}{}", focal, aperture),
+                            );
+                        }
+                    }
+                }
                 _ => {
-                    let val = field.display_value().with_unit(&exif_obj).to_string();
-                    if !val.trim().is_empty() {
-                        map.insert(field.tag.to_string(), val);
+                    if let exif::Value::Ascii(ref components) = field.value {
+                        if let Some(val) = clean_ascii_field(components) {
+                            map.insert(field.tag.to_string(), val);
+                        }
+                    } else if let exif::Value::Undefined(ref bytes, _) = field.value {
+                        let tag_name = field.tag.to_string();
+                        if let Some(val) = clean_undefined_field(&tag_name, bytes, || {
+                            field.display_value().with_unit(&exif_obj).to_string()
+                        }) {
+                            map.insert(tag_name, val);
+                        }
+                    } else {
+                        let val = field.display_value().with_unit(&exif_obj).to_string();
+                        if !val.trim().is_empty() {
+                            map.insert(field.tag.to_string(), val);
+                        }
                     }
                 }
             }
+        }
+    }
+
+    let needs_lens_spec_patch = !map
+        .get("LensSpecification")
+        .is_some_and(|s| s.contains("f/"));
+
+    if needs_lens_spec_patch
+        && let Some(patch_meta) = read_raw_metadata(file_bytes)
+        && let Some(lens_desc) = &patch_meta.lens
+    {
+        let fmt_rat_patch = |r: &rawler::formats::tiff::Rational| -> f32 {
+            if r.d == 0 { 0.0 } else { r.n as f32 / r.d as f32 }
+        };
+        let focal_min = fmt_rat_patch(&lens_desc.focal_range[0]);
+        let focal_max = fmt_rat_patch(&lens_desc.focal_range[1]);
+        let focal = if (focal_min - focal_max).abs() < f32::EPSILON {
+            format!("{} mm", focal_min)
+        } else {
+            format!("{}-{} mm", focal_min, focal_max)
+        };
+        let aperture_min = fmt_rat_patch(&lens_desc.aperture_range[0]);
+        let aperture_max = fmt_rat_patch(&lens_desc.aperture_range[1]);
+        if aperture_min > 0.0 || aperture_max > 0.0 {
+            let aperture = if (aperture_min - aperture_max).abs() < f32::EPSILON {
+                format!(", f/{}", aperture_min)
+            } else {
+                format!(", f/{}-{}", aperture_min, aperture_max)
+            };
+            map.insert(
+                "LensSpecification".to_string(),
+                format!("{}{}", focal, aperture),
+            );
         }
     }
 
@@ -1126,8 +1286,29 @@ pub fn read_exif_data_from_bytes(path: &str, file_bytes: &[u8]) -> HashMap<Strin
     let mut exif_data = HashMap::new();
     if let Some(exif) = read_exif(file_bytes) {
         for field in exif.fields() {
-            let raw_val = field.display_value().with_unit(&exif).to_string();
-            exif_data.insert(field.tag.to_string(), truncate_large_exif(&raw_val));
+            if field.tag == exif::Tag::CFAPattern {
+                if let exif::Value::Undefined(ref bytes, _) = field.value
+                    && let Some(pattern) = decode_cfa_pattern(bytes)
+                {
+                    exif_data.insert("CFAPattern".to_string(), pattern);
+                }
+                continue;
+            }
+            if let exif::Value::Ascii(ref components) = field.value {
+                if let Some(val) = clean_ascii_field(components) {
+                    exif_data.insert(field.tag.to_string(), truncate_large_exif(&val));
+                }
+            } else if let exif::Value::Undefined(ref bytes, _) = field.value {
+                let tag_name = field.tag.to_string();
+                if let Some(val) = clean_undefined_field(&tag_name, bytes, || {
+                    field.display_value().with_unit(&exif).to_string()
+                }) {
+                    exif_data.insert(tag_name, truncate_large_exif(&val));
+                }
+            } else {
+                let raw_val = field.display_value().with_unit(&exif).to_string();
+                exif_data.insert(field.tag.to_string(), truncate_large_exif(&raw_val));
+            }
         }
     }
     exif_data

--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -295,9 +295,6 @@ fn clean_undefined_field(
     fallback_display: impl FnOnce() -> String,
 ) -> Option<String> {
     if tag_name == "UserComment" {
-        // First 8 bytes are a character-code header (e.g. b"ASCII\0\0\0",
-        // b"UNICODE\0"). Strip it, then check whether what remains is
-        // meaningful text or just padding/zeros.
         let body = if bytes.len() > 8 { &bytes[8..] } else { &[][..] };
         let text = String::from_utf8_lossy(body)
             .trim_matches(char::from(0))
@@ -965,15 +962,7 @@ pub fn write_image_with_metadata(
 
             let get_string_val = |field: &exif::Field| -> String {
                 match &field.value {
-                    exif::Value::Ascii(vec) => vec
-                        .iter()
-                        .map(|v| {
-                            String::from_utf8_lossy(v)
-                                .trim_matches(char::from(0))
-                                .to_string()
-                        })
-                        .collect::<Vec<String>>()
-                        .join(" "),
+                    exif::Value::Ascii(components) => clean_ascii_field(components).unwrap_or_default(),
                     _ => field
                         .display_value()
                         .to_string()


### PR DESCRIPTION
## Description
This PR improves EXIF metadata extraction by normalizing EXIF value
representations before serializing metadata into RRData sidecar files.

The primary objective is to correctly preserve `LensModel` metadata across
different EXIF encodings, allowing RapidRAW's automatic lens correction to
reliably identify compatible lens profiles.

While implementing this fix, additional EXIF parsing paths were improved to
produce cleaner, more consistent metadata by properly handling `Ascii` and
`Undefined` EXIF values.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Added `decode_cfa_pattern()` to decode TIFF-encoded
  `CFAPattern` (`Undefined`) values into standard Bayer pattern
  strings (e.g. RGGB, BGGR).

- Added `clean_ascii_field()` to normalize EXIF `Ascii` values by removing
  null padding and empty components before writing RRData sidecar metadata.

- Added `clean_undefined_field()` to normalize EXIF `Undefined`
  values according to the EXIF specification by decoding
  `UserComment` while suppressing meaningless binary payloads
  (e.g. empty `MakerNote` data).

- Improved `LensModel` extraction by correctly handling multiple EXIF value
  representations before serializing metadata into RRData sidecar files,
  allowing automatic lens correction to detect compatible lens profiles.

- Added fallback handling for `LensSpecification` using RAW metadata when
  invalid or incomplete aperture rational values are returned by
  `kamadak-exif`.

- Improved metadata extraction consistency by sharing common parsing logic
  between standard EXIF extraction and RAW metadata extraction paths.

- Improved EXIF metadata sanitization to prevent null-padded strings,
  binary payloads, and unsupported `Undefined` values from being exported
  into RRData sidecar metadata.


## Screenshots/Videos
### NEF RAW Image

<table align="center">
<tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
<td><img width="362" height="980" alt="Image" src="https://github.com/user-attachments/assets/7dabf653-4f10-4535-8aba-c3024b8a0a3f" />
<td><img width="367" height="976" alt="Image" src="https://github.com/user-attachments/assets/24cd0e18-5175-4007-9b00-61145851cbab" />
</tr>
</table>

---
<div align="center">
  <p><b>Lens Auto Correction Fix</b></p>
<img width="325" height="293" alt="Image" src="https://github.com/user-attachments/assets/aa752b5a-134d-43e2-8a0e-ad5053ab05a9" />
</div>

---
### CR2 RAW Image
<table align="center">
<tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
<td><img width="380" height="976" alt="{347D685E-F133-4E5C-983A-6464539012D8}" src="https://github.com/user-attachments/assets/2cee8837-a80b-4c22-8146-9b1624d43900" />
<td><img width="379" height="977" alt="{6CA145D7-C535-415B-BDAD-0B1420B69EA1}" src="https://github.com/user-attachments/assets/8758dfed-3444-49c7-8f36-12117357a1cc" />
</tr>
</table>

---

<table align="center">
<tr>
    <td align="center"><b>Before</b></td>
    <td align="center"><b>After</b></td>
  </tr>
  <tr>
<td><img width="301" height="274" alt="{B59B8F03-0A2C-484E-B965-9383A6912B5D}" src="https://github.com/user-attachments/assets/0f3b8c3f-17cf-46ad-a06e-9a610ac721e8" />
<td><img width="268" height="199" alt="{9313AFD2-F5B7-4447-9A23-6615448647BB}" src="https://github.com/user-attachments/assets/906e2543-44a3-4ca9-8d2a-03d841b6f2ae" />
</tr>
</table>

---
### JPEG Non-Raw Image

<div align="center">
  <p><b>Non-Raw Image Test</b></p>
<img width="383" height="414" alt="{A9668E09-DA18-4A6E-91B4-6C2F3DA7BC90}" src="https://github.com/user-attachments/assets/dcf04fbc-bd4b-48e6-a43e-8d37986970ec" />
</div>

---

<div align="center">
  <p><b>Lens Auto Correction Fix</b></p>
<img width="321" height="271" alt="{7D68B584-9C24-4C8B-9E8B-992692858CF6}" src="https://github.com/user-attachments/assets/aeef6c47-c83a-4123-9696-ee0030ec0775" />
</div>

---

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues
**Verified:**
- [X] LensModel is correctly written to the RRData sidecar.
- [X] Automatic lens profile selection now succeeds for the sample image from #1123.
- [X] CFAPattern is decoded correctly.
- [X] ASCII EXIF fields no longer contain null-padded strings.
- [X] UserComment is decoded correctly.
- [X] Existing metadata extraction behavior remains unchanged for tested images.

**Test Configuration:**
- **OS:** Windows 11 24H2 LTSC
- **Hardware:** RYZEN 5600G, RTX 4060TI
## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

This PR originated from investigating the EXIF metadata serialization issue
documented in #1371.

The investigation identified that EXIF metadata written to RRData sidecar files
was not consistently normalized across different EXIF value representations.
Consequently, metadata such as `LensModel` could be omitted or incorrectly
serialized, preventing RapidRAW's automatic lens correction from reliably
identifying compatible lens profiles.

To validate the fix, I tested the sample image provided in #1123. After these
changes, the generated RRData sidecar contains the expected metadata, allowing
automatic lens profile selection to function correctly for that sample.

Since the root cause affects EXIF metadata serialization, these changes may
also resolve or improve related issues involving lens detection and automatic
lens correction, including:

- #1123
- #1367
- #1210
- #1266

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
