### PR TITLE
Unload Spinner When Loading Is Done

### DIFF
--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -165,6 +165,7 @@ export default function MainLibrary(props: MainLibraryProps) {
   const [isUpdateAvailable, setIsUpdateAvailable] = useState(false);
   const [latestVersion, setLatestVersion] = useState('');
   const [isBusyDelayed, setIsBusyDelayed] = useState(false);
+  const [isBusyLoaderMounted, setIsBusyLoaderMounted] = useState(false);
   const [isProgressHovered, setIsProgressHovered] = useState(false);
   const isSettingsOpen = useUIStore((state) => state.isSettingsOpen);
 
@@ -261,6 +262,12 @@ export default function MainLibrary(props: MainLibraryProps) {
 
     return () => clearTimeout(timer);
   }, [isBusy]);
+
+  useEffect(() => {
+    if (isBusyDelayed) {
+      setIsBusyLoaderMounted(true);
+    }
+  }, [isBusyDelayed]);
 
   useEffect(() => {
     const compareVersions = (v1: string, v2: string) => {
@@ -511,8 +518,15 @@ export default function MainLibrary(props: MainLibraryProps) {
                 className={`flex items-center gap-2 overflow-hidden transition-all duration-300 whitespace-nowrap ${
                   isBusyDelayed ? 'max-w-xs opacity-100' : 'max-w-0 opacity-0'
                 }`}
+                onTransitionEnd={(e) => {
+                  if (e.propertyName === 'opacity' && !isBusyDelayed) {
+                    setIsBusyLoaderMounted(false);
+                  }
+                }}
               >
-                <Loader2 size={14} className="animate-spin text-text-secondary shrink-0" />
+                {isBusyLoaderMounted && (
+                  <Loader2 size={14} className="animate-spin text-text-secondary shrink-0" />
+                )}
                 <div
                   className={`flex items-center transition-all duration-300 ease-out overflow-hidden ${
                     isProgressHovered && isBusyDelayed && (props.thumbnailProgress?.total ?? 0) > 0

--- a/src/components/panel/editor/EditorToolbar.tsx
+++ b/src/components/panel/editor/EditorToolbar.tsx
@@ -49,6 +49,7 @@ const EditorToolbar = memo(
     const { t } = useTranslation();
     const isAnyLoading = isLoading;
     const [isLoaderVisible, setIsLoaderVisible] = useState(false);
+    const [isLoaderMounted, setIsLoaderMounted] = useState(false);
     const [disableLoaderTransition, setDisableLoaderTransition] = useState(false);
     const hideTimeoutRef = useRef<number | null>(null);
     const prevIsLoadingRef = useRef(isLoading);
@@ -137,6 +138,14 @@ const EditorToolbar = memo(
         if (hideTimeoutRef.current) clearTimeout(hideTimeoutRef.current);
       };
     }, [isAnyLoading, isLoading, isLoaderVisible]);
+
+    useEffect(() => {
+      if (isLoaderVisible) {
+        setIsLoaderMounted(true);
+      } else if (disableLoaderTransition) {
+        setIsLoaderMounted(false);
+      }
+    }, [isLoaderVisible, disableLoaderTransition]);
 
     useEffect(() => {
       if (!isHistoryVisible) return;
@@ -433,8 +442,13 @@ const EditorToolbar = memo(
                   isLoaderVisible ? 'max-w-4 opacity-100 ml-2' : 'max-w-0 opacity-0 ml-0',
                   disableLoaderTransition ? 'transition-none' : 'transition-all duration-300',
                 )}
+                onTransitionEnd={(e) => {
+                  if (e.propertyName === 'opacity' && !isLoaderVisible) {
+                    setIsLoaderMounted(false);
+                  }
+                }}
               >
-                <Loader2 size={12} className="text-text-secondary animate-spin" />
+                {isLoaderMounted && <Loader2 size={12} className="text-text-secondary animate-spin" />}
               </div>
             </div>
 


### PR DESCRIPTION
## Description
I tracked down the root cause for #1301, it seems like the spinners in the header in the library view and in the editor don't actually unload once they're hidden. This causes the web view to constantly re-render even if there is nothing happening on the screen.
After these changes the library view and the editor now sit at ~1% GPU usage while doing nothing, like all the other views in RapidRAW.

Closes: #1301 

## Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Add a conditional for when the spinner is mounted and unmount it when the animation is not visible

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [X] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)