### PR TITLE
Reduce Unnecessary UI Re-Renders

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -609,23 +609,27 @@ fn start_analytics_worker(app_handle: tauri::AppHandle) {
                 job = latest;
             }
 
-            if let Ok(histogram_data) = image_processing::calculate_histogram_from_image(&job.image)
-            {
-                let _ = app_handle.emit(
-                    "histogram-update",
-                    serde_json::json!({ "path": job.path, "data": histogram_data }),
-                );
-            }
+            let histogram_data =
+                image_processing::calculate_histogram_from_image(&job.image).ok();
 
-            if job.compute_waveform
-                && let Ok(waveform_data) = image_processing::calculate_waveform_from_image(
+            let waveform_data = if job.compute_waveform {
+                image_processing::calculate_waveform_from_image(
                     &job.image,
                     job.active_waveform_channel.as_deref(),
                 )
-            {
+                .ok()
+            } else {
+                None
+            };
+
+            if histogram_data.is_some() || waveform_data.is_some() {
                 let _ = app_handle.emit(
-                    "waveform-update",
-                    serde_json::json!({ "path": job.path, "data": waveform_data }),
+                    "analytics-update",
+                    serde_json::json!({
+                        "path": job.path,
+                        "histogram": histogram_data,
+                        "waveform": waveform_data,
+                    }),
                 );
             }
         }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -609,8 +609,7 @@ fn start_analytics_worker(app_handle: tauri::AppHandle) {
                 job = latest;
             }
 
-            let histogram_data =
-                image_processing::calculate_histogram_from_image(&job.image).ok();
+            let histogram_data = image_processing::calculate_histogram_from_image(&job.image).ok();
 
             let waveform_data = if job.compute_waveform {
                 image_processing::calculate_waveform_from_image(

--- a/src/components/panel/FolderTree.tsx
+++ b/src/components/panel/FolderTree.tsx
@@ -30,6 +30,7 @@ import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
 import Text from '../ui/Text';
 import { TEXT_COLOR_KEYS, TextColors, TextVariants, TextWeights } from '../../types/typography';
+import { useShallow } from 'zustand/react/shallow';
 import { useLibraryStore } from '../../store/useLibraryStore';
 import { useSettingsStore } from '../../store/useSettingsStore';
 import { AlbumItem, AlbumGroup, Album, Invokes, FolderTreeSort, SortDirection } from '../ui/AppProperties';
@@ -615,7 +616,12 @@ export default function FolderTree({
   isInstantTransition,
 }: FolderTreeProps) {
   const { t } = useTranslation();
-  const { appSettings, handleSettingsChange } = useSettingsStore();
+  const { appSettings, handleSettingsChange } = useSettingsStore(
+    useShallow((state) => ({
+      appSettings: state.appSettings,
+      handleSettingsChange: state.handleSettingsChange,
+    })),
+  );
   const {
     folderTrees,
     pinnedFolderTrees,
@@ -625,7 +631,18 @@ export default function FolderTree({
     albumTree,
     activeAlbumId,
     expandedAlbumGroups,
-  } = useLibraryStore();
+  } = useLibraryStore(
+    useShallow((state) => ({
+      folderTrees: state.folderTrees,
+      pinnedFolderTrees: state.pinnedFolderTrees,
+      currentFolderPath: state.currentFolderPath,
+      expandedFolders: state.expandedFolders,
+      isTreeLoading: state.isTreeLoading,
+      albumTree: state.albumTree,
+      activeAlbumId: state.activeAlbumId,
+      expandedAlbumGroups: state.expandedAlbumGroups,
+    })),
+  );
 
   const [searchQuery, setSearchQuery] = useState('');
   const [isHovering, setIsHovering] = useState(false);

--- a/src/components/panel/library/LibraryGrid.tsx
+++ b/src/components/panel/library/LibraryGrid.tsx
@@ -4,6 +4,7 @@ import { ChevronUp, ChevronDown } from 'lucide-react';
 import debounce from 'lodash.debounce';
 import { useTranslation } from 'react-i18next';
 import { Row } from './LibraryItems';
+import { useShallow } from 'zustand/react/shallow';
 import { useLibraryStore } from '../../../store/useLibraryStore';
 import { LibraryViewMode, SortDirection, LibraryDisplayMode } from '../../ui/AppProperties';
 import Text from '../../ui/Text';
@@ -173,7 +174,14 @@ export default function LibraryGrid(props: any) {
     thumbnailSizeOptions,
     onThumbnailSizeChange,
   } = props;
-  const { listColumnWidths, setLibrary, sortCriteria, setSortCriteria } = useLibraryStore();
+  const { listColumnWidths, setLibrary, sortCriteria, setSortCriteria } = useLibraryStore(
+    useShallow((state) => ({
+      listColumnWidths: state.listColumnWidths,
+      setLibrary: state.setLibrary,
+      sortCriteria: state.sortCriteria,
+      setSortCriteria: state.setSortCriteria,
+    })),
+  );
   const [gridSize, setGridSize] = useState({ height: 0, width: 0 });
   const [listHandle, setListHandle] = useListCallbackRef();
   const [collapsedRecursiveFolders, setCollapsedRecursiveFolders] = useState<Set<string>>(new Set());

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -27,7 +27,6 @@ import { useExportSettings } from '../../../hooks/useExportSettings';
 import { useOsPlatform } from '../../../hooks/useOsPlatform';
 import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
-import { useShallow } from 'zustand/react/shallow';
 import { useEditorStore } from '../../../store/useEditorStore';
 
 interface ExportPanelProps {
@@ -237,11 +236,7 @@ export default function ExportPanel({
     currentSettingsObject,
   } = useExportSettings();
 
-  const { adjustments } = useEditorStore(
-    useShallow((state) => ({
-      adjustments: state.adjustments,
-    })),
-  );
+  const adjustmentsRef = useRef(useEditorStore.getState().adjustments);
 
   const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
   const initDone = useRef(false);
@@ -392,11 +387,21 @@ export default function ExportPanel({
           : null,
     };
     const format = FILE_FORMATS.find((f: FileFormat) => f.id === fileFormat)?.extensions[0] || 'jpeg';
-    debouncedEstimateSize(pathsToExport, adjustments, selectedImage?.path, exportSettings, format);
-    return () => debouncedEstimateSize.cancel();
+    const runEstimate = () =>
+      debouncedEstimateSize(pathsToExport, adjustmentsRef.current, selectedImage?.path, exportSettings, format);
+
+    runEstimate();
+    const unsubscribe = useEditorStore.subscribe((state) => {
+      adjustmentsRef.current = state.adjustments;
+      runEstimate();
+    });
+
+    return () => {
+      unsubscribe();
+      debouncedEstimateSize.cancel();
+    };
   }, [
     pathsToExport,
-    adjustments,
     selectedImage?.path,
     fileFormat,
     jpegQuality,
@@ -524,7 +529,7 @@ export default function ExportPanel({
           exportSettings,
           outputFormat: selectedFormat.extensions[0],
           currentEditPath: selectedImage?.path || null,
-          currentEditAdjustments: adjustments || null,
+          currentEditAdjustments: adjustmentsRef.current || null,
         });
       }
     } catch (error) {

--- a/src/hooks/useTauriListeners.ts
+++ b/src/hooks/useTauriListeners.ts
@@ -74,9 +74,12 @@ export function useTauriListeners({
       listen('preview-update-uncropped', (event: any) => {
         if (isEffectActive) useEditorStore.getState().setEditor({ uncroppedAdjustedPreviewUrl: event.payload });
       }),
-      listen('histogram-update', (event: any) => {
+      listen('analytics-update', (event: any) => {
         if (isEffectActive && event.payload.path === useEditorStore.getState().selectedImage?.path) {
-          useEditorStore.getState().setEditor({ histogram: event.payload.data });
+          const update: { histogram?: any; waveform?: any } = {};
+          if (event.payload.histogram != null) update.histogram = event.payload.histogram;
+          if (event.payload.waveform != null) update.waveform = event.payload.waveform;
+          useEditorStore.getState().setEditor(update);
         }
       }),
       listen('open-with-file', (event: any) => {
@@ -84,11 +87,6 @@ export function useTauriListeners({
       }),
       listen('external-edit-session', (event: any) => {
         if (isEffectActive) useProcessStore.getState().setProcess({ externalEditSession: event.payload });
-      }),
-      listen('waveform-update', (event: any) => {
-        if (isEffectActive && event.payload.path === useEditorStore.getState().selectedImage?.path) {
-          useEditorStore.getState().setEditor({ waveform: event.payload.data });
-        }
       }),
       listen('thumbnail-progress', (event: any) => {
         if (isEffectActive)


### PR DESCRIPTION
## Description
This PR tackles one issue type, where structures were fully subscribed without any selections. This caused a bunch of re-renders for unrelated UI elements, because the `.subscribe()` call wasn't scoped to relevant changes. E.g. the export panel was being re-rendered on every single adjustment made to the picture, despite not even being visible.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [X] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Remove adjustments from the export panel scope
- Narrow the scope for `FolderTree` and `LibraryGrid`
- Batch waveform and histogram updates into one Tauri call, as they are being calculated at the same time, but both caused one individual re-render instead of rendering once they're both done calculating

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## Additional Notes
I did some profiling with the dev tools and across different interactions I saw the average event-dispatch rate drop from `~1250/s -> ~950/s`. This resulted in both less CPU busy time and more stable frame times.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [X] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)