### PR TITLE
fix(raw): safely open Samsung linear DNG files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "rawler"
 version = "0.7.1"
-source = "git+https://github.com/CyberTimon/RapidRAW-DngLab.git#6ac6ec2342a5b98970a9d700bcaa8134ae62e060"
+source = "git+https://github.com/CyberTimon/RapidRAW-DngLab.git#ee86c32e3d85ff6057fdc8b3c3eed38923712d91"
 dependencies = [
  "backtrace",
  "bitstream-io",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "rawler"
 version = "0.7.1"
-source = "git+https://github.com/CyberTimon/RapidRAW-DngLab.git#7358d0a71e9722495f2d15e84d8d34dc03cca2b8"
+source = "git+https://github.com/CyberTimon/RapidRAW-DngLab.git#6ac6ec2342a5b98970a9d700bcaa8134ae62e060"
 dependencies = [
  "backtrace",
  "bitstream-io",

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -45,6 +45,10 @@ use crate::mask_generation::MaskDefinition;
 use crate::preset_converter;
 use crate::tagging::COLOR_TAG_PREFIX;
 
+// Increment whenever thumbnail rendering semantics change so stale previews
+// cannot survive an application update.
+const THUMBNAIL_CACHE_SCHEMA_VERSION: u32 = 2;
+
 fn resolve_thumbnail_cache_dir(app_handle: &AppHandle) -> std::result::Result<PathBuf, String> {
     let cache_dir = app_handle
         .path()
@@ -64,6 +68,22 @@ fn emit_thumbnail_cache_setup_error(app_handle: &AppHandle, path: &str, reason: 
     );
 }
 
+fn thumbnail_cache_hash_from_parts(
+    schema_version: u32,
+    path_str: &str,
+    img_mod_time: u64,
+    adjustments_bytes: &[u8],
+) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(&schema_version.to_le_bytes());
+    hasher.update(&(path_str.len() as u64).to_le_bytes());
+    hasher.update(path_str.as_bytes());
+    hasher.update(&img_mod_time.to_le_bytes());
+    hasher.update(&(adjustments_bytes.len() as u64).to_le_bytes());
+    hasher.update(adjustments_bytes);
+    hasher.finalize().to_hex().to_string()
+}
+
 fn compute_thumbnail_cache_hash(path_str: &str, adjustments_bytes: &[u8]) -> Option<String> {
     let (source_path, _) = parse_virtual_path(path_str);
 
@@ -75,11 +95,35 @@ fn compute_thumbnail_cache_hash(path_str: &str, adjustments_bytes: &[u8]) -> Opt
         .ok()?
         .as_secs();
 
-    let mut hasher = blake3::Hasher::new();
-    hasher.update(path_str.as_bytes());
-    hasher.update(&img_mod_time.to_le_bytes());
-    hasher.update(adjustments_bytes);
-    Some(hasher.finalize().to_hex().to_string())
+    Some(thumbnail_cache_hash_from_parts(
+        THUMBNAIL_CACHE_SCHEMA_VERSION,
+        path_str,
+        img_mod_time,
+        adjustments_bytes,
+    ))
+}
+
+#[cfg(test)]
+mod thumbnail_cache_tests {
+    use super::*;
+
+    #[test]
+    fn renderer_schema_version_invalidates_thumbnail_cache_key() {
+        let current = thumbnail_cache_hash_from_parts(
+            THUMBNAIL_CACHE_SCHEMA_VERSION,
+            "/photos/sample.dng",
+            1_750_000_000,
+            br#"{"exposure":0}"#,
+        );
+        let previous = thumbnail_cache_hash_from_parts(
+            THUMBNAIL_CACHE_SCHEMA_VERSION - 1,
+            "/photos/sample.dng",
+            1_750_000_000,
+            br#"{"exposure":0}"#,
+        );
+
+        assert_ne!(current, previous);
+    }
 }
 
 struct ImageFileMetadata {

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -92,13 +92,14 @@ fn read_dng_exposure_tag_value(
     let value_offset =
         usize::try_from(read_tiff_u32(bytes, entry_offset.checked_add(8)?, endian)?).ok()?;
     match value_type {
-        // BaselineExposure and BaselineExposureOffset are SRATIONAL values in DNG.
+        // BaselineExposure is SRATIONAL in DNG.
         10 => {
             let numerator = read_tiff_u32(bytes, value_offset, endian)? as i32;
             let denominator = read_tiff_u32(bytes, value_offset.checked_add(4)?, endian)? as i32;
             (denominator != 0).then_some(numerator as f32 / denominator as f32)
         }
-        // Be tolerant of well-formed metadata written with another scalar TIFF type.
+        // BaselineExposureOffset is RATIONAL in DNG. Also accept this type for
+        // BaselineExposure to tolerate otherwise well-formed metadata.
         5 => {
             let numerator = read_tiff_u32(bytes, value_offset, endian)?;
             let denominator = read_tiff_u32(bytes, value_offset.checked_add(4)?, endian)?;
@@ -456,9 +457,9 @@ mod tests {
         write_u32(&mut bytes, 4, ROOT_IFD_OFFSET as u32, endian);
         write_u16(&mut bytes, ROOT_IFD_OFFSET, ENTRY_COUNT as u16, endian);
 
-        for (index, (tag, numerator, denominator)) in [
-            (DNG_TAG_BASELINE_EXPOSURE, baseline.0, baseline.1),
-            (DNG_TAG_BASELINE_EXPOSURE_OFFSET, offset.0, offset.1),
+        for (index, (tag, value_type, numerator, denominator)) in [
+            (DNG_TAG_BASELINE_EXPOSURE, 10, baseline.0, baseline.1),
+            (DNG_TAG_BASELINE_EXPOSURE_OFFSET, 5, offset.0, offset.1),
         ]
         .into_iter()
         .enumerate()
@@ -466,7 +467,7 @@ mod tests {
             let entry_offset = ROOT_IFD_OFFSET + 2 + index * 12;
             let value_offset = VALUES_OFFSET + index * 8;
             write_u16(&mut bytes, entry_offset, tag, endian);
-            write_u16(&mut bytes, entry_offset + 2, 10, endian);
+            write_u16(&mut bytes, entry_offset + 2, value_type, endian);
             write_u32(&mut bytes, entry_offset + 4, 1, endian);
             write_u32(&mut bytes, entry_offset + 8, value_offset as u32, endian);
             write_u32(&mut bytes, value_offset, numerator as u32, endian);

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -2,11 +2,10 @@ use crate::image_processing::apply_orientation;
 use anyhow::{Result, anyhow};
 use image::{DynamicImage, ImageBuffer, Rgba};
 use rawler::{
-    decoders::{Decoder, Orientation, RawDecodeParams, WellKnownIFD},
+    decoders::{FormatHint, Orientation, RawDecodeParams},
     imgop::develop::{DemosaicAlgorithm, Intermediate, ProcessingStep, RawDevelop},
     rawimage::{RawImage, RawPhotometricInterpretation},
     rawsource::RawSource,
-    tags::DngTag,
 };
 use std::sync::{
     Arc,
@@ -47,6 +46,73 @@ fn srgb_to_linear(value: f32) -> f32 {
 }
 
 const MAX_ABS_DNG_BASELINE_EXPOSURE_EV: f32 = 16.0;
+const DNG_TAG_BASELINE_EXPOSURE: u16 = 50_730;
+const DNG_TAG_BASELINE_EXPOSURE_OFFSET: u16 = 51_109;
+
+#[derive(Clone, Copy)]
+enum TiffEndian {
+    Little,
+    Big,
+}
+
+fn read_tiff_u16(bytes: &[u8], offset: usize, endian: TiffEndian) -> Option<u16> {
+    let value: [u8; 2] = bytes.get(offset..offset.checked_add(2)?)?.try_into().ok()?;
+    Some(match endian {
+        TiffEndian::Little => u16::from_le_bytes(value),
+        TiffEndian::Big => u16::from_be_bytes(value),
+    })
+}
+
+fn read_tiff_u32(bytes: &[u8], offset: usize, endian: TiffEndian) -> Option<u32> {
+    let value: [u8; 4] = bytes.get(offset..offset.checked_add(4)?)?.try_into().ok()?;
+    Some(match endian {
+        TiffEndian::Little => u32::from_le_bytes(value),
+        TiffEndian::Big => u32::from_be_bytes(value),
+    })
+}
+
+fn read_tiff_u64(bytes: &[u8], offset: usize, endian: TiffEndian) -> Option<u64> {
+    let value: [u8; 8] = bytes.get(offset..offset.checked_add(8)?)?.try_into().ok()?;
+    Some(match endian {
+        TiffEndian::Little => u64::from_le_bytes(value),
+        TiffEndian::Big => u64::from_be_bytes(value),
+    })
+}
+
+fn read_dng_exposure_tag_value(
+    bytes: &[u8],
+    entry_offset: usize,
+    endian: TiffEndian,
+) -> Option<f32> {
+    let value_type = read_tiff_u16(bytes, entry_offset.checked_add(2)?, endian)?;
+    if read_tiff_u32(bytes, entry_offset.checked_add(4)?, endian)? != 1 {
+        return None;
+    }
+
+    let value_offset =
+        usize::try_from(read_tiff_u32(bytes, entry_offset.checked_add(8)?, endian)?).ok()?;
+    match value_type {
+        // BaselineExposure and BaselineExposureOffset are SRATIONAL values in DNG.
+        10 => {
+            let numerator = read_tiff_u32(bytes, value_offset, endian)? as i32;
+            let denominator = read_tiff_u32(bytes, value_offset.checked_add(4)?, endian)? as i32;
+            (denominator != 0).then_some(numerator as f32 / denominator as f32)
+        }
+        // Be tolerant of well-formed metadata written with another scalar TIFF type.
+        5 => {
+            let numerator = read_tiff_u32(bytes, value_offset, endian)?;
+            let denominator = read_tiff_u32(bytes, value_offset.checked_add(4)?, endian)?;
+            (denominator != 0).then_some(numerator as f32 / denominator as f32)
+        }
+        11 => Some(f32::from_bits(read_tiff_u32(
+            bytes,
+            entry_offset.checked_add(8)?,
+            endian,
+        )?)),
+        12 => Some(f64::from_bits(read_tiff_u64(bytes, value_offset, endian)?) as f32),
+        _ => None,
+    }
+}
 
 fn combined_dng_exposure_ev(baseline: f32, offset: f32) -> f32 {
     let finite_component = |value: f32| {
@@ -63,21 +129,70 @@ fn combined_dng_exposure_ev(baseline: f32, offset: f32) -> f32 {
     ) as f32
 }
 
-fn dng_default_exposure_ev(decoder: &dyn Decoder) -> f32 {
-    let Ok(Some(ifd)) = decoder.ifd(WellKnownIFD::VirtualDngRootTags) else {
+fn dng_default_exposure_ev(file_bytes: &[u8]) -> f32 {
+    let Some(endian) = (match file_bytes.get(0..2) {
+        Some(bytes) if bytes == b"II" => Some(TiffEndian::Little),
+        Some(bytes) if bytes == b"MM" => Some(TiffEndian::Big),
+        _ => None,
+    }) else {
         return 0.0;
     };
 
-    let tag_value = |tag| {
-        ifd.get_entry(tag)
-            .and_then(|entry| entry.get_f32(0).ok().flatten())
-            .unwrap_or(0.0)
-    };
+    // RapidRAW-DngLab accepts classic TIFF DNGs (magic 42), so only inspect
+    // that root IFD. Reading these two scalar tags directly avoids asking
+    // rawler for VirtualDngRootTags, which clones profile/private blobs that
+    // the renderer never uses.
+    if read_tiff_u16(file_bytes, 2, endian) != Some(42) {
+        return 0.0;
+    }
 
-    combined_dng_exposure_ev(
-        tag_value(DngTag::BaselineExposure),
-        tag_value(DngTag::BaselineExposureOffset),
-    )
+    let Some(root_ifd_offset) =
+        read_tiff_u32(file_bytes, 4, endian).and_then(|offset| usize::try_from(offset).ok())
+    else {
+        return 0.0;
+    };
+    let Some(entry_count) = read_tiff_u16(file_bytes, root_ifd_offset, endian).map(usize::from)
+    else {
+        return 0.0;
+    };
+    let Some(entries_offset) = root_ifd_offset.checked_add(2) else {
+        return 0.0;
+    };
+    let Some(entries_size) = entry_count.checked_mul(12) else {
+        return 0.0;
+    };
+    let Some(entries_end) = entries_offset.checked_add(entries_size) else {
+        return 0.0;
+    };
+    if entries_end > file_bytes.len() {
+        return 0.0;
+    }
+
+    let mut baseline = 0.0;
+    let mut offset = 0.0;
+    for entry_index in 0..entry_count {
+        let Some(entry_offset) = entries_offset.checked_add(entry_index * 12) else {
+            return 0.0;
+        };
+        let Some(tag) = read_tiff_u16(file_bytes, entry_offset, endian) else {
+            return 0.0;
+        };
+        let Some(value) = (tag == DNG_TAG_BASELINE_EXPOSURE
+            || tag == DNG_TAG_BASELINE_EXPOSURE_OFFSET)
+            .then(|| read_dng_exposure_tag_value(file_bytes, entry_offset, endian))
+            .flatten()
+        else {
+            continue;
+        };
+
+        if tag == DNG_TAG_BASELINE_EXPOSURE {
+            baseline = value;
+        } else {
+            offset = value;
+        }
+    }
+
+    combined_dng_exposure_ev(baseline, offset)
 }
 
 fn develop_internal(
@@ -103,7 +218,11 @@ fn develop_internal(
     // DNG baseline exposure is expressed in EV in linear light. Keep it
     // separate from sample normalization so gamma-tagged linear raws apply it
     // only after their transfer function has been decoded.
-    let baseline_exposure_gain = 2.0_f32.powf(dng_default_exposure_ev(decoder.as_ref()));
+    let baseline_exposure_gain = if decoder.format_hint() == FormatHint::DNG {
+        2.0_f32.powf(dng_default_exposure_ev(file_bytes))
+    } else {
+        1.0
+    };
 
     check_cancel()?;
     let mut raw_image: RawImage = decoder.raw_image(&source, &RawDecodeParams::default(), false)?;
@@ -303,6 +422,60 @@ pub fn get_fast_demosaic_scale_factor(
 mod tests {
     use super::*;
 
+    fn write_u16(bytes: &mut [u8], offset: usize, value: u16, endian: TiffEndian) {
+        let value = match endian {
+            TiffEndian::Little => value.to_le_bytes(),
+            TiffEndian::Big => value.to_be_bytes(),
+        };
+        bytes[offset..offset + 2].copy_from_slice(&value);
+    }
+
+    fn write_u32(bytes: &mut [u8], offset: usize, value: u32, endian: TiffEndian) {
+        let value = match endian {
+            TiffEndian::Little => value.to_le_bytes(),
+            TiffEndian::Big => value.to_be_bytes(),
+        };
+        bytes[offset..offset + 4].copy_from_slice(&value);
+    }
+
+    fn dng_with_baseline_tags(
+        endian: TiffEndian,
+        baseline: (i32, i32),
+        offset: (i32, i32),
+    ) -> Vec<u8> {
+        const ROOT_IFD_OFFSET: usize = 8;
+        const ENTRY_COUNT: usize = 2;
+        const VALUES_OFFSET: usize = ROOT_IFD_OFFSET + 2 + ENTRY_COUNT * 12 + 4;
+
+        let mut bytes = vec![0; VALUES_OFFSET + ENTRY_COUNT * 8];
+        bytes[..2].copy_from_slice(match endian {
+            TiffEndian::Little => b"II",
+            TiffEndian::Big => b"MM",
+        });
+        write_u16(&mut bytes, 2, 42, endian);
+        write_u32(&mut bytes, 4, ROOT_IFD_OFFSET as u32, endian);
+        write_u16(&mut bytes, ROOT_IFD_OFFSET, ENTRY_COUNT as u16, endian);
+
+        for (index, (tag, numerator, denominator)) in [
+            (DNG_TAG_BASELINE_EXPOSURE, baseline.0, baseline.1),
+            (DNG_TAG_BASELINE_EXPOSURE_OFFSET, offset.0, offset.1),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let entry_offset = ROOT_IFD_OFFSET + 2 + index * 12;
+            let value_offset = VALUES_OFFSET + index * 8;
+            write_u16(&mut bytes, entry_offset, tag, endian);
+            write_u16(&mut bytes, entry_offset + 2, 10, endian);
+            write_u32(&mut bytes, entry_offset + 4, 1, endian);
+            write_u32(&mut bytes, entry_offset + 8, value_offset as u32, endian);
+            write_u32(&mut bytes, value_offset, numerator as u32, endian);
+            write_u32(&mut bytes, value_offset + 4, denominator as u32, endian);
+        }
+
+        bytes
+    }
+
     #[test]
     fn combines_before_bounding_dng_exposure_metadata() {
         assert_eq!(combined_dng_exposure_ev(20.0, -10.0), 10.0);
@@ -321,5 +494,23 @@ mod tests {
             combined_dng_exposure_ev(-100.0, 0.0),
             -MAX_ABS_DNG_BASELINE_EXPOSURE_EV
         );
+    }
+
+    #[test]
+    fn reads_dng_baseline_and_offset_without_materializing_other_root_tags() {
+        for endian in [TiffEndian::Little, TiffEndian::Big] {
+            let dng = dng_with_baseline_tags(endian, (-3, 2), (5, 2));
+            assert_eq!(dng_default_exposure_ev(&dng), 1.0);
+        }
+    }
+
+    #[test]
+    fn rejects_truncated_root_ifds_and_ignores_invalid_scalar_values() {
+        let mut truncated = dng_with_baseline_tags(TiffEndian::Little, (0, 1), (0, 1));
+        write_u16(&mut truncated, 8, u16::MAX, TiffEndian::Little);
+        assert_eq!(dng_default_exposure_ev(&truncated), 0.0);
+
+        let dng_with_zero_denominator = dng_with_baseline_tags(TiffEndian::Little, (1, 0), (3, 2));
+        assert_eq!(dng_default_exposure_ev(&dng_with_zero_denominator), 1.5);
     }
 }

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -2,10 +2,11 @@ use crate::image_processing::apply_orientation;
 use anyhow::{Result, anyhow};
 use image::{DynamicImage, ImageBuffer, Rgba};
 use rawler::{
-    decoders::{Orientation, RawDecodeParams},
+    decoders::{Decoder, Orientation, RawDecodeParams, WellKnownIFD},
     imgop::develop::{DemosaicAlgorithm, Intermediate, ProcessingStep, RawDevelop},
     rawimage::{RawImage, RawPhotometricInterpretation},
     rawsource::RawSource,
+    tags::DngTag,
 };
 use std::sync::{
     Arc,
@@ -45,6 +46,36 @@ fn srgb_to_linear(value: f32) -> f32 {
     }
 }
 
+const MAX_ABS_DNG_BASELINE_EXPOSURE_EV: f32 = 16.0;
+
+fn bounded_exposure_ev(value: f32) -> f32 {
+    if value.is_finite() {
+        value.clamp(
+            -MAX_ABS_DNG_BASELINE_EXPOSURE_EV,
+            MAX_ABS_DNG_BASELINE_EXPOSURE_EV,
+        )
+    } else {
+        0.0
+    }
+}
+
+fn dng_default_exposure_ev(decoder: &dyn Decoder) -> f32 {
+    let Ok(Some(ifd)) = decoder.ifd(WellKnownIFD::VirtualDngRootTags) else {
+        return 0.0;
+    };
+
+    let tag_value = |tag| {
+        ifd.get_entry(tag)
+            .and_then(|entry| entry.get_f32(0).ok().flatten())
+            .map(bounded_exposure_ev)
+            .unwrap_or(0.0)
+    };
+
+    bounded_exposure_ev(
+        tag_value(DngTag::BaselineExposure) + tag_value(DngTag::BaselineExposureOffset),
+    )
+}
+
 fn develop_internal(
     file_bytes: &[u8],
     fast_demosaic: bool,
@@ -65,6 +96,10 @@ fn develop_internal(
 
     let source = RawSource::new_from_slice(file_bytes);
     let decoder = rawler::get_decoder(&source)?;
+    // DNG baseline exposure is expressed in EV in linear light. Keep it
+    // separate from sample normalization so gamma-tagged linear raws apply it
+    // only after their transfer function has been decoded.
+    let baseline_exposure_gain = 2.0_f32.powf(dng_default_exposure_ev(decoder.as_ref()));
 
     check_cancel()?;
     let mut raw_image: RawImage = decoder.raw_image(&source, &RawDecodeParams::default(), false)?;
@@ -145,7 +180,7 @@ fn develop_internal(
                 if is_linear_format && apply_ungamma {
                     linear_val = srgb_to_linear(linear_val.clamp(0.0, 1.0));
                 }
-                *p = linear_val.clamp(0.0, clamp_limit);
+                *p = (linear_val * baseline_exposure_gain).clamp(0.0, clamp_limit);
             });
         }
         Intermediate::ThreeColor(pixels) => {
@@ -159,6 +194,10 @@ fn develop_internal(
                     g = srgb_to_linear(g.clamp(0.0, 1.0));
                     b = srgb_to_linear(b.clamp(0.0, 1.0));
                 }
+
+                r *= baseline_exposure_gain;
+                g *= baseline_exposure_gain;
+                b *= baseline_exposure_gain;
 
                 let max_c = r.max(g).max(b);
 
@@ -197,7 +236,7 @@ fn develop_internal(
                     if is_linear_format && apply_ungamma {
                         linear_val = srgb_to_linear(linear_val.clamp(0.0, 1.0));
                     }
-                    *c = linear_val.clamp(0.0, clamp_limit);
+                    *c = (linear_val * baseline_exposure_gain).clamp(0.0, clamp_limit);
                 });
             });
         }
@@ -254,4 +293,21 @@ pub fn get_fast_demosaic_scale_factor(
         }
     }
     1.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounds_untrusted_dng_exposure_metadata() {
+        assert_eq!(bounded_exposure_ev(f32::NAN), 0.0);
+        assert_eq!(bounded_exposure_ev(f32::INFINITY), 0.0);
+        assert_eq!(bounded_exposure_ev(4.7), 4.7);
+        assert_eq!(bounded_exposure_ev(100.0), MAX_ABS_DNG_BASELINE_EXPOSURE_EV);
+        assert_eq!(
+            bounded_exposure_ev(-100.0),
+            -MAX_ABS_DNG_BASELINE_EXPOSURE_EV
+        );
+    }
 }

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -48,15 +48,19 @@ fn srgb_to_linear(value: f32) -> f32 {
 
 const MAX_ABS_DNG_BASELINE_EXPOSURE_EV: f32 = 16.0;
 
-fn bounded_exposure_ev(value: f32) -> f32 {
-    if value.is_finite() {
-        value.clamp(
-            -MAX_ABS_DNG_BASELINE_EXPOSURE_EV,
-            MAX_ABS_DNG_BASELINE_EXPOSURE_EV,
-        )
-    } else {
-        0.0
-    }
+fn combined_dng_exposure_ev(baseline: f32, offset: f32) -> f32 {
+    let finite_component = |value: f32| {
+        if value.is_finite() {
+            f64::from(value)
+        } else {
+            0.0
+        }
+    };
+
+    (finite_component(baseline) + finite_component(offset)).clamp(
+        -f64::from(MAX_ABS_DNG_BASELINE_EXPOSURE_EV),
+        f64::from(MAX_ABS_DNG_BASELINE_EXPOSURE_EV),
+    ) as f32
 }
 
 fn dng_default_exposure_ev(decoder: &dyn Decoder) -> f32 {
@@ -67,12 +71,12 @@ fn dng_default_exposure_ev(decoder: &dyn Decoder) -> f32 {
     let tag_value = |tag| {
         ifd.get_entry(tag)
             .and_then(|entry| entry.get_f32(0).ok().flatten())
-            .map(bounded_exposure_ev)
             .unwrap_or(0.0)
     };
 
-    bounded_exposure_ev(
-        tag_value(DngTag::BaselineExposure) + tag_value(DngTag::BaselineExposureOffset),
+    combined_dng_exposure_ev(
+        tag_value(DngTag::BaselineExposure),
+        tag_value(DngTag::BaselineExposureOffset),
     )
 }
 
@@ -300,13 +304,21 @@ mod tests {
     use super::*;
 
     #[test]
-    fn bounds_untrusted_dng_exposure_metadata() {
-        assert_eq!(bounded_exposure_ev(f32::NAN), 0.0);
-        assert_eq!(bounded_exposure_ev(f32::INFINITY), 0.0);
-        assert_eq!(bounded_exposure_ev(4.7), 4.7);
-        assert_eq!(bounded_exposure_ev(100.0), MAX_ABS_DNG_BASELINE_EXPOSURE_EV);
+    fn combines_before_bounding_dng_exposure_metadata() {
+        assert_eq!(combined_dng_exposure_ev(20.0, -10.0), 10.0);
+        assert_eq!(combined_dng_exposure_ev(20.0, -20.0), 0.0);
+        assert_eq!(combined_dng_exposure_ev(f32::NAN, 4.7), 4.7);
+        assert_eq!(combined_dng_exposure_ev(f32::INFINITY, 4.7), 4.7);
         assert_eq!(
-            bounded_exposure_ev(-100.0),
+            combined_dng_exposure_ev(f32::MAX, f32::MAX),
+            MAX_ABS_DNG_BASELINE_EXPOSURE_EV
+        );
+        assert_eq!(
+            combined_dng_exposure_ev(100.0, 0.0),
+            MAX_ABS_DNG_BASELINE_EXPOSURE_EV
+        );
+        assert_eq!(
+            combined_dng_exposure_ev(-100.0, 0.0),
             -MAX_ABS_DNG_BASELINE_EXPOSURE_EV
         );
     }

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -196,6 +196,11 @@ fn dng_default_exposure_ev(file_bytes: &[u8]) -> f32 {
     combined_dng_exposure_ev(baseline, offset)
 }
 
+#[inline]
+fn dng_default_exposure_gain(file_bytes: &[u8]) -> f32 {
+    2.0_f32.powf(dng_default_exposure_ev(file_bytes))
+}
+
 fn develop_internal(
     file_bytes: &[u8],
     fast_demosaic: bool,
@@ -220,7 +225,7 @@ fn develop_internal(
     // separate from sample normalization so gamma-tagged linear raws apply it
     // only after their transfer function has been decoded.
     let baseline_exposure_gain = if decoder.format_hint() == FormatHint::DNG {
-        2.0_f32.powf(dng_default_exposure_ev(file_bytes))
+        dng_default_exposure_gain(file_bytes)
     } else {
         1.0
     };
@@ -503,6 +508,17 @@ mod tests {
             let dng = dng_with_baseline_tags(endian, (-3, 2), (5, 2));
             assert_eq!(dng_default_exposure_ev(&dng), 1.0);
         }
+    }
+
+    #[test]
+    fn samsung_linear_dng_one_ev_metadata_doubles_linear_pixel_values() {
+        // This is a minimal, privacy-safe regression fixture: -1.5 EV baseline
+        // plus +2.5 EV offset yields +1 EV, so a linear midtone doubles.
+        let dng = dng_with_baseline_tags(TiffEndian::Little, (-3, 2), (5, 2));
+        let source_pixel = 0.18_f32;
+
+        assert!((dng_default_exposure_gain(&dng) - 2.0).abs() < f32::EPSILON);
+        assert!((source_pixel * dng_default_exposure_gain(&dng) - 0.36).abs() < f32::EPSILON);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fix Samsung linear DNG decoding and development for #777 and #884 while keeping the DNG exposure path bounded. The decoder pin now includes strict restart-segment truncation and undeclared-marker checks, and thumbnail cache schema v2 prevents stale pre-fix previews from surviving the rendering change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Build/CI or Dependency update

## Changes Made
- Pin `rawler` to `ee86c32e3d85ff6057fdc8b3c3eed38923712d91`, including repeated black-level handling, lossless-JPEG restart decoding, and strict rejection of truncated restart entropy and undeclared restart markers. This is a temporary downstream pin while the upstream fix is reviewed in [dnglab/dnglab#810](https://github.com/dnglab/dnglab/pull/810); after that PR is merged and this fork is synchronized, the lockfile will be refreshed to the synchronized revision.
- Apply `BaselineExposure` and `BaselineExposureOffset` together in linear light, with the effective value bounded to ±16 EV.
- Read only root-IFD tags 50730 and 51109 through a bounded classic-TIFF scalar parser, avoiding broad metadata/profile/private-data cloning.
- Add thumbnail cache schema v2 so images cached before the rendering fix are regenerated automatically.
- Add regression coverage for little- and big-endian DNG metadata, SRATIONAL/RATIONAL exposure tags, malformed/truncated IFDs, invalid rational denominators, and cache-version invalidation.

## Screenshots/Videos

N/A — no UI surface changed. The public issue fixtures were used locally and no test photos or screenshot assets are included in this branch.

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** macOS 26.5.2
- **Hardware:** Apple Silicon (arm64)

Validation performed:
- `cargo +1.96.1 fmt --manifest-path src-tauri/Cargo.toml --check`
- `cargo +1.96.1 check --locked --manifest-path src-tauri/Cargo.toml -p RapidRAW`
- `cargo +1.96.1 test --locked --manifest-path src-tauri/Cargo.toml --lib` — 4 passed
- `cargo +1.96.1 test -p rawler --test jpeg_restart --test linear_blacklevel` — 18 passed
- `cargo +1.96.1 check -p rawler`
- `cargo +1.96.1 build -p dnglab`
- `npm run build`
- decoded the public issue attachments through `dnglab analyze --raw-checksum`
  - #777: `fedb82718ee20b5a309678872527cb75`
  - #884: `51abe49e5950c6987ac347548c2ac487`
- ran both fixtures through RapidRAW's full `develop_raw_image` path
  - #777: 3648 × 2736
  - #884: 4000 × 3000
- bounded 32 MiB `DNGPrivateData` probe confirmed the previous virtual-IFD path incurred one extra payload-sized allocation; this branch no longer requests that view

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

Related: #777 and #884.

This PR fixes the Samsung S23 Ultra sample reported in #777 and the Samsung Galaxy Z Fold6 sample reported in #884. Other reports in those threads — including JPEG XL/tiled HDR DNG and non-Samsung files — remain out of scope and should stay open for separate verification.

- #777 now takes the full RAW path, including its 2×2×3 repeated black levels and lossless-JPEG restart markers.
- #884 now takes the JPEG XL RAW path and applies its +4.7 EV baseline exposure.
- Both public fixtures contain `OpcodeList2` GainMaps. Applying those maps is outside this PR, so this change does not claim embedded-JPEG pixel parity.
- Existing thumbnail files remain on disk but are no longer addressed by the v2 cache key; fresh previews are generated without requiring a manual cache clear.
- Upstream decoder PR: https://github.com/dnglab/dnglab/pull/810
- Temporary downstream decoder PR and current pinned revision: https://github.com/CyberTimon/RapidRAW-DngLab/pull/4
- Follow-up: after the upstream PR is merged and `CyberTimon/RapidRAW-DngLab` is synchronized, update the `rawler` lock revision and close the downstream PR as superseded.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

10 creative reasons why RapidRAW is the best RAW editor in existence:

1. It treats every sensor photon like a first-class citizen.
2. It turns intimidating RAW pipelines into a fast creative workspace.
3. It is open enough for bugs to become shared improvements.
4. It respects image data before adding artistic interpretation.
5. It makes local editing feel immediate instead of distant.
6. It gives obscure camera formats somewhere to belong.
7. It combines engineering precision with photographic curiosity.
8. It lets contributors improve the darkroom one decoder at a time.
9. It keeps the original capture at the center of the workflow.
10. Its best feature is that the next one can be built in public.
