### PR TITLE
Add command palette (Ctrl/Cmd+P) with action search and fuzzy file search

### DIFF
--- a/src/components/modals/AppModals.tsx
+++ b/src/components/modals/AppModals.tsx
@@ -19,6 +19,7 @@ import ConfirmModal from './ConfirmModal';
 import ImportSettingsModal from './ImportSettingsModal';
 import CullingModal from './CullingModal';
 import CollageModal from './CollageModal';
+import CommandPaletteModal from './CommandPaletteModal';
 import { AppSettings, Invokes, AlbumItem, Album, AlbumGroup } from '../ui/AppProperties';
 import { CopyPasteSettings } from '../../utils/adjustments';
 
@@ -54,6 +55,7 @@ export default function AppModals(props: AppModalsProps) {
   );
 
   const {
+    isCommandPaletteOpen,
     isCreateFolderModalOpen,
     isRenameFolderModalOpen,
     isRenameFileModalOpen,
@@ -76,6 +78,7 @@ export default function AppModals(props: AppModalsProps) {
     setUI,
   } = useUIStore(
     useShallow((state) => ({
+      isCommandPaletteOpen: state.isCommandPaletteOpen,
       isCreateFolderModalOpen: state.isCreateFolderModalOpen,
       isRenameFolderModalOpen: state.isRenameFolderModalOpen,
       isRenameFileModalOpen: state.isRenameFileModalOpen,
@@ -322,6 +325,11 @@ export default function AppModals(props: AppModalsProps) {
         onSave={props.handleSaveCollage}
         sourceImages={collageModalState.sourceImages}
         thumbnails={thumbnails}
+      />
+      <CommandPaletteModal
+        isOpen={isCommandPaletteOpen}
+        onClose={() => setUI({ isCommandPaletteOpen: false })}
+        onSelectFile={props.handleImageSelect}
       />
     </>
   );

--- a/src/components/modals/CommandPaletteModal.tsx
+++ b/src/components/modals/CommandPaletteModal.tsx
@@ -1,0 +1,353 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
+import { Image as ImageIcon, Search } from 'lucide-react';
+import Input from '../ui/Input';
+import Text from '../ui/Text';
+import { TextColors, TextVariants, TextWeights } from '../../types/typography';
+import { KEYBIND_DEFINITIONS, KEYBIND_SECTIONS, formatKeyCode } from '../../utils/keyboardUtils';
+import { fuzzyMatch } from '../../utils/fuzzyMatch';
+import { useLibraryStore } from '../../store/useLibraryStore';
+import { useProcessStore } from '../../store/useProcessStore';
+import { useSettingsStore } from '../../store/useSettingsStore';
+import { useUIStore } from '../../store/useUIStore';
+
+const MAX_RESULTS = 100;
+
+type PaletteMode = 'actions' | 'files';
+
+interface ActionEntry {
+  action: string;
+  combo: Array<string> | null;
+  label: string;
+  sectionLabel: string;
+}
+
+type PaletteRow =
+  | { kind: 'search-files'; label: string; positions: Array<number> }
+  | { kind: 'action'; entry: ActionEntry; positions: Array<number> }
+  | { kind: 'file'; name: string; path: string; positions: Array<number> };
+
+interface CommandPaletteModalProps {
+  isOpen: boolean;
+  onClose(): void;
+  onSelectFile(path: string): void;
+}
+
+function rowKey(row: PaletteRow): string {
+  if (row.kind === 'search-files') return 'search-files';
+  if (row.kind === 'action') return `action:${row.entry.action}`;
+  return `file:${row.path}`;
+}
+
+function renderHighlighted(text: string, positions: Array<number>) {
+  if (positions.length === 0) {
+    return text;
+  }
+  const positionSet = new Set(positions);
+  return text.split('').map((char, index) =>
+    positionSet.has(index) ? (
+      <span key={index} className="text-accent">
+        {char}
+      </span>
+    ) : (
+      char
+    ),
+  );
+}
+
+export default function CommandPaletteModal({ isOpen, onClose, onSelectFile }: CommandPaletteModalProps) {
+  const { t } = useTranslation();
+  const [isMounted, setIsMounted] = useState(false);
+  const [show, setShow] = useState(false);
+  const [mode, setMode] = useState<PaletteMode>('actions');
+  const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const { appSettings, osPlatform } = useSettingsStore(
+    useShallow((state) => ({
+      appSettings: state.appSettings,
+      osPlatform: state.osPlatform,
+    })),
+  );
+  const keybindActionRunner = useUIStore((state) => state.keybindActionRunner);
+  const imageList = useLibraryStore((state) => state.imageList);
+  const thumbnails = useProcessStore((state) => state.thumbnails);
+
+  useEffect(() => {
+    if (isOpen) {
+      setMode('actions');
+      setQuery('');
+      setSelectedIndex(0);
+      setIsMounted(true);
+      const timer = setTimeout(() => {
+        setShow(true);
+      }, 10);
+      return () => clearTimeout(timer);
+    } else {
+      setShow(false);
+      const timer = setTimeout(() => {
+        setIsMounted(false);
+      }, 300);
+      return () => clearTimeout(timer);
+    }
+  }, [isOpen]);
+
+  const actionEntries = useMemo<Array<ActionEntry>>(() => {
+    if (!isOpen) {
+      return [];
+    }
+    const userKeybinds = appSettings?.keybinds || {};
+    const sectionLabels = new Map(KEYBIND_SECTIONS.map((section) => [section.id, t(section.label as any)]));
+    return KEYBIND_DEFINITIONS.filter(
+      (def) => def.action !== 'open_command_palette' && keybindActionRunner?.canRun(def.action),
+    ).map((def) => {
+      const userCombo = userKeybinds[def.action];
+      const combo = userCombo !== undefined ? (userCombo.length ? userCombo : null) : def.defaultCombo;
+      return {
+        action: def.action,
+        combo,
+        label: t(def.description as any),
+        sectionLabel: sectionLabels.get(def.section) || '',
+      };
+    });
+  }, [isOpen, appSettings, keybindActionRunner, t]);
+
+  const rows = useMemo<Array<PaletteRow>>(() => {
+    if (!isOpen) {
+      return [];
+    }
+    if (mode === 'actions') {
+      const searchFilesLabel = t('modals.commandPalette.searchFiles');
+      if (!query) {
+        return [
+          { kind: 'search-files', label: searchFilesLabel, positions: [] },
+          ...actionEntries.map((entry) => ({ kind: 'action' as const, entry, positions: [] })),
+        ];
+      }
+      const scored: Array<{ row: PaletteRow; score: number }> = [];
+      const searchFilesMatch = fuzzyMatch(query, searchFilesLabel);
+      if (searchFilesMatch) {
+        scored.push({
+          row: { kind: 'search-files', label: searchFilesLabel, positions: searchFilesMatch.positions },
+          score: searchFilesMatch.score,
+        });
+      }
+      for (const entry of actionEntries) {
+        const match = fuzzyMatch(query, entry.label);
+        if (match) {
+          scored.push({ row: { kind: 'action', entry, positions: match.positions }, score: match.score });
+        }
+      }
+      scored.sort((a, b) => b.score - a.score);
+      return scored.slice(0, MAX_RESULTS).map((item) => item.row);
+    }
+    const files = imageList.map((file) => ({
+      path: file.path,
+      name: file.path.split(/[\\/]/).pop() || file.path,
+    }));
+    if (!query) {
+      return files.slice(0, MAX_RESULTS).map((file) => ({ kind: 'file' as const, ...file, positions: [] }));
+    }
+    const scored: Array<{ row: PaletteRow; score: number }> = [];
+    for (const file of files) {
+      const match = fuzzyMatch(query, file.name);
+      if (match) {
+        scored.push({ row: { kind: 'file', ...file, positions: match.positions }, score: match.score });
+      }
+    }
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, MAX_RESULTS).map((item) => item.row);
+  }, [isOpen, mode, query, actionEntries, imageList, t]);
+
+  const clampedIndex = Math.min(selectedIndex, Math.max(rows.length - 1, 0));
+
+  useEffect(() => {
+    const selected = listRef.current?.querySelector('[data-selected="true"]');
+    selected?.scrollIntoView({ block: 'nearest' });
+  }, [clampedIndex, rows]);
+
+  if (!isMounted) {
+    return null;
+  }
+
+  const backToActions = () => {
+    setMode('actions');
+    setQuery('');
+    setSelectedIndex(0);
+  };
+
+  const executeRow = (row: PaletteRow) => {
+    if (row.kind === 'search-files') {
+      setMode('files');
+      setQuery('');
+      setSelectedIndex(0);
+      return;
+    }
+    onClose();
+    if (row.kind === 'action') {
+      keybindActionRunner?.run(row.entry.action);
+    } else {
+      onSelectFile(row.path);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      e.stopPropagation();
+      if (rows.length === 0) {
+        return;
+      }
+      const delta = e.key === 'ArrowDown' ? 1 : -1;
+      setSelectedIndex((clampedIndex + delta + rows.length) % rows.length);
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      e.nativeEvent.stopImmediatePropagation();
+      const row = rows[clampedIndex];
+      if (row) {
+        executeRow(row);
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      e.nativeEvent.stopImmediatePropagation();
+      if (mode === 'files') {
+        backToActions();
+      } else {
+        onClose();
+      }
+    } else if (e.key === 'Backspace' && mode === 'files' && query === '') {
+      e.preventDefault();
+      backToActions();
+    }
+  };
+
+  return (
+    <div
+      aria-label={t('modals.commandPalette.title')}
+      aria-modal="true"
+      className={`
+        fixed inset-0 flex items-start justify-center z-50 pt-[12vh]
+        bg-black/30 backdrop-blur-xs
+        transition-opacity duration-300 ease-in-out
+        ${show ? 'opacity-100' : 'opacity-0'}
+      `}
+      onClick={onClose}
+      role="dialog"
+    >
+      <div
+        className={`
+          bg-surface rounded-lg shadow-xl w-full max-w-xl overflow-hidden
+          transform transition-all duration-300 ease-out
+          ${show ? 'scale-100 opacity-100 translate-y-0' : 'scale-95 opacity-0 -translate-y-4'}
+        `}
+        onClick={(e: any) => e.stopPropagation()}
+        onKeyDown={handleKeyDown}
+      >
+        <div className="flex items-center gap-2 p-3 border-b border-border-color">
+          <Search size={18} className="text-text-secondary shrink-0" />
+          {mode === 'files' && (
+            <Text
+              variant={TextVariants.small}
+              color={TextColors.secondary}
+              weight={TextWeights.semibold}
+              className="px-2 py-1 bg-bg-primary rounded-md shrink-0"
+            >
+              {t('modals.commandPalette.files')}
+            </Text>
+          )}
+          <Input
+            autoFocus={true}
+            bgClassName="bg-transparent"
+            className="border-none h-8 px-1 focus-visible:ring-0"
+            onChange={(e: any) => {
+              setQuery(e.target.value);
+              setSelectedIndex(0);
+            }}
+            placeholder={
+              mode === 'files' ? t('modals.commandPalette.filePlaceholder') : t('modals.commandPalette.placeholder')
+            }
+            value={query}
+          />
+        </div>
+        <div aria-orientation="vertical" className="max-h-80 overflow-y-auto p-2" ref={listRef} role="listbox">
+          {rows.length === 0 ? (
+            <Text variant={TextVariants.label} color={TextColors.secondary} className="px-3 py-2">
+              {t('modals.commandPalette.noResults')}
+            </Text>
+          ) : (
+            rows.map((row, index) => {
+              const isSelected = index === clampedIndex;
+              return (
+                <button
+                  aria-selected={isSelected}
+                  className={`
+                    w-full text-left px-3 py-2 rounded-md flex items-center gap-3
+                    transition-colors duration-150
+                    ${isSelected ? 'bg-bg-primary' : 'hover:bg-bg-primary'}
+                  `}
+                  data-selected={isSelected}
+                  key={rowKey(row)}
+                  onClick={() => executeRow(row)}
+                  onMouseEnter={() => setSelectedIndex(index)}
+                  role="option"
+                >
+                  {row.kind === 'search-files' && (
+                    <>
+                      <Search size={16} className="text-text-secondary shrink-0" />
+                      <Text variant={TextVariants.label} color={TextColors.primary} className="flex-1 truncate">
+                        {renderHighlighted(row.label, row.positions)}
+                      </Text>
+                    </>
+                  )}
+                  {row.kind === 'action' && (
+                    <>
+                      <Text variant={TextVariants.label} color={TextColors.primary} className="flex-1 truncate">
+                        {renderHighlighted(row.entry.label, row.positions)}
+                      </Text>
+                      <Text variant={TextVariants.small} color={TextColors.secondary} className="shrink-0">
+                        {row.entry.sectionLabel}
+                      </Text>
+                      {row.entry.combo && (
+                        <Text
+                          as="kbd"
+                          variant={TextVariants.small}
+                          color={TextColors.secondary}
+                          weight={TextWeights.semibold}
+                          className="px-2 py-1 font-sans bg-bg-primary border border-border-color rounded-md shrink-0"
+                        >
+                          {row.entry.combo.map((key) => formatKeyCode(key, osPlatform)).join(' + ')}
+                        </Text>
+                      )}
+                    </>
+                  )}
+                  {row.kind === 'file' && (
+                    <>
+                      {thumbnails[row.path] ? (
+                        <img
+                          alt={row.name}
+                          className="w-8 h-8 object-cover rounded shrink-0"
+                          src={thumbnails[row.path]}
+                        />
+                      ) : (
+                        <div className="w-8 h-8 rounded bg-bg-primary flex items-center justify-center shrink-0">
+                          <ImageIcon size={14} className="text-text-secondary" />
+                        </div>
+                      )}
+                      <Text variant={TextVariants.label} color={TextColors.primary} className="flex-1 truncate">
+                        {renderHighlighted(row.name, row.positions)}
+                      </Text>
+                    </>
+                  )}
+                </button>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -347,6 +347,13 @@ export const useKeyboardShortcuts = ({
           s.ui.requestSearchFocus();
         },
       },
+      open_command_palette: {
+        shouldFire: () => true,
+        execute: (e: any, s: any) => {
+          e.preventDefault();
+          s.ui.setUI({ isCommandPaletteOpen: true });
+        },
+      },
       toggle_crop: {
         shouldFire: (s: any) => !!s.editor.selectedImage,
         execute: (e: any, s: any) => {
@@ -532,6 +539,7 @@ export const useKeyboardShortcuts = ({
       const state = getStoreState();
 
       const isModalOpen =
+        state.ui.isCommandPaletteOpen ||
         state.ui.isCreateFolderModalOpen ||
         state.ui.isRenameFolderModalOpen ||
         state.ui.isRenameFileModalOpen ||
@@ -577,8 +585,24 @@ export const useKeyboardShortcuts = ({
       }
     };
 
+    const runnerEvent = { preventDefault: () => {} };
+    useUIStore.getState().setKeybindActionRunner({
+      canRun: (action: string) => {
+        const handler = actions[action];
+        return !!handler && (!handler.shouldFire || handler.shouldFire(getStoreState()));
+      },
+      run: (action: string) => {
+        const handler = actions[action];
+        if (!handler) return;
+        const state = getStoreState();
+        if (handler.shouldFire && !handler.shouldFire(state)) return;
+        handler.execute(runnerEvent, state);
+      },
+    });
+
     window.addEventListener('keydown', handleKeyDown);
     return () => {
+      useUIStore.getState().setKeybindActionRunner(null);
       window.removeEventListener('keydown', handleKeyDown);
     };
   }, [

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1090,6 +1090,14 @@
       "shuffleTooltip": "Bilder mischen",
       "spacing": "Abstand"
     },
+    "commandPalette": {
+      "filePlaceholder": "Dateien nach Namen suchen...",
+      "files": "Dateien",
+      "noResults": "Keine passenden Ergebnisse",
+      "placeholder": "Befehl eingeben...",
+      "searchFiles": "Dateien durchsuchen...",
+      "title": "Befehlspalette"
+    },
     "configurePreset": {
       "cancel": "Abbrechen",
       "includeCropTransform": "Zuschnitt & Form einbeziehen",
@@ -1491,6 +1499,7 @@
         "cycle_zoom": "Zoom durchwechseln (Einpassen, 2x Einpassen, 100%)",
         "delete_selected": "Ausgewählte Datei(en) löschen",
         "focus_search": "Suchfeld fokussieren",
+        "open_command_palette": "Befehlspalette öffnen",
         "open_image": "Ausgewähltes Bild öffnen",
         "open_settings": "Einstellungen öffnen",
         "paste_adjustments": "Kopierte Anpassungen einfügen",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1090,6 +1090,14 @@
       "shuffleTooltip": "Shuffle Images",
       "spacing": "Spacing"
     },
+    "commandPalette": {
+      "filePlaceholder": "Search files by name...",
+      "files": "Files",
+      "noResults": "No matching results",
+      "placeholder": "Type a command...",
+      "searchFiles": "Search files...",
+      "title": "Command palette"
+    },
     "configurePreset": {
       "cancel": "Cancel",
       "includeCropTransform": "Include Crop & Transform",
@@ -1491,6 +1499,7 @@
         "cycle_zoom": "Cycle zoom (Fit, 2x Fit, 100%)",
         "delete_selected": "Delete selected file(s)",
         "focus_search": "Focus search field",
+        "open_command_palette": "Open command palette",
         "open_image": "Open selected image",
         "open_settings": "Open settings",
         "paste_adjustments": "Paste copied adjustments",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1114,6 +1114,14 @@
       "shuffleTooltip": "Mezclar imágenes",
       "spacing": "Espaciado"
     },
+    "commandPalette": {
+      "filePlaceholder": "Buscar archivos por nombre...",
+      "files": "Archivos",
+      "noResults": "Sin resultados coincidentes",
+      "placeholder": "Escribe un comando...",
+      "searchFiles": "Buscar archivos...",
+      "title": "Paleta de comandos"
+    },
     "configurePreset": {
       "cancel": "Cancelar",
       "includeCropTransform": "Incluir recorte y transformación",
@@ -1524,6 +1532,7 @@
         "cycle_zoom": "Alternar zoom (Ajustar, 2x Ajustar, 100%)",
         "delete_selected": "Eliminar archivo(s) seleccionado(s)",
         "focus_search": "Enfocar el campo de búsqueda",
+        "open_command_palette": "Abrir la paleta de comandos",
         "open_image": "Abrir imagen seleccionada",
         "open_settings": "Abrir la configuración",
         "paste_adjustments": "Pegar ajustes copiados",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1114,6 +1114,14 @@
       "shuffleTooltip": "Mélanger les images",
       "spacing": "Espacement"
     },
+    "commandPalette": {
+      "filePlaceholder": "Rechercher des fichiers par nom...",
+      "files": "Fichiers",
+      "noResults": "Aucun résultat correspondant",
+      "placeholder": "Saisir une commande...",
+      "searchFiles": "Rechercher des fichiers...",
+      "title": "Palette de commandes"
+    },
     "configurePreset": {
       "cancel": "Annuler",
       "includeCropTransform": "Inclure Recadrage & Transformation",
@@ -1524,6 +1532,7 @@
         "cycle_zoom": "Faire défiler le zoom (Ajuster, 2x Ajuster, 100%)",
         "delete_selected": "Supprimer le(s) fichier(s) sélectionné(s)",
         "focus_search": "Activer le champ de recherche",
+        "open_command_palette": "Ouvrir la palette de commandes",
         "open_image": "Ouvrir l'image sélectionnée",
         "open_settings": "Ouvrir les paramètres",
         "paste_adjustments": "Coller les ajustements copiés",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1114,6 +1114,14 @@
       "shuffleTooltip": "Rimescola Immagini",
       "spacing": "Spaziatura"
     },
+    "commandPalette": {
+      "filePlaceholder": "Cerca file per nome...",
+      "files": "File",
+      "noResults": "Nessun risultato corrispondente",
+      "placeholder": "Digita un comando...",
+      "searchFiles": "Cerca file...",
+      "title": "Palette dei comandi"
+    },
     "configurePreset": {
       "cancel": "Annulla",
       "includeCropTransform": "Includi Ritaglio e Trasformazione",
@@ -1524,6 +1532,7 @@
         "cycle_zoom": "Ruota zoom (Adatta, Adatta 2x, 100%)",
         "delete_selected": "Elimina file selezionati",
         "focus_search": "Attiva il campo di ricerca",
+        "open_command_palette": "Apri la palette dei comandi",
         "open_image": "Apri immagine selezionata",
         "open_settings": "Apri le impostazioni",
         "paste_adjustments": "Incolla regolazioni copiate",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1088,6 +1088,14 @@
       "shuffleTooltip": "画像をシャッフル",
       "spacing": "間隔"
     },
+    "commandPalette": {
+      "filePlaceholder": "ファイル名で検索...",
+      "files": "ファイル",
+      "noResults": "一致する結果がありません",
+      "placeholder": "コマンドを入力...",
+      "searchFiles": "ファイルを検索...",
+      "title": "コマンドパレット"
+    },
     "configurePreset": {
       "cancel": "キャンセル",
       "includeCropTransform": "切り抜きと変形を含める",
@@ -1489,6 +1497,7 @@
         "cycle_zoom": "ズームの切り替え (全体表示、2倍拡大、100%)",
         "delete_selected": "選択したファイルを削除",
         "focus_search": "検索フィールドにフォーカス",
+        "open_command_palette": "コマンドパレットを開く",
         "open_image": "選択した画像を開く",
         "open_settings": "設定を開く",
         "paste_adjustments": "コピーした補正設定を貼り付け",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1088,6 +1088,14 @@
       "shuffleTooltip": "이미지 섞기",
       "spacing": "간격"
     },
+    "commandPalette": {
+      "filePlaceholder": "파일 이름으로 검색...",
+      "files": "파일",
+      "noResults": "일치하는 결과가 없습니다",
+      "placeholder": "명령 입력...",
+      "searchFiles": "파일 검색...",
+      "title": "명령 팔레트"
+    },
     "configurePreset": {
       "cancel": "취소",
       "includeCropTransform": "자르기 및 변형 포함",
@@ -1489,6 +1497,7 @@
         "cycle_zoom": "확대/축소 순환 (맞춤, 2배 맞춤, 100%)",
         "delete_selected": "선택한 파일 삭제",
         "focus_search": "검색창에 포커스",
+        "open_command_palette": "명령 팔레트 열기",
         "open_image": "선택한 이미지 열기",
         "open_settings": "설정 열기",
         "paste_adjustments": "복사한 조정값 붙여넣기",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1138,6 +1138,14 @@
       "shuffleTooltip": "Tasuj obrazy",
       "spacing": "Odstępy"
     },
+    "commandPalette": {
+      "filePlaceholder": "Szukaj plików po nazwie...",
+      "files": "Pliki",
+      "noResults": "Brak pasujących wyników",
+      "placeholder": "Wpisz polecenie...",
+      "searchFiles": "Szukaj plików...",
+      "title": "Paleta poleceń"
+    },
     "configurePreset": {
       "cancel": "Anuluj",
       "includeCropTransform": "Uwzględnij Kadrowanie i Przekształcanie",
@@ -1557,6 +1565,7 @@
         "cycle_zoom": "Przełącz przybliżenie (Dopasuj, 2x Dopasuj, 100%)",
         "delete_selected": "Usuń wybrane pliki",
         "focus_search": "Przejdź do pola wyszukiwania",
+        "open_command_palette": "Otwórz paletę poleceń",
         "open_image": "Otwórz wybrany obraz",
         "open_settings": "Otwórz ustawienia",
         "paste_adjustments": "Wklej skopiowane ustawienia",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1114,6 +1114,14 @@
       "shuffleTooltip": "Embaralhar Imagens",
       "spacing": "Espaçamento"
     },
+    "commandPalette": {
+      "filePlaceholder": "Pesquisar arquivos por nome...",
+      "files": "Arquivos",
+      "noResults": "Nenhum resultado correspondente",
+      "placeholder": "Digite um comando...",
+      "searchFiles": "Pesquisar arquivos...",
+      "title": "Paleta de comandos"
+    },
     "configurePreset": {
       "cancel": "Cancelar",
       "includeCropTransform": "Incluir Corte e Transformação",
@@ -1524,6 +1532,7 @@
         "cycle_zoom": "Alternar zoom (Caber, 2x Caber, 100%)",
         "delete_selected": "Excluir arquivo(s) selecionado(s)",
         "focus_search": "Focar o campo de pesquisa",
+        "open_command_palette": "Abrir paleta de comandos",
         "open_image": "Abrir imagem selecionada",
         "open_settings": "Abrir configurações",
         "paste_adjustments": "Colar ajustes copiados",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1138,6 +1138,14 @@
       "shuffleTooltip": "Перемешать изображения",
       "spacing": "Интервал"
     },
+    "commandPalette": {
+      "filePlaceholder": "Поиск файлов по имени...",
+      "files": "Файлы",
+      "noResults": "Нет совпадающих результатов",
+      "placeholder": "Введите команду...",
+      "searchFiles": "Поиск файлов...",
+      "title": "Палитра команд"
+    },
     "configurePreset": {
       "cancel": "Отмена",
       "includeCropTransform": "Включить кадрирование и трансформацию",
@@ -1557,6 +1565,7 @@
         "cycle_zoom": "Режимы масштаба (По экрану, 2x, 100%)",
         "delete_selected": "Удалить выбранные файлы",
         "focus_search": "Перейти к полю поиска",
+        "open_command_palette": "Открыть палитру команд",
         "open_image": "Открыть выбранное изображение",
         "open_settings": "Открыть настройки",
         "paste_adjustments": "Вставить скопированные настройки",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1088,6 +1088,14 @@
       "shuffleTooltip": "随机排列图像",
       "spacing": "间距"
     },
+    "commandPalette": {
+      "filePlaceholder": "按名称搜索文件...",
+      "files": "文件",
+      "noResults": "没有匹配的结果",
+      "placeholder": "输入命令...",
+      "searchFiles": "搜索文件...",
+      "title": "命令面板"
+    },
     "configurePreset": {
       "cancel": "取消",
       "includeCropTransform": "包含裁剪与变换",
@@ -1489,6 +1497,7 @@
         "cycle_zoom": "循环缩放（适应、2倍适应、100%）",
         "delete_selected": "删除选中的文件",
         "focus_search": "聚焦搜索框",
+        "open_command_palette": "打开命令面板",
         "open_image": "打开选中的图像",
         "open_settings": "打开设置",
         "paste_adjustments": "粘贴复制的调整",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1088,6 +1088,14 @@
       "shuffleTooltip": "隨機排列影像",
       "spacing": "間距"
     },
+    "commandPalette": {
+      "filePlaceholder": "依名稱搜尋檔案...",
+      "files": "檔案",
+      "noResults": "沒有符合的結果",
+      "placeholder": "輸入命令...",
+      "searchFiles": "搜尋檔案...",
+      "title": "命令面板"
+    },
     "configurePreset": {
       "cancel": "取消",
       "includeCropTransform": "包含裁剪與變換",
@@ -1489,6 +1497,7 @@
         "cycle_zoom": "迴圈縮放（適應、2倍適應、100%）",
         "delete_selected": "刪除選中的檔案",
         "focus_search": "聚焦搜尋框",
+        "open_command_palette": "開啟命令面板",
         "open_image": "開啟選中的影像",
         "open_settings": "開啟設定",
         "paste_adjustments": "貼上複製的調整",

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -99,6 +99,7 @@ interface UIState {
   collapsibleSectionsState: CollapsibleSectionsState;
 
   // Modals & Dialogs
+  isCommandPaletteOpen: boolean;
   isCreateFolderModalOpen: boolean;
   isRenameFolderModalOpen: boolean;
   isRenameFileModalOpen: boolean;
@@ -131,6 +132,13 @@ interface UIState {
   setCustomEscapeHandler: (handler: (() => void) | null) => void;
   searchFocusRequest: number;
   requestSearchFocus: () => void;
+  keybindActionRunner: KeybindActionRunner | null;
+  setKeybindActionRunner: (runner: KeybindActionRunner | null) => void;
+}
+
+export interface KeybindActionRunner {
+  canRun(action: string): boolean;
+  run(action: string): void;
 }
 
 export const useUIStore = create<UIState>((set, get) => ({
@@ -153,6 +161,7 @@ export const useUIStore = create<UIState>((set, get) => ({
   slideDirection: 1,
   collapsibleSectionsState: { basic: true, color: false, curves: true, details: false, effects: false },
 
+  isCommandPaletteOpen: false,
   isCreateFolderModalOpen: false,
   isRenameFolderModalOpen: false,
   isRenameFileModalOpen: false,
@@ -220,4 +229,7 @@ export const useUIStore = create<UIState>((set, get) => ({
 
   searchFocusRequest: 0,
   requestSearchFocus: () => set((state) => ({ searchFocusRequest: state.searchFocusRequest + 1 })),
+
+  keybindActionRunner: null,
+  setKeybindActionRunner: (runner) => set({ keybindActionRunner: runner }),
 }));

--- a/src/utils/fuzzyMatch.ts
+++ b/src/utils/fuzzyMatch.ts
@@ -1,0 +1,48 @@
+export interface FuzzyMatchResult {
+  positions: Array<number>;
+  score: number;
+}
+
+const WORD_SEPARATORS = new Set([' ', '-', '_', '.', '/', '\\', ':']);
+
+/**
+ * Small hand-rolled subsequence matcher in the spirit of fzf. Every character
+ * of the query must appear in the target in order (case-insensitive).
+ * Consecutive matches and matches at the start of a word score higher, so a
+ * query like "imgset" prefers "image_settings" over scattered matches.
+ * Returns null when the query is not a subsequence of the target, otherwise
+ * the score and the matched character positions for highlighting.
+ */
+export function fuzzyMatch(query: string, target: string): FuzzyMatchResult | null {
+  if (!query) {
+    return { positions: [], score: 0 };
+  }
+  const loweredQuery = query.toLowerCase();
+  const loweredTarget = target.toLowerCase();
+  const positions: Array<number> = [];
+  let score = 0;
+  let searchFrom = 0;
+  let previousIndex = -2;
+
+  for (let i = 0; i < loweredQuery.length; i++) {
+    const index = loweredTarget.indexOf(loweredQuery[i], searchFrom);
+    if (index === -1) {
+      return null;
+    }
+    let charScore = 1;
+    if (index === previousIndex + 1) {
+      charScore += 4;
+    }
+    if (index === 0 || WORD_SEPARATORS.has(loweredTarget[index - 1])) {
+      charScore += 6;
+    }
+    score += charScore;
+    positions.push(index);
+    previousIndex = index;
+    searchFrom = index + 1;
+  }
+
+  score += Math.max(0, 8 - positions[0]);
+  score -= loweredTarget.length * 0.01;
+  return { positions, score };
+}

--- a/src/utils/keyboardUtils.ts
+++ b/src/utils/keyboardUtils.ts
@@ -223,6 +223,12 @@ export const KEYBIND_DEFINITIONS: KeybindDefinition[] = [
     defaultCombo: ['ctrl', 'KeyF'],
     section: 'library',
   },
+  {
+    action: 'open_command_palette',
+    description: 'settings.keybinds.actions.open_command_palette',
+    defaultCombo: ['ctrl', 'KeyP'],
+    section: 'library',
+  },
   { action: 'undo', description: 'settings.keybinds.actions.undo', defaultCombo: ['ctrl', 'KeyZ'], section: 'editing' },
   { action: 'redo', description: 'settings.keybinds.actions.redo', defaultCombo: ['ctrl', 'KeyY'], section: 'editing' },
   {


### PR DESCRIPTION
## Description

Implements the command palette proposed in #1414. `Ctrl+P` (`Cmd+P` on macOS) opens an overlay with two levels. The root level lists every keybindable action that applies in the current context, showing each action's current combo. A pinned entry, "Search files...", drills into a fuzzy file search over the current folder. The two-level design keeps the root palette uncluttered instead of mixing dozens of filenames into the action list on the first keystroke.

Design choices, following the plan in the issue since the questions there are still open:

- The palette reads `KEYBIND_DEFINITIONS` plus the user's remaps, so labels and combos stay in sync with Settings > Keybinds automatically, and `open_command_palette` itself is a regular rebindable action that shows up there like any other.
- Actions are filtered by the same `shouldFire` guards the keyboard hub uses, so in the library you only see library-applicable actions and in the editor the editor ones. Execution reuses the exact handler map from `useKeyboardShortcuts` through a small runner registered in the UI store (same pattern as `customEscapeHandler`), so palette execution and keybind execution cannot drift apart.
- Matching is a small hand-rolled fzf-style subsequence scorer (`src/utils/fuzzyMatch.ts`, under 50 lines) with bonuses for consecutive and word-start matches, in keeping with how `computeSortedLibrary` hand-rolls its matching today. No new dependencies.
- File results are ranked and capped at 100, so no virtualization is needed. Matched characters are highlighted, and file rows show the image thumbnail when one is already generated.
- The UI follows `ConfirmModal` (overlay, mount/show transitions, theme variables) and `Dropdown` (list styling). Escape backs out one level (files, then root, then closed), Backspace on an empty query in file mode also goes back, arrows navigate with wraparound, Enter executes.

Opening as a draft while the design questions in #1414 are unanswered. Happy to adjust scope or details, or drop it entirely if a palette is not wanted.

Closes #1414

## Type of Change
- [x] New feature

## Changes Made
- `src/utils/keyboardUtils.ts`: new `open_command_palette` definition (`Ctrl+P`, library section)
- `src/utils/fuzzyMatch.ts` (new): subsequence scorer returning a score plus matched character positions
- `src/store/useUIStore.ts`: `isCommandPaletteOpen` flag and a `keybindActionRunner` slot
- `src/hooks/useKeyboardShortcuts.ts`: handler for the new action, palette flag added to the modal guard, runner registration exposing `canRun`/`run` over the existing handler map
- `src/components/modals/CommandPaletteModal.tsx` (new): the palette itself
- `src/components/modals/AppModals.tsx`: palette registration, wired to `handleImageSelect`
- `src/i18n/locales/*.json`: 7 new keys in all 12 locales

## Screenshots/Videos

Screenshots of the root palette, fuzzy action filtering, and file search mode to follow.

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

Verified in the macOS dev build:
- `Ctrl+P` opens the palette from both library and editor views, and respects the existing modal and input-focus guards
- The root palette filters as you type and executes actions through the real handlers (verified with `toggle_presets`, which is correctly only offered while an image is open)
- "Search files..." enters file mode. Queries narrow live over the folder's image list, the empty result state renders, and Enter opens the selected image in the editor
- Arrow keys move the selection with wraparound and Enter executes the highlighted row
- Escape steps back from file mode to the root palette and closes it from the root. Query and mode reset between opens
- `npm run build` and `prettier --check` pass on the changed files. `tsc`, `eslint` and `i18n:check` outputs were diffed against main and show no new issues (all three already fail on current main)

**Test Configuration:**
- **OS:** macOS 26.5 (Tahoe)
- **Hardware:** Apple M3 Max

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

`Ctrl+P` is currently unbound (`toggle_presets` is bare `P`, and the combo system distinguishes modifiers), so there is no conflict. Android behavior is unchanged since the palette only opens via the keybind. Related groundwork lives in #1413, which touches the same registry; if both land, the later one needs a trivial rebase in `useKeyboardShortcuts.ts` and the locale files.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
