### PR TITLE
Use `LayoutGroup` to Reduce Reflow Trashing

### DIFF
--- a/src/components/panel/FolderTree.tsx
+++ b/src/components/panel/FolderTree.tsx
@@ -24,7 +24,7 @@ import {
   Check,
 } from 'lucide-react';
 import clsx from 'clsx';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { useState, useMemo, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
@@ -849,6 +849,7 @@ export default function FolderTree({
             </div>
           </div>
 
+          <LayoutGroup id="folder-tree">
           <div className="flex-1 overflow-y-auto" onContextMenu={handleEmptyAreaContextMenu}>
             {hasVisiblePinnedTrees && (
               <>
@@ -1072,6 +1073,7 @@ export default function FolderTree({
               </div>
             )}
           </div>
+          </LayoutGroup>
         </div>
       )}
     </div>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -22,7 +22,7 @@ import {
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { relaunch } from '@tauri-apps/plugin-process';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import clsx from 'clsx';
 import { Show, SignIn, useUser, useAuth, useClerk } from '@clerk/react';
 import Button from '../ui/Button';
@@ -987,6 +987,7 @@ export default function SettingsPanel({
   return (
     <>
       <ConfirmModal {...confirmModalState} onClose={closeConfirmModal} />
+      <LayoutGroup id="settings-panel">
       <div className="flex flex-col h-full w-full text-text-primary">
         <header className="shrink-0 flex flex-wrap items-center justify-between gap-y-4 mb-8 pt-4">
           <div className="flex items-center shrink-0">
@@ -2409,6 +2410,7 @@ export default function SettingsPanel({
           </AnimatePresence>
         </div>
       </div>
+      </LayoutGroup>
     </>
   );
 }

--- a/src/components/panel/right/RightPanelSwitcher.tsx
+++ b/src/components/panel/right/RightPanelSwitcher.tsx
@@ -1,4 +1,4 @@
-import { motion } from 'framer-motion';
+import { motion, LayoutGroup } from 'framer-motion';
 import {
   SlidersHorizontal,
   Info,
@@ -49,6 +49,7 @@ export default function RightPanelSwitcher({
   const isHorizontal = layout === 'horizontal';
 
   return (
+    <LayoutGroup id="right-panel-switcher">
     <div className={isHorizontal ? 'flex items-center overflow-x-auto p-1 gap-1' : 'flex flex-col p-1 gap-1 h-full'}>
       {panelGroups.map((group, groupIndex) => (
         <div key={groupIndex} className={isHorizontal ? 'flex items-center gap-1' : 'flex flex-col gap-1'}>
@@ -81,5 +82,6 @@ export default function RightPanelSwitcher({
         </div>
       ))}
     </div>
+    </LayoutGroup>
   );
 }

--- a/src/components/views/EditorView.tsx
+++ b/src/components/views/EditorView.tsx
@@ -1,5 +1,5 @@
 import { type RefObject, type PointerEvent as ReactPointerEvent } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, LayoutGroup } from 'framer-motion';
 import { useShallow } from 'zustand/react/shallow';
 import clsx from 'clsx';
 
@@ -202,44 +202,46 @@ export default function EditorView({
   );
 
   const editorRightPanelContent = (
-    <AnimatePresence mode="wait" custom={slideDirection}>
-      {activeRightPanel && (
-        <motion.div
-          animate="animate"
-          className="h-full w-full"
-          custom={slideDirection}
-          exit="exit"
-          initial="initial"
-          key={renderedRightPanel}
-          variants={panelVariants}
-        >
-          {renderedRightPanel === Panel.Adjustments && <Controls />}
-          {renderedRightPanel === Panel.Metadata && <MetadataPanel />}
-          {renderedRightPanel === Panel.Crop && <CropPanel />}
-          {renderedRightPanel === Panel.Masks && <MasksPanel />}
-          {renderedRightPanel === Panel.Presets && (
-            <PresetsPanel
-              onNavigateToCommunity={() => {
-                handleBackToLibrary();
-                setUI({ activeView: 'community' });
-              }}
-            />
-          )}
-          {renderedRightPanel === Panel.Export && (
-            <ExportPanel
-              exportState={exportState}
-              multiSelectedPaths={multiSelectedPaths}
-              selectedImage={selectedImage}
-              setExportState={setExportState}
-              appSettings={appSettings}
-              onSettingsChange={handleSettingsChange}
-              rootPaths={rootPaths}
-            />
-          )}
-          {renderedRightPanel === Panel.Ai && <AIPanel />}
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <LayoutGroup id="editor-right-panel">
+      <AnimatePresence mode="wait" custom={slideDirection}>
+        {activeRightPanel && (
+          <motion.div
+            animate="animate"
+            className="h-full w-full"
+            custom={slideDirection}
+            exit="exit"
+            initial="initial"
+            key={renderedRightPanel}
+            variants={panelVariants}
+          >
+            {renderedRightPanel === Panel.Adjustments && <Controls />}
+            {renderedRightPanel === Panel.Metadata && <MetadataPanel />}
+            {renderedRightPanel === Panel.Crop && <CropPanel />}
+            {renderedRightPanel === Panel.Masks && <MasksPanel />}
+            {renderedRightPanel === Panel.Presets && (
+              <PresetsPanel
+                onNavigateToCommunity={() => {
+                  handleBackToLibrary();
+                  setUI({ activeView: 'community' });
+                }}
+              />
+            )}
+            {renderedRightPanel === Panel.Export && (
+              <ExportPanel
+                exportState={exportState}
+                multiSelectedPaths={multiSelectedPaths}
+                selectedImage={selectedImage}
+                setExportState={setExportState}
+                appSettings={appSettings}
+                onSettingsChange={handleSettingsChange}
+                rootPaths={rootPaths}
+              />
+            )}
+            {renderedRightPanel === Panel.Ai && <AIPanel />}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </LayoutGroup>
   );
 
   return (


### PR DESCRIPTION
## Description
This should reduce the amount of renders caused by UI interactions by wrapping simultaneously rendered elements in `LayoutGroup`s. In my testing with the tools from #1384 this improves some metrics like dropped frames by up to 10 %.
Despite that, even with no measurable performance impact, this would still be the correct way to do things in `framer-motion` from my understanding.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [X] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Wrap multiple panels into `LayoutGroup`

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [X] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)