### PR TITLE
Improve Library Browsing Performance

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Condvar, Mutex};
 
 use image::{DynamicImage, GrayImage};
 use serde::{Deserialize, Serialize};
+use sysinfo::Disks;
 use tokio::sync::Mutex as TokioMutex;
 use tokio::task::JoinHandle;
 use wgpu::{Texture, TextureView};
@@ -174,4 +175,6 @@ pub struct AppState {
     pub decoded_image_cache: Mutex<DecodedImageCache>,
     pub thumbnail_manager: Arc<ThumbnailManager>,
     pub metadata_manager: Arc<MetadataManager>,
+    pub disks_cache: Mutex<Option<Disks>>,
+    pub disks_cache_refreshing: AtomicBool,
 }

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -101,6 +101,8 @@ pub struct ThumbnailManager {
     pub queue: Mutex<VecDeque<String>>,
     pub cvar: Condvar,
     pub processing_now: Mutex<HashSet<String>>,
+    pub rotational_disk: AtomicBool,
+    pub io_gate: Mutex<()>,
 }
 
 impl ThumbnailManager {
@@ -109,6 +111,8 @@ impl ThumbnailManager {
             queue: Mutex::new(VecDeque::new()),
             cvar: Condvar::new(),
             processing_now: Mutex::new(HashSet::new()),
+            rotational_disk: AtomicBool::new(false),
+            io_gate: Mutex::new(()),
         })
     }
 }

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -390,12 +390,7 @@ pub async fn update_exif_fields(
     .map_err(|e| format!("Task failed: {}", e))?
 }
 
