### PR TITLE
Refactor Nvidia Workaround

### DIFF
--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -382,6 +382,8 @@ pub struct AppSettings {
     #[serde(default)]
     pub linux_gpu_optimization: Option<bool>,
     #[serde(default)]
+    pub linux_gpu_optimization_migrated_v1: Option<bool>,
+    #[serde(default)]
     pub library_view_mode: Option<String>,
     #[serde(default = "default_export_presets")]
     pub export_presets: Vec<ExportPreset>,
@@ -480,10 +482,8 @@ impl Default for AppSettings {
             copy_paste_settings: CopyPasteSettings::default(),
             raw_highlight_compression: Some(2.5),
             processing_backend: Some("auto".to_string()),
-            #[cfg(target_os = "linux")]
-            linux_gpu_optimization: Some(true),
-            #[cfg(not(target_os = "linux"))]
             linux_gpu_optimization: Some(false),
+            linux_gpu_optimization_migrated_v1: Some(true),
             library_view_mode: Some("flat".to_string()),
             export_presets: default_export_presets(),
             my_lenses: Some(Vec::new()),
@@ -562,6 +562,15 @@ pub fn load_settings(app_handle: AppHandle) -> Result<AppSettings, String> {
         && let Some(last) = &settings.last_root_path
     {
         settings.root_folders.push(last.clone());
+        settings_modified = true;
+    }
+
+    #[cfg(target_os = "linux")]
+    if !settings.linux_gpu_optimization_migrated_v1.unwrap_or(false) {
+        if settings.linux_gpu_optimization == Some(true) {
+            settings.linux_gpu_optimization = Some(false);
+        }
+        settings.linux_gpu_optimization_migrated_v1 = Some(true);
         settings_modified = true;
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1611,6 +1611,11 @@ async fn generate_preview_for_path(
     .map_err(|e| format!("Task execution failed: {}", e))?
 }
 
+#[cfg(target_os = "linux")]
+fn is_nvidia_gpu() -> bool {
+    std::path::Path::new("/proc/driver/nvidia/version").exists()
+}
+
 fn setup_logging(app_handle: &tauri::AppHandle) {
     let log_dir = match app_handle.path().app_log_dir() {
         Ok(dir) => dir,
@@ -2050,12 +2055,14 @@ pub fn run() {
                         std::env::set_var("WGPU_BACKEND", backend);
                     }
 
-                if settings.linux_gpu_optimization.unwrap_or(true) {
-                    #[cfg(target_os = "linux")]
-                    {
+                #[cfg(target_os = "linux")]
+                {
+                    if settings.linux_gpu_optimization.unwrap_or(false) {
                         std::env::set_var("WEBKIT_DISABLE_DMABUF_RENDERER", "1");
                         std::env::set_var("WEBKIT_DISABLE_COMPOSITING_MODE", "1");
                         std::env::set_var("NODEVICE_SELECT", "1");
+                    } else if is_nvidia_gpu() {
+                        std::env::set_var("__NV_DISABLE_EXPLICIT_SYNC", "1");
                     }
                 }
 
@@ -2088,10 +2095,12 @@ pub fn run() {
                 && backend != "auto" {
                     log::info!("Applied processing backend setting: {}", backend);
                 }
-            if settings.linux_gpu_optimization.unwrap_or(false) {
-                #[cfg(target_os = "linux")]
-                {
-                    log::info!("Applied Linux GPU optimizations.");
+            #[cfg(target_os = "linux")]
+            {
+                if settings.linux_gpu_optimization.unwrap_or(false) {
+                    log::info!("Applied Linux Compatibility Mode (forced software compositing).");
+                } else if is_nvidia_gpu() {
+                    log::info!("Applied Nvidia explicit-sync workaround (hardware compositing kept).");
                 }
             }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1609,7 +1609,7 @@
       "imageCacheDesc": "Maximum number of full-resolution images kept in RAM. Higher values make switching between recently edited images instant, but use significantly more memory.",
       "images": "Images",
       "linuxCompat": "Linux Compatibility Mode",
-      "linuxCompatDesc": "Enable workarounds for common GPU driver and display server issues. Disable this to enable full GPU acceleration.",
+      "linuxCompatDesc": "Force software compositing to work around GPU driver crashes. Nvidia GPUs already get a lighter, non-software-fallback workaround automatically, so only enable this if you still experience crashes on launch or when opening images.",
       "linuxCompatLabel": "Enable Compatibility Mode",
       "livePreviewQuality": "Live Preview Quality",
       "livePreviewQualityDesc": "Controls the resolution and compression of the image while dragging sliders. Lower quality significantly improves responsiveness.",


### PR DESCRIPTION
## Description
This reworks the workaround for Linux system to only automatically apply to Nvidia systems, and use a softer workaround `__NV_DISABLE_EXPLICIT_SYNC=1`, that doesn't disable hardware rendering (thanks to [this comment](https://github.com/CyberTimon/RapidRAW/issues/306#issuecomment-4804339878)).
The original toggle is preserved as a last resort solution, but not enabled by default any more. This should greatly improve the user experience on Linux systems for basically every one.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [X] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Add Nvidia hardware detection
- Migrate settings to enable hardware rendering again on Linux systems
- Fix logic mistake in Linux detection
- Update English description to match new behaviour

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## Additional Notes
It would obviously be great if more people could test this. Ideally at least someone previously affected by the crashes to ensure it doesn't re-introduce that.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [X] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)