### PR TITLE
Fix Thumbnails on Windows

### DIFF
--- a/src/hooks/useTauriListeners.ts
+++ b/src/hooks/useTauriListeners.ts
@@ -104,7 +104,7 @@ export function useTauriListeners({
         const { path, thumbnailPath, rating, is_edited, data } = event.payload;
 
         if (thumbnailPath) {
-          thumbnailBuffer.current[path] = convertFileSrc(thumbnailPath);
+          thumbnailBuffer.current[path] = convertFileSrc(thumbnailPath.replace(/\\/g, '/'));
           refs.current.markGenerated(path);
         } else if (data) {
           thumbnailBuffer.current[path] = data;


### PR DESCRIPTION
## Description
Small follow-up to #1350, it seems like we need some manual trickery for the file paths to work on Windows.

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Normalize the path so Windows can handle it

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## Additional Notes
Closes: #1403 

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [X] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)