### PR TITLE
fix(raw): fall back to embedded preview after decoder panic

### DIFF
--- a/src-tauri/src/image_loader.rs
+++ b/src-tauri/src/image_loader.rs
@@ -141,7 +141,7 @@ pub fn load_base_image_from_bytes(
                     path_for_ext_check,
                     classified
                 );
-                if let Some(preview) = embedded_preview_fallback(bytes, path_for_ext_check) {
+                if let Some(preview) = safe_embedded_preview_fallback(bytes, path_for_ext_check) {
                     log::warn!(
                         "Using embedded preview fallback for '{}' ({}x{})",
                         path_for_ext_check,
@@ -149,31 +149,22 @@ pub fn load_base_image_from_bytes(
                         preview.height()
                     );
 
-                    let mut linear_preview = apply_srgb_to_linear(preview);
-                    match &mut linear_preview {
-                        image::DynamicImage::ImageRgb32F(img) => {
-                            for p in img.pixels_mut() {
-                                p[0] *= 0.4;
-                                p[1] *= 0.4;
-                                p[2] *= 0.4;
-                            }
-                        }
-                        image::DynamicImage::ImageRgba32F(img) => {
-                            for p in img.pixels_mut() {
-                                p[0] *= 0.4;
-                                p[1] *= 0.4;
-                                p[2] *= 0.4;
-                            }
-                        }
-                        _ => {}
-                    }
-
-                    return Ok(linear_preview);
+                    return Ok(linearize_embedded_preview(preview));
                 }
                 Err(classified)
             }
             Err(_) => {
                 log::error!("Panic while processing RAW file: {}", path_for_ext_check);
+                if let Some(preview) = safe_embedded_preview_fallback(bytes, path_for_ext_check) {
+                    log::warn!(
+                        "Using embedded preview fallback for '{}' after RAW decoder panic ({}x{})",
+                        path_for_ext_check,
+                        preview.width(),
+                        preview.height()
+                    );
+
+                    return Ok(linearize_embedded_preview(preview));
+                }
                 Err(anyhow!(
                     "Failed to process RAW file: {}",
                     path_for_ext_check
@@ -334,6 +325,29 @@ fn embedded_preview_fallback(bytes: &[u8], path: &str) -> Option<DynamicImage> {
         Some(o) if o > 1 => apply_orientation(img, Orientation::from_u16(o as u16)),
         _ => img,
     })
+}
+
+fn safe_embedded_preview_fallback(bytes: &[u8], path: &str) -> Option<DynamicImage> {
+    match panic::catch_unwind(panic::AssertUnwindSafe(|| {
+        embedded_preview_fallback(bytes, path)
+    })) {
+        Ok(preview) => preview,
+        Err(_) => {
+            log::warn!("Embedded RAW preview extraction panicked for '{}'", path);
+            None
+        }
+    }
+}
+
+fn linearize_embedded_preview(preview: DynamicImage) -> DynamicImage {
+    let preview = DynamicImage::ImageRgb32F(preview.to_rgb32f());
+    let mut linear_preview = apply_srgb_to_linear(preview).into_rgb32f();
+    for pixel in linear_preview.pixels_mut() {
+        pixel[0] *= 0.4;
+        pixel[1] *= 0.4;
+        pixel[2] *= 0.4;
+    }
+    DynamicImage::ImageRgb32F(linear_preview)
 }
 
 pub fn load_image_with_orientation(


### PR DESCRIPTION
## Description

When the RAW decoder panics on an unsupported or malformed RAW/DNG file, keep the load path alive and display the file's embedded JPEG preview when one is available.

This provides a concrete usability fallback for the public Samsung DNG samples discussed in #777 and #884. It does **not** add or replace RAW decoder support, and the displayed preview is not developed RAW data. For that reason, this PR is related to those issues but does not close them.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Attempt the existing embedded-preview fallback after a caught RAW decoder panic.
- Isolate preview extraction itself so a second decoder panic becomes a normal load error.
- Convert embedded previews to `Rgb32F` before sRGB-to-linear conversion, making the intended linearization and brightness scaling effective.
- Keep cancellation, EXIF, non-RAW loading, and RAW decoder behavior otherwise unchanged.

## Screenshots/Videos

N/A — backend RAW loading change with no UI layout changes.

## Testing

- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** macOS 26.5.2
- **Hardware:** Apple Silicon (`arm64`)

Commands:

- `cargo +1.96.1 fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo +1.96.1 test --locked --manifest-path src-tauri/Cargo.toml`
- `git diff --check`

Public issue fixtures:

- #777 — Samsung Galaxy S23 Ultra, `20251219_072240.dng`, lossless JPEG-compressed Linear RAW
  - Reproduced the rawler panic: `Blacklevel (12) and Whitelevel (3) count mismatch`
  - Verified fallback to the embedded 3648×2736 preview
  - Verified the returned image is finite `Rgb32F` data rather than an empty or all-black image
- #884 — Samsung Galaxy Z Fold6, `20241011_002550.dng`, JPEG XL-compressed DNG
  - Reproduced the same rawler black/white-level mismatch panic
  - Verified fallback to the embedded 4000×3000 preview
  - Verified the returned image is finite `Rgb32F` data rather than an empty or all-black image

The public DNG files were tested from temporary local paths and are not included in this branch. The later Lightroom HDR/JPEG XL case mentioned in #777 has no public fixture in that issue and remains unverified.

The build reports 17 pre-existing warnings outside the changed code; this PR introduces no new warnings.

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

### Scope and issue status

This PR is intentionally limited to panic containment and preview fallback. It improves the user-visible behavior for the tested #777 and #884 files, but it does not provide full RAW development for either sample. Both issues should remain open for the decoder-level follow-up.

### Expected follow-up

The next fix is expected to be a separate dependency-focused change:

1. Sync dnglab's upstream panic-to-warning change ([dnglab commit `96c0b736`](https://github.com/dnglab/dnglab/commit/96c0b7367be0f2bf279a32d359160636ab4fc18c)) into `CyberTimon/RapidRAW-DngLab`.
2. Update RapidRAW's pinned rawler dependency commit.
3. Validate full developed-RAW output for the public #777 and #884 samples, including exposure and color accuracy.
4. Re-test a public Lightroom HDR/JPEG XL sample if one becomes available.

That work should remain separate because it changes decoder behavior and requires image-quality validation, while this PR is a small defensive fallback.

## AI Disclaimer:

Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
