### PR TITLE
fix(frontend): align shared TypeScript contracts

### DIFF
--- a/src/components/modals/CollageModal.tsx
+++ b/src/components/modals/CollageModal.tsx
@@ -28,7 +28,7 @@ interface CollageModalProps {
   isOpen: boolean;
   onClose(): void;
   onSave(base64Data: string, firstPath: string): Promise<string>;
-  sourceImages: ImageFile[];
+  sourceImages: Array<Pick<ImageFile, 'path'>>;
   thumbnails: Record<string, string>;
 }
 
@@ -152,7 +152,7 @@ export default function CollageModal({ isOpen, onClose, onSave, sourceImages }: 
             path: imageFile.path,
             jsAdjustments: adjustments,
           });
-          const blob = new Blob([imageData], { type: 'image/jpeg' });
+          const blob = new Blob([new Uint8Array(imageData)], { type: 'image/jpeg' });
           const url = URL.createObjectURL(blob);
 
           return new Promise<LoadedImage>((resolve, reject) => {

--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -6,7 +6,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { toast } from 'react-toastify';
 import debounce from 'lodash.debounce';
 
-import { ImageDimensions, useImageRenderSize } from '../../hooks/useImageRenderSize';
+import { ImageDimensions, RenderSize, useImageRenderSize } from '../../hooks/useImageRenderSize';
 import { Adjustments, AiPatch, MaskContainer } from '../../utils/adjustments';
 import { calculateCenteredCrop } from '../../utils/cropUtils';
 import EditorToolbar from './editor/EditorToolbar';
@@ -209,7 +209,7 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
   }, [isFullScreen, selectedImage, targetZoom, setUI]);
 
   const handleDisplaySizeChange = useCallback(
-    (size: any) => {
+    (size: RenderSize) => {
       setEditor({ displaySize: { width: size.width, height: size.height } });
       if (size.scale) {
         const baseWidth = size.width / size.scale;
@@ -222,7 +222,7 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
           containerWidth: size.containerWidth || 0,
           containerHeight: size.containerHeight || 0,
         };
-        setEditor({ baseRenderSize: newSize as any });
+        setEditor({ baseRenderSize: newSize });
       }
     },
     [setEditor],
@@ -1334,7 +1334,7 @@ export default function Editor({ onBackToLibrary, onContextMenu, transformWrappe
     return JSON.stringify({
       id: activeMaskDef.id,
       invert: activeMaskDef.invert,
-      opacity: activeMaskDef.opacity,
+      ...('opacity' in activeMaskDef ? { opacity: activeMaskDef.opacity } : {}),
       subMasks,
       geometry,
       renderSize: { w: imageRenderSize.width, h: imageRenderSize.height },

--- a/src/components/panel/editor/ExifIcons.tsx
+++ b/src/components/panel/editor/ExifIcons.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import type { SVGProps } from 'react';
 
 const iconProps = {
   width: 16,
@@ -11,15 +12,17 @@ const iconProps = {
   strokeLinejoin: 'round' as const,
 };
 
-export const IconAperture = () => (
-  <svg {...iconProps}>
+type ExifIconProps = SVGProps<SVGSVGElement>;
+
+export const IconAperture = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <circle cx="12" cy="12" r="10" />
     <path d="M14.31 8l5.74 9.94M9.69 8h11.48M7.38 12l5.74-9.94M9.69 16L3.95 6.06M14.31 16H2.83M16.62 12l-5.74 9.94" />
   </svg>
 );
 
-export const IconShutter = () => (
-  <svg {...iconProps}>
+export const IconShutter = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <circle cx="12" cy="12" r="10" />
     <path d="M12 12V7" />
     <path d="M12 2v2" />
@@ -33,16 +36,16 @@ export const IconShutter = () => (
   </svg>
 );
 
-export const IconIso = () => (
-  <svg {...iconProps}>
+export const IconIso = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <rect x="2" y="4" width="20" height="16" rx="2" />
     <circle cx="12" cy="12" r="3" />
     <path d="M6 8h.01M6 16h.01M18 8h.01M18 16h.01" />
   </svg>
 );
 
-export const IconFocalLength = () => (
-  <svg {...iconProps}>
+export const IconFocalLength = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <path d="M2 12L22 12" />
     <path d="M17 12a5 5 0 0 0-5-5 5 5 0 0 0-5 5" />
     <path d="M2 12l6 8" />
@@ -50,8 +53,8 @@ export const IconFocalLength = () => (
   </svg>
 );
 
-export const IconCalendar = () => (
-  <svg {...iconProps}>
+export const IconCalendar = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
     <line x1="16" y1="2" x2="16" y2="6" />
     <line x1="8" y1="2" x2="8" y2="6" />
@@ -59,15 +62,15 @@ export const IconCalendar = () => (
   </svg>
 );
 
-export const IconClock = () => (
-  <svg {...iconProps}>
+export const IconClock = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <circle cx="12" cy="12" r="10" />
     <polyline points="12 6 12 12 16 14" />
   </svg>
 );
 
-export const IconLens = () => (
-  <svg {...iconProps}>
+export const IconLens = (props: ExifIconProps) => (
+  <svg {...iconProps} {...props}>
     <circle cx="12" cy="12" r="10" />
     <circle cx="12" cy="12" r="5" />
     <path d="M12 7a5 5 0 0 1 5 5" strokeWidth="1.5" strokeOpacity="0.4" />

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -1997,7 +1997,7 @@ const ImageCanvas = memo(
           return;
         }
 
-        if (isAiSubjectActive && previewBoxRef.current) {
+        if (isAiSubjectActive && previewBoxRef.current && pos) {
           const updatedBox = { ...previewBoxRef.current, end: pos };
           previewBoxRef.current = updatedBox;
           setPreviewBox(updatedBox);

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -506,13 +506,12 @@ export default function ExportPanel({
 
       if (isAndroid || outputFolderOrFile) {
         if (!isAndroid) {
-          const dir =
-            shouldChooseOutputFile
-              ? outputFolderOrFile.substring(
-                  0,
-                  Math.max(outputFolderOrFile.lastIndexOf('/'), outputFolderOrFile.lastIndexOf('\\')),
-                )
-              : outputFolderOrFile;
+          const dir = shouldChooseOutputFile
+            ? outputFolderOrFile.substring(
+                0,
+                Math.max(outputFolderOrFile.lastIndexOf('/'), outputFolderOrFile.lastIndexOf('\\')),
+              )
+            : outputFolderOrFile;
           if (dir) saveLastUsedPreset(dir);
         }
 
@@ -599,7 +598,7 @@ export default function ExportPanel({
                     }
                     max={100}
                     min={1}
-                    onChange={(e) => setJpegQuality(parseInt(e.target.value))}
+                    onChange={(e) => setJpegQuality(Number(e.target.value))}
                     step={1}
                     value={jpegQuality}
                     fillOrigin="min"
@@ -729,7 +728,7 @@ export default function ExportPanel({
                               max={50}
                               step={1}
                               value={watermarkScale}
-                              onChange={(e) => setWatermarkScale(parseInt(e.target.value))}
+                              onChange={(e) => setWatermarkScale(Number(e.target.value))}
                               disabled={isExporting}
                               defaultValue={10}
                             />
@@ -739,7 +738,7 @@ export default function ExportPanel({
                               max={25}
                               step={1}
                               value={watermarkSpacing}
-                              onChange={(e) => setWatermarkSpacing(parseInt(e.target.value))}
+                              onChange={(e) => setWatermarkSpacing(Number(e.target.value))}
                               disabled={isExporting}
                               defaultValue={5}
                             />
@@ -749,7 +748,7 @@ export default function ExportPanel({
                               max={100}
                               step={1}
                               value={watermarkOpacity}
-                              onChange={(e) => setWatermarkOpacity(parseInt(e.target.value))}
+                              onChange={(e) => setWatermarkOpacity(Number(e.target.value))}
                               disabled={isExporting}
                               defaultValue={75}
                             />

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -648,7 +648,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
           break;
         }
 
-        const blob = new Blob([imageData], { type: 'image/jpeg' });
+        const blob = new Blob([new Uint8Array(imageData)], { type: 'image/jpeg' });
         const url = URL.createObjectURL(blob);
         setPreviews((prev: Record<string, string | null>) => {
           const oldUrl = prev[preset.id];
@@ -714,7 +714,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
 
         if (pathAtStart !== currentImagePathRef.current) return;
 
-        const blob = new Blob([imageData], { type: 'image/jpeg' });
+        const blob = new Blob([new Uint8Array(imageData)], { type: 'image/jpeg' });
         const url = URL.createObjectURL(blob);
 
         setPreviews((prev: Record<string, string | null>) => {

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -172,6 +172,8 @@ export interface AppSettings {
   enableLivePreviews?: boolean;
   livePreviewQuality?: string;
   enableAiTagging?: boolean;
+  aiTagCount?: number;
+  customAiTags?: string[];
   filterCriteria?: FilterCriteria;
   lastFolderState?: any;
   pinnedFolders?: any;
@@ -209,7 +211,10 @@ export interface AppSettings {
   folderIcons?: Record<string, string>;
   exifOverlay?: ExifOverlay;
   language?: string;
+  fontFamily?: string;
   folderTreeSort?: FolderTreeSort;
+  rootFolders?: string[];
+  taggingShortcuts?: string[];
 }
 
 export interface BrushSettings {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,17 +1,21 @@
 import clsx from 'clsx';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
 
-interface ButtonProps {
-  autoFocus?: boolean;
-  children: any;
-  className?: string;
-  disabled?: boolean;
-  onClick: any;
+interface ButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'size'> {
+  children: ReactNode;
   size?: string;
-  title?: string;
   variant?: string;
 }
 
-const Button = ({ children, onClick, disabled, className = '', ...props }: ButtonProps) => {
+const Button = ({
+  children,
+  onClick,
+  disabled,
+  className = '',
+  size: _size,
+  variant: _variant,
+  ...props
+}: ButtonProps) => {
   const baseClasses = `
     flex items-center justify-center gap-2 
     font-semibold py-2 px-4 rounded-md 

--- a/src/components/ui/LUTControl.tsx
+++ b/src/components/ui/LUTControl.tsx
@@ -154,7 +154,7 @@ export default function LUTControl({
               console.error('Failed to resolve Android URI:', e);
               return path;
             }
-          })
+          }),
         );
         const allowedExtensions = new Set(['cube', '3dl']);
         validPaths = sourcePaths.filter((_, index) => {
@@ -297,7 +297,7 @@ export default function LUTControl({
                 step={1}
                 value={lutIntensity}
                 defaultValue={100}
-                onChange={(e) => onIntensityChange(parseInt(e.target.value, 10))}
+                onChange={(e) => onIntensityChange(Number(e.target.value))}
                 onDragStateChange={onDragStateChange}
                 fillOrigin="min"
               />

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -12,6 +12,7 @@ type SliderChangeEvent =
 
 interface SliderProps {
   defaultValue?: number;
+  disabled?: boolean;
   label: React.ReactNode;
   max: number;
   min: number;
@@ -34,6 +35,7 @@ const hasFineAdjustmentModifier = (event: MouseEvent | TouchEvent | React.MouseE
 
 const Slider = ({
   defaultValue = 0,
+  disabled = false,
   label,
   max,
   min,
@@ -113,7 +115,7 @@ const Slider = ({
     if (!sliderElement) return;
 
     const handleWheel = (event: WheelEvent) => {
-      if (!event.shiftKey) {
+      if (disabled || !event.shiftKey) {
         return;
       }
 
@@ -149,7 +151,7 @@ const Slider = ({
     return () => {
       sliderElement.removeEventListener('wheel', handleWheel);
     };
-  }, [value, min, max, step, onChange, decimalPlaces]);
+  }, [disabled, value, min, max, step, onChange, decimalPlaces]);
 
   // Handle Dragging
   useEffect(() => {
@@ -279,6 +281,8 @@ const Slider = ({
   }, [isEditing]);
 
   const handleReset = () => {
+    if (disabled) return;
+
     const syntheticEvent = {
       target: {
         value: defaultValue,
@@ -288,7 +292,7 @@ const Slider = ({
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (suppressTouchChangeRef.current) {
+    if (disabled || suppressTouchChangeRef.current) {
       return;
     }
 
@@ -299,6 +303,8 @@ const Slider = ({
   };
 
   const handleMouseDown = (e: React.MouseEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
     if (Date.now() - lastUpTime.current < DOUBLE_CLICK_THRESHOLD_MS) {
       e.preventDefault();
       return;
@@ -319,6 +325,8 @@ const Slider = ({
   };
 
   const handleTouchStart = (e: React.TouchEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
     if (e.touches.length === 0) return;
 
     const touch = e.touches[0];
@@ -345,6 +353,8 @@ const Slider = ({
   };
 
   const handleTouchMove = (e: React.TouchEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
     if (isDragging || !pendingTouchRef.current || e.touches.length === 0) return;
 
     const touch = e.touches[0];
@@ -390,10 +400,14 @@ const Slider = ({
   };
 
   const handleValueClick = () => {
+    if (disabled) return;
+
     setIsEditing(true);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
     const textVal = e.target.value;
     if (!/^[0-9.,\-]*$/.test(textVal)) {
       return;
@@ -412,6 +426,8 @@ const Slider = ({
   };
 
   const handleInputCommit = () => {
+    if (disabled) return;
+
     let newValue = parseFloat(inputValue.replace(',', '.'));
     if (isNaN(newValue)) {
       newValue = value;
@@ -428,6 +444,8 @@ const Slider = ({
   };
 
   const handleInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (disabled) return;
+
     if (e.key === 'Enter') {
       handleInputCommit();
       e.currentTarget.blur();
@@ -466,14 +484,14 @@ const Slider = ({
   const numericValue = isNaN(Number(value)) ? 0 : Number(value);
 
   return (
-    <div className="mb-2 group" ref={containerRef}>
+    <div className={`mb-2 group ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`} ref={containerRef}>
       <div className="flex justify-between items-center mb-1">
         <div
-          className={`grid ${typeof label === 'string' ? 'cursor-pointer' : ''}`}
-          onClick={typeof label === 'string' ? handleReset : undefined}
-          onDoubleClick={typeof label === 'string' ? handleReset : undefined}
-          onMouseEnter={typeof label === 'string' ? () => setIsLabelHovered(true) : undefined}
-          onMouseLeave={typeof label === 'string' ? () => setIsLabelHovered(false) : undefined}
+          className={`grid ${typeof label === 'string' && !disabled ? 'cursor-pointer' : ''}`}
+          onClick={typeof label === 'string' && !disabled ? handleReset : undefined}
+          onDoubleClick={typeof label === 'string' && !disabled ? handleReset : undefined}
+          onMouseEnter={typeof label === 'string' && !disabled ? () => setIsLabelHovered(true) : undefined}
+          onMouseLeave={typeof label === 'string' && !disabled ? () => setIsLabelHovered(false) : undefined}
         >
           <span
             aria-hidden={isLabelHovered && typeof label === 'string'}
@@ -498,6 +516,7 @@ const Slider = ({
           {isEditing ? (
             <input
               className="w-full text-sm text-right bg-card-active border border-gray-500 rounded-sm px-1 py-0 outline-none focus:ring-1 focus:ring-blue-500 text-text-primary"
+              disabled={disabled}
               max={max}
               min={min}
               onBlur={handleInputCommit}
@@ -510,9 +529,9 @@ const Slider = ({
             />
           ) : (
             <span
-              className="text-sm text-text-primary w-full text-right select-none cursor-text"
-              onClick={handleValueClick}
-              onDoubleClick={handleReset}
+              className={`text-sm text-text-primary w-full text-right select-none ${disabled ? '' : 'cursor-text'}`}
+              onClick={disabled ? undefined : handleValueClick}
+              onDoubleClick={disabled ? undefined : handleReset}
               data-tooltip={t('ui.slider.clickToEdit')}
             >
               {decimalPlaces > 0 && numericValue === 0 ? '0' : numericValue.toFixed(decimalPlaces)}
@@ -539,7 +558,8 @@ const Slider = ({
           ref={rangeInputRef}
           className={`absolute top-1/2 left-0 w-full h-1.5 appearance-none bg-transparent cursor-pointer m-0 p-0 slider-input z-10 ${
             isDragging ? 'slider-thumb-active' : ''
-          }`}
+          } ${disabled ? 'cursor-not-allowed' : ''}`}
+          disabled={disabled}
           style={{ margin: 0, touchAction: isDragging ? 'none' : 'pan-y' }}
           max={String(max)}
           min={String(min)}

--- a/src/components/ui/Slider.tsx
+++ b/src/components/ui/Slider.tsx
@@ -111,6 +111,29 @@ const Slider = ({
   }, [isDragging, onDragStateChange]);
 
   useEffect(() => {
+    if (!disabled) return;
+
+    pendingTouchRef.current = null;
+    suppressTouchChangeRef.current = false;
+    isWheelActivelyChangingRef.current = false;
+
+    if (wheelTimeoutRef.current !== undefined) {
+      window.clearTimeout(wheelTimeoutRef.current);
+      wheelTimeoutRef.current = undefined;
+    }
+    if (animationFrameRef.current !== undefined) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = undefined;
+    }
+
+    setIsDragging(false);
+    setIsEditing(false);
+    setIsLabelHovered(false);
+    setDisplayValue(value);
+    setInputValue(String(value));
+  }, [disabled, value]);
+
+  useEffect(() => {
     const sliderElement = containerRef.current;
     if (!sliderElement) return;
 
@@ -155,7 +178,7 @@ const Slider = ({
 
   // Handle Dragging
   useEffect(() => {
-    if (!isDragging) return;
+    if (!isDragging || disabled) return;
 
     const inputEl = rangeInputRef.current;
     if (!inputEl) return;
@@ -217,7 +240,7 @@ const Slider = ({
       window.removeEventListener('touchend', handlePointerUp);
       window.removeEventListener('touchcancel', handlePointerUp);
     };
-  }, [isDragging]);
+  }, [disabled, isDragging]);
 
   useEffect(() => {
     if (isDragging) {
@@ -409,7 +432,7 @@ const Slider = ({
     if (disabled) return;
 
     const textVal = e.target.value;
-    if (!/^[0-9.,\-]*$/.test(textVal)) {
+    if (!/^[0-9.,-]*$/.test(textVal)) {
       return;
     }
     setInputValue(textVal);
@@ -426,7 +449,11 @@ const Slider = ({
   };
 
   const handleInputCommit = () => {
-    if (disabled) return;
+    if (disabled) {
+      setInputValue(String(value));
+      setIsEditing(false);
+      return;
+    }
 
     let newValue = parseFloat(inputValue.replace(',', '.'));
     if (isNaN(newValue)) {
@@ -532,7 +559,7 @@ const Slider = ({
               className={`text-sm text-text-primary w-full text-right select-none ${disabled ? '' : 'cursor-text'}`}
               onClick={disabled ? undefined : handleValueClick}
               onDoubleClick={disabled ? undefined : handleReset}
-              data-tooltip={t('ui.slider.clickToEdit')}
+              data-tooltip={disabled ? undefined : t('ui.slider.clickToEdit')}
             >
               {decimalPlaces > 0 && numericValue === 0 ? '0' : numericValue.toFixed(decimalPlaces)}
               {suffix && <span className="text-[10px] align-top inline-block mt-0.5 ml-0.5">{suffix}</span>}

--- a/src/components/views/EditorView.tsx
+++ b/src/components/views/EditorView.tsx
@@ -172,7 +172,7 @@ export default function EditorView({
       onRequestThumbnails={requestThumbnails}
       onZoomChange={handleZoomChange}
       rating={imageRatings[selectedImage?.path || ''] || 0}
-      selectedImage={selectedImage}
+      selectedImage={selectedImage ?? undefined}
       setIsFilmstripVisible={(value: boolean) =>
         setUI((state) => ({ uiVisibility: { ...state.uiVisibility, filmstrip: value } }))
       }

--- a/src/hooks/useImageRenderSize.ts
+++ b/src/hooks/useImageRenderSize.ts
@@ -6,6 +6,8 @@ export interface ImageDimensions {
 }
 
 export interface RenderSize {
+  containerHeight: number;
+  containerWidth: number;
   height: number;
   offsetX: number;
   offsetY: number;
@@ -13,10 +15,18 @@ export interface RenderSize {
   width: number;
 }
 
-const DEFAULT_SIZE: RenderSize = { width: 0, height: 0, scale: 1, offsetX: 0, offsetY: 0 };
+const DEFAULT_SIZE: RenderSize = {
+  width: 0,
+  height: 0,
+  scale: 1,
+  offsetX: 0,
+  offsetY: 0,
+  containerWidth: 0,
+  containerHeight: 0,
+};
 
 export const useImageRenderSize = (
-  containerRef: React.RefObject<HTMLElement>,
+  containerRef: React.RefObject<HTMLElement | null>,
   imageDimensions: ImageDimensions | null,
 ) => {
   const [renderSize, setRenderSize] = useState<RenderSize>(DEFAULT_SIZE);
@@ -48,7 +58,7 @@ export const useImageRenderSize = (
       const offsetX = (containerWidth - width) / 2;
       const offsetY = (containerHeight - height) / 2;
 
-      setRenderSize({ width, height, scale: width / imgWidth, offsetX, offsetY });
+      setRenderSize({ width, height, scale: width / imgWidth, offsetX, offsetY, containerWidth, containerHeight });
     };
 
     updateSize();

--- a/src/store/useEditorStore.ts
+++ b/src/store/useEditorStore.ts
@@ -14,6 +14,13 @@ export interface InteractivePatch {
   normH: number;
 }
 
+interface BaseRenderSize extends ImageDimensions {
+  containerHeight: number;
+  containerWidth: number;
+  offsetX: number;
+  offsetY: number;
+}
+
 interface EditorState {
   // Core Image & Adjustments
   selectedImage: SelectedImage | null;
@@ -43,7 +50,7 @@ interface EditorState {
   zoom: number;
   displaySize: ImageDimensions;
   previewSize: ImageDimensions;
-  baseRenderSize: ImageDimensions;
+  baseRenderSize: BaseRenderSize;
   originalSize: ImageDimensions;
 
   // Tools State
@@ -107,7 +114,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   zoom: 1,
   displaySize: { width: 0, height: 0 },
   previewSize: { width: 0, height: 0 },
-  baseRenderSize: { width: 0, height: 0 },
+  baseRenderSize: { width: 0, height: 0, offsetX: 0, offsetY: 0, containerWidth: 0, containerHeight: 0 },
   originalSize: { width: 0, height: 0 },
 
   isRotationActive: false,

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -30,7 +30,7 @@ export interface ConfirmModalState {
 
 export interface CollageModalState {
   isOpen: boolean;
-  sourceImages: ImageFile[];
+  sourceImages: Array<Pick<ImageFile, 'path'>>;
 }
 
 export interface PanoramaModalState {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,20 @@
 {
   "compilerOptions": {
-    "types": [],
+    "types": ["vite/client"],
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "jsx": "react-jsx",
     "lib": ["dom", "esnext"],
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "noUncheckedSideEffectImports": true,
     "resolveJsonModule": true,
     "rootDir": "./src",
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2025",
+    "target": "es2025"
   },
   "include": ["src"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Description

Align the shared frontend TypeScript contracts with the values RapidRAW already uses at runtime. This is the first of two focused type-cleanup PRs; it reduces the current typecheck surface without bundling the editor/library-specific follow-up.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [x] Build/CI or Dependency update

## Changes Made

- Configure TypeScript for the Vite bundler and load `vite/client` declarations.
- Model render-size, editor-store, settings, icon, button, collage, and slider contracts with their actual runtime shapes.
- Preserve optional mask opacity during cache serialization and guard nullable pointer data.
- Convert invoke byte buffers into valid `BlobPart` values and make existing slider `disabled` props effective.
- When a slider becomes disabled, terminate pending drag, touch, wheel, animation, hover, and numeric-edit state while keeping the displayed value synchronized with its controlled prop.

## Screenshots/Videos

Not applicable; this PR does not intentionally redesign the UI.

## Testing

- [x] I have tested these changes locally and confirmed that they work as expected without issues

- `npm run build` — passed; only the existing large-chunk warning remains.
- `npm run typecheck` — 72 diagnostics, down from 117 on current `main`; the remaining editor/library diagnostics are isolated to the follow-up PR.
- `npx eslint src/components/ui/Slider.tsx` — passed.
- `npx prettier --check src/components/ui/Slider.tsx` — passed.
- Rendered Slider interaction QA — verified reset and pointer changes while enabled; disabled state blocks reset and pointer changes; controlled parent updates remain synchronized; disabling during numeric editing exits the editor; re-enabling restores pointer interaction.
- `git diff --check origin/main...HEAD` — passed.
- Rebase range-diff against current `main` — patch unchanged.

- Revalidated on 2026-07-18 against upstream `main` at `026a78f7`: branch head `ee6c768d` matches the PR head; production build, diff check, Slider ESLint, and Slider Prettier passed; the staged typecheck count remains 72.

**Test Configuration:**

- **OS:** macOS 26.5.2
- **Hardware:** Apple M4 Pro (arm64)

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The changed-file Prettier check currently reports `Editor.tsx` because the newly merged benchmark hunk on `main` is not Prettier-clean. This PR does not change that hunk; the Slider follow-up itself passes targeted Prettier and ESLint checks.

## AI Disclaimer:

- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
