### PR TITLE
Jxl fix

### DIFF
--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, GenericImageView, GrayImage, ImageBuffer, ImageFormat, Luma, imageops};
-use jxl_encoder::{api::quality_to_distance, LosslessConfig, LossyConfig, PixelLayout};
+use jxl_encoder::{api::{calibrated_jxl_quality, quality_to_distance}, LosslessConfig, LossyConfig, PixelLayout};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::Emitter;
@@ -474,7 +474,8 @@ fn encode_image_to_bytes(
                         .map_err(|e| format!("Failed to encode lossless JXL: {}", e))?
                 }
             } else {
-                let distance = quality_to_distance(jpeg_quality as f32);
+                let jxl_quality = calibrated_jxl_quality(jpeg_quality as f32);
+                let distance = quality_to_distance(jxl_quality);
 
                 if has_alpha {
                     let rgba = image.to_rgba8();

--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -8,7 +8,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, GenericImageView, GrayImage, ImageBuffer, ImageFormat, Luma, imageops};
-use jxl_encoder::{api::{calibrated_jxl_quality, quality_to_distance}, LosslessConfig, LossyConfig, PixelLayout};
+use jxl_encoder::{
+    LosslessConfig, LossyConfig, PixelLayout,
+    api::{calibrated_jxl_quality, quality_to_distance},
+};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::Emitter;

--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, GenericImageView, GrayImage, ImageBuffer, ImageFormat, Luma, imageops};
-use jxl_encoder::{LosslessConfig, LossyConfig, PixelLayout};
+use jxl_encoder::{api::quality_to_distance, LosslessConfig, LossyConfig, PixelLayout};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tauri::Emitter;
@@ -474,8 +474,7 @@ fn encode_image_to_bytes(
                         .map_err(|e| format!("Failed to encode lossless JXL: {}", e))?
                 }
             } else {
-                let distance = (100.0 - jpeg_quality as f32) / 10.0;
-                let distance = distance.max(0.01);
+                let distance = quality_to_distance(jpeg_quality as f32);
 
                 if has_alpha {
                     let rgba = image.to_rgba8();


### PR DESCRIPTION
## Description
This change imports api::quality_to_distance from the jxl_encoder crate to replace the hardcoded lines (100.0 - jpeg_quality) / 10.0 clamped at 0.01 with the official conversion function. The previous implementation was flawed because JXL visual distance (Butteraugli metric) is non-linear. File size now drops drastically for the same given quality setting, calibrated to look similar to an identical quality jpg (though will still likely look better for any given size)

Closes: #947

## Type of Change
- [x ] Bug fix

## Changes Made
A few lines in export_processing.rs

## Testing
- [x ] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 11
- **Hardware:** Intel i9-9900, RX9070

## Checklist
- [x ] My code follows the project's code style
- [ x] I haven't added unnecessary AI-generated code comments
- [x ] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [x ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