-fn is_rotational_disk(path: &Path) -> bool {
-    let Ok(canonical) = path.canonicalize() else {
-        return false;
-    };
-
-    let disks = Disks::new_with_refreshed_list();
+fn match_disk_kind(disks: &Disks, canonical: &Path) -> Option<bool> {
     let mut best_match: Option<(&Path, bool)> = None;
 
     for disk in disks.list() {
@@ -410,16 +405,41 @@ fn is_rotational_disk(path: &Path) -> bool {
         }
     }
 
-    best_match.map(|(_, is_hdd)| is_hdd).unwrap_or(false)
+    best_match.map(|(_, is_hdd)| is_hdd)
 }
 
 fn update_rotational_disk_flag(path: &str, app_handle: &AppHandle) {
     let state = app_handle.state::<crate::AppState>();
-    let detected_hdd = is_rotational_disk(Path::new(path));
-    state
-        .thumbnail_manager
-        .rotational_disk
-        .store(detected_hdd, Ordering::Relaxed);
+    let Ok(canonical) = Path::new(path).canonicalize() else {
+        return;
+    };
+
+    let cached_match = {
+        let cache = state.disks_cache.lock().unwrap();
+        cache
+            .as_ref()
+            .and_then(|disks| match_disk_kind(disks, &canonical))
+    };
+
+    match cached_match {
+        Some(is_hdd) => {
+            state
+                .thumbnail_manager
+                .rotational_disk
+                .store(is_hdd, Ordering::Relaxed);
+        }
+        None => {
+            if !state.disks_cache_refreshing.swap(true, Ordering::Relaxed) {
+                let refresh_app_handle = app_handle.clone();
+                thread::spawn(move || {
+                    let disks = Disks::new_with_refreshed_list();
+                    let state = refresh_app_handle.state::<crate::AppState>();
+                    *state.disks_cache.lock().unwrap() = Some(disks);
+                    state.disks_cache_refreshing.store(false, Ordering::Relaxed);
+                });
+            }
+        }
+    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -1694,6 +1694,11 @@ fn generate_single_thumbnail_and_cache(
     None
 }
 
+fn prefetch_source_file(path_str: &str) {
+    let (source_path, _) = parse_virtual_path(path_str);
+    let _ = fs::read(&source_path);
+}
+
 pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
     let state = app_handle.state::<crate::AppState>();
     let manager = state.thumbnail_manager.clone();
@@ -1729,10 +1734,10 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                     crate::gpu_processing::get_or_init_gpu_context(&state, &app_clone).ok();
 
                 if let Ok(cache_dir) = get_thumb_cache_dir(&app_clone) {
-                    let _io_permit = manager_clone
-                        .rotational_disk
-                        .load(Ordering::Relaxed)
-                        .then(|| manager_clone.io_gate.lock().unwrap());
+                    if manager_clone.rotational_disk.load(Ordering::Relaxed) {
+                        let _io_permit = manager_clone.io_gate.lock().unwrap();
+                        prefetch_source_file(&path_to_process);
+                    }
 
                     let result = generate_single_thumbnail_and_cache(
                         &path_to_process,

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -9,6 +9,7 @@ use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 use std::thread;
 
 use anyhow::Result;
@@ -16,6 +17,7 @@ use chrono::{DateTime, Utc};
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, GenericImageView, ImageBuffer, Luma};
 use rayon::prelude::*;
+use sysinfo::Disks;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -388,10 +390,44 @@ pub async fn update_exif_fields(
     .map_err(|e| format!("Task failed: {}", e))?
 }
 
+fn is_rotational_disk(path: &Path) -> bool {
+    let Ok(canonical) = path.canonicalize() else {
+        return false;
+    };
+
+    let disks = Disks::new_with_refreshed_list();
+    let mut best_match: Option<(&Path, bool)> = None;
+
+    for disk in disks.list() {
+        let mount_point = disk.mount_point();
+        if canonical.starts_with(mount_point) {
+            let is_longer_match = best_match
+                .map(|(current, _)| mount_point.as_os_str().len() > current.as_os_str().len())
+                .unwrap_or(true);
+            if is_longer_match {
+                best_match = Some((mount_point, disk.kind() == sysinfo::DiskKind::HDD));
+            }
+        }
+    }
+
+    best_match.map(|(_, is_hdd)| is_hdd).unwrap_or(false)
+}
+
+fn update_rotational_disk_flag(path: &str, app_handle: &AppHandle) {
+    let state = app_handle.state::<crate::AppState>();
+    let detected_hdd = is_rotational_disk(Path::new(path));
+    state
+        .thumbnail_manager
+        .rotational_disk
+        .store(detected_hdd, Ordering::Relaxed);
+}
+
 #[tauri::command]
 pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<ImageFile>, String> {
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
+
+    update_rotational_disk_flag(&path, &app_handle);
 
     let entries = fs::read_dir(&path).map_err(|e| e.to_string())?;
     let mut images = Vec::new();
@@ -510,6 +546,8 @@ pub fn list_images_recursive(
 ) -> Result<Vec<ImageFile>, String> {
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
+
+    update_rotational_disk_flag(&path, &app_handle);
 
     let root_path = Path::new(&path);
     let mut images = Vec::new();
@@ -1614,6 +1652,11 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                     crate::gpu_processing::get_or_init_gpu_context(&state, &app_clone).ok();
 
                 if let Ok(cache_dir) = get_thumb_cache_dir(&app_clone) {
+                    let _io_permit = manager_clone
+                        .rotational_disk
+                        .load(Ordering::Relaxed)
+                        .then(|| manager_clone.io_gate.lock().unwrap());
+
                     let result = generate_single_thumbnail_and_cache(
                         &path_to_process,
                         &cache_dir,

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -1726,8 +1726,15 @@ pub fn update_thumbnail_queue(
         queue.pop_front();
     }
 
-    for path in unique_paths {
-        queue.push_back(path);
+    if state.thumbnail_manager.rotational_disk.load(Ordering::Relaxed) {
+        unique_paths.sort();
+        for path in unique_paths.into_iter().rev() {
+            queue.push_back(path);
+        }
+    } else {
+        for path in unique_paths {
+            queue.push_back(path);
+        }
     }
 
     let queue_len = queue.len();

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -17,10 +17,10 @@ use chrono::{DateTime, Utc};
 use image::codecs::jpeg::JpegEncoder;
 use image::{DynamicImage, GenericImageView, ImageBuffer, Luma};
 use rayon::prelude::*;
-use sysinfo::Disks;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sysinfo::Disks;
 use tauri::{AppHandle, Emitter, Manager};
 use uuid::Uuid;
 use walkdir::WalkDir;
@@ -1239,6 +1239,55 @@ pub fn read_file_mapped(path: &Path) -> Result<Mmap, ReadFileError> {
     Ok(mmap)
 }
 
+fn find_embedded_jpeg(exif: &exif::Exif, ifd: exif::In) -> Option<&[u8]> {
+    let offset = exif
+        .get_field(exif::Tag::JPEGInterchangeFormat, ifd)?
+        .value
+        .get_uint(0)? as usize;
+    let len = exif
+        .get_field(exif::Tag::JPEGInterchangeFormatLength, ifd)?
+        .value
+        .get_uint(0)? as usize;
+    exif.buf().get(offset..offset + len)
+}
+
+fn apply_exif_orientation(img: DynamicImage, orientation: u32) -> DynamicImage {
+    match orientation {
+        2 => img.fliph(),
+        3 => img.rotate180(),
+        4 => img.flipv(),
+        5 => img.rotate90().fliph(),
+        6 => img.rotate90(),
+        7 => img.rotate270().fliph(),
+        8 => img.rotate270(),
+        _ => img,
+    }
+}
+
+fn try_load_embedded_raw_preview(source_path: &Path, target_res: u32) -> Option<DynamicImage> {
+    let mmap = read_file_mapped(source_path).ok()?;
+    let exif = exif_processing::read_exif(&mmap)?;
+
+    let (jpeg_bytes, ifd) = find_embedded_jpeg(&exif, exif::In::PRIMARY)
+        .map(|b| (b, exif::In::PRIMARY))
+        .or_else(|| {
+            find_embedded_jpeg(&exif, exif::In::THUMBNAIL).map(|b| (b, exif::In::THUMBNAIL))
+        })?;
+
+    let img = image::load_from_memory_with_format(jpeg_bytes, image::ImageFormat::Jpeg).ok()?;
+
+    if img.width().max(img.height()) < (target_res as f32 * 0.95) as u32 {
+        return None;
+    }
+
+    let orientation = exif
+        .get_field(exif::Tag::Orientation, ifd)
+        .and_then(|f| f.value.get_uint(0))
+        .unwrap_or(1);
+
+    Some(apply_exif_orientation(img, orientation))
+}
+
 pub fn generate_thumbnail_data(
     path_str: &str,
     gpu_context: Option<&GpuContext>,
@@ -1266,6 +1315,14 @@ pub fn generate_thumbnail_data(
     let adjustments = metadata
         .as_ref()
         .map_or(serde_json::Value::Null, |m| m.adjustments.clone());
+
+    if is_raw && adjustments.is_null() && preloaded_image.is_none() {
+        let settings = load_settings(app_handle.clone()).unwrap_or_default();
+        let target_res = settings.thumbnail_resolution.unwrap_or(720);
+        if let Some(preview) = try_load_embedded_raw_preview(&source_path, target_res) {
+            return Ok(preview);
+        }
+    }
 
     if let (Some(context), Some(meta)) = (gpu_context, metadata)
         && !meta.adjustments.is_null()
@@ -1726,7 +1783,11 @@ pub fn update_thumbnail_queue(
         queue.pop_front();
     }
 
-    if state.thumbnail_manager.rotational_disk.load(Ordering::Relaxed) {
+    if state
+        .thumbnail_manager
+        .rotational_disk
+        .load(Ordering::Relaxed)
+    {
         unique_paths.sort();
         for path in unique_paths.into_iter().rev() {
             queue.push_back(path);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2022,6 +2022,16 @@ pub fn run() {
             }
 
             let app_handle = app.handle().clone();
+
+            {
+                let disks_app_handle = app_handle.clone();
+                std::thread::spawn(move || {
+                    let disks = sysinfo::Disks::new_with_refreshed_list();
+                    let state = disks_app_handle.state::<AppState>();
+                    *state.disks_cache.lock().unwrap() = Some(disks);
+                });
+            }
+
             let config_dir = app_handle.path().app_config_dir().expect("Failed to get config dir");
             let crash_flag_path = config_dir.join(".gpu_init_crash_flag");
 
@@ -2303,6 +2313,8 @@ pub fn run() {
             decoded_image_cache: Mutex::new(DecodedImageCache::new(5)),
             thumbnail_manager: ThumbnailManager::new(),
             metadata_manager: MetadataManager::new(),
+            disks_cache: Mutex::new(None),
+            disks_cache_refreshing: AtomicBool::new(false),
         })
         .invoke_handler(tauri::generate_handler![
             apply_adjustments,

--- a/src/components/panel/library/LibraryGrid.tsx
+++ b/src/components/panel/library/LibraryGrid.tsx
@@ -473,6 +473,15 @@ export default function LibraryGrid(props: any) {
     handleToggleRecursiveFolder,
   ]);
 
+  const getItemSize = useCallback(
+    (index: number) => {
+      if (!gridData) return 0;
+      if (gridData.rows[index].type === 'footer') return gridData.isListView ? 24 : gridData.OUTER_PADDING;
+      return gridData.rows[index].type === 'header' ? gridData.headerHeight : gridData.rowHeight;
+    },
+    [gridData],
+  );
+
   if (!gridData) {
     return (
       <div
@@ -483,11 +492,6 @@ export default function LibraryGrid(props: any) {
       />
     );
   }
-
-  const getItemSize = (index: number) => {
-    if (gridData.rows[index].type === 'footer') return gridData.isListView ? 24 : gridData.OUTER_PADDING;
-    return gridData.rows[index].type === 'header' ? gridData.headerHeight : gridData.rowHeight;
-  };
 
   const handleHeaderSort = (key: string) => {
     props.onClearSelection();


### PR DESCRIPTION
## Description
This started as an approach to fix #1391, and then became something a little bigger.
I made a few changes that should greatly improve the library performance, the gains should be the biggest on HDDs, but also apply to SSDs.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [X] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Limit the worker threads for thumbnail loading on spinning disks to just one process
- Load thumbnails in path order, to make better use of sequential performance and lose less to random access
- Load the embedded preview for RAW files if possible to avoid parsing the full RAW unless necessary

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## Additional Notes
The change about embedded previews kinda changes the RapidRAW behaviour. Because we use the thumbnail generated by the camera, there is some processing etc. applied.
That means when actually switching to the image it will look different, because we actually load the RAW on that action.
Personally I think it is more than worth the trade-off for the improved performance and decreased compute effort, however, it could be argued that we should make this a preference, in case people dislike that behaviour.
Please let me know if there are any strong opinions on that, and I can add a preference.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [X] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)