### PR TITLE
Support importing multiple preset files at once

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -243,6 +243,20 @@ pub struct PresetFile {
     pub presets: Vec<PresetItem>,
 }
 
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PresetImportFailure {
+    pub file_name: String,
+    pub error: String,
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct PresetImportResult {
+    pub presets: Vec<PresetItem>,
+    pub failures: Vec<PresetImportFailure>,
+}
+
 #[derive(Debug)]
 pub enum ReadFileError {
     Io(std::io::Error),
@@ -2986,71 +3000,41 @@ pub fn get_or_create_internal_library_root(app_handle: AppHandle) -> Result<Stri
     Ok(library_root.to_string_lossy().to_string())
 }
 
-#[tauri::command]
-pub fn handle_import_presets_from_file(
-    file_path: String,
-    app_handle: AppHandle,
-) -> Result<Vec<PresetItem>, String> {
-    let content =
-        fs::read_to_string(file_path).map_err(|e| format!("Failed to read preset file: {}", e))?;
-    let imported_preset_file: PresetFile = serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse preset file: {}", e))?;
+fn preset_file_display_name(file_path: &str) -> String {
+    Path::new(file_path)
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| file_path.to_string())
+}
 
-    let mut current_presets = load_presets(app_handle.clone())?;
-
-    let mut current_names: HashSet<String> = current_presets
+fn collect_top_level_preset_names(items: &[PresetItem]) -> HashSet<String> {
+    items
         .iter()
         .map(|item| match item {
             PresetItem::Preset(p) => p.name.clone(),
             PresetItem::Folder(f) => f.name.clone(),
         })
-        .collect();
-
-    for mut imported_item in imported_preset_file.presets {
-        let (current_name, _new_id) = match &mut imported_item {
-            PresetItem::Preset(p) => {
-                p.id = Uuid::new_v4().to_string();
-                (p.name.clone(), p.id.clone())
-            }
-            PresetItem::Folder(f) => {
-                f.id = Uuid::new_v4().to_string();
-                for child in &mut f.children {
-                    child.id = Uuid::new_v4().to_string();
-                }
-                (f.name.clone(), f.id.clone())
-            }
-        };
-
-        let mut new_name = current_name.clone();
-        let mut counter = 1;
-        while current_names.contains(&new_name) {
-            new_name = format!("{} ({})", current_name, counter);
-            counter += 1;
-        }
-
-        match &mut imported_item {
-            PresetItem::Preset(p) => p.name = new_name.clone(),
-            PresetItem::Folder(f) => f.name = new_name.clone(),
-        }
-
-        current_names.insert(new_name);
-        current_presets.push(imported_item);
-    }
-
-    save_presets(current_presets.clone(), app_handle)?;
-    Ok(current_presets)
+        .collect()
 }
 
-#[tauri::command]
-pub fn handle_import_legacy_presets_from_file(
-    file_path: String,
-    app_handle: AppHandle,
-) -> Result<Vec<PresetItem>, String> {
-    let content = fs::read_to_string(&file_path)
+fn parse_preset_file(file_path: &str) -> Result<Vec<PresetItem>, String> {
+    let lower_path = file_path.to_lowercase();
+    let is_legacy = lower_path.ends_with(".xmp") || lower_path.ends_with(".lrtemplate");
+
+    if !is_legacy {
+        let content = fs::read_to_string(file_path)
+            .map_err(|e| format!("Failed to read preset file: {}", e))?;
+        let preset_file: PresetFile = serde_json::from_str(&content)
+            .map_err(|e| format!("Failed to parse preset file: {}", e))?;
+        return Ok(preset_file.presets);
+    }
+
+    let content = fs::read_to_string(file_path)
         .map_err(|e| format!("Failed to read legacy preset file: {}", e))?;
 
-    let xmp_content = if file_path.to_lowercase().ends_with(".lrtemplate") {
-        let re = Regex::new(r#"(?s)s.xmp = "(.*)""#).unwrap();
+    let xmp_content = if lower_path.ends_with(".lrtemplate") {
+        let re = Regex::new(r#"(?s)s.xmp = "(.*)""#)
+            .map_err(|e| format!("Regex compilation failed: {}", e))?;
         if let Some(caps) = re.captures(&content) {
             caps.get(1)
                 .map(|m| m.as_str().replace(r#"\""#, r#"""#))
@@ -3063,35 +3047,108 @@ pub fn handle_import_legacy_presets_from_file(
     };
 
     let converted_preset = preset_converter::convert_xmp_to_preset(&xmp_content)?;
+    Ok(vec![PresetItem::Preset(converted_preset)])
+}
+
+fn merge_imported_items(
+    target: &mut Vec<PresetItem>,
+    taken_names: &mut HashSet<String>,
+    imported: Vec<PresetItem>,
+) {
+    for mut imported_item in imported {
+        let original_name = match &mut imported_item {
+            PresetItem::Preset(p) => {
+                p.id = Uuid::new_v4().to_string();
+                p.name.clone()
+            }
+            PresetItem::Folder(f) => {
+                f.id = Uuid::new_v4().to_string();
+                for child in &mut f.children {
+                    child.id = Uuid::new_v4().to_string();
+                }
+                f.name.clone()
+            }
+        };
+
+        let mut new_name = original_name.clone();
+        let mut counter = 1;
+        while taken_names.contains(&new_name) {
+            new_name = format!("{} ({})", original_name, counter);
+            counter += 1;
+        }
+
+        match &mut imported_item {
+            PresetItem::Preset(p) => p.name = new_name.clone(),
+            PresetItem::Folder(f) => f.name = new_name.clone(),
+        }
+
+        taken_names.insert(new_name);
+        target.push(imported_item);
+    }
+}
+
+fn import_preset_file_into_library(
+    file_path: &str,
+    app_handle: AppHandle,
+) -> Result<Vec<PresetItem>, String> {
+    let imported = parse_preset_file(file_path)?;
 
     let mut current_presets = load_presets(app_handle.clone())?;
-
-    let current_names: HashSet<String> = current_presets
-        .iter()
-        .flat_map(|item| match item {
-            PresetItem::Preset(p) => vec![p.name.clone()],
-            PresetItem::Folder(f) => {
-                let mut names = vec![f.name.clone()];
-                names.extend(f.children.iter().map(|c| c.name.clone()));
-                names
-            }
-        })
-        .collect();
-
-    let mut new_name = converted_preset.name.clone();
-    let mut counter = 1;
-    while current_names.contains(&new_name) {
-        new_name = format!("{} ({})", converted_preset.name, counter);
-        counter += 1;
-    }
-
-    let mut final_preset = converted_preset;
-    final_preset.name = new_name;
-
-    current_presets.push(PresetItem::Preset(final_preset));
+    let mut taken_names = collect_top_level_preset_names(&current_presets);
+    merge_imported_items(&mut current_presets, &mut taken_names, imported);
 
     save_presets(current_presets.clone(), app_handle)?;
     Ok(current_presets)
+}
+
+#[tauri::command]
+pub fn handle_import_presets_from_file(
+    file_path: String,
+    app_handle: AppHandle,
+) -> Result<Vec<PresetItem>, String> {
+    import_preset_file_into_library(&file_path, app_handle)
+}
+
+#[tauri::command]
+pub fn handle_import_legacy_presets_from_file(
+    file_path: String,
+    app_handle: AppHandle,
+) -> Result<Vec<PresetItem>, String> {
+    import_preset_file_into_library(&file_path, app_handle)
+}
+
+#[tauri::command]
+pub fn handle_import_presets_from_files(
+    file_paths: Vec<String>,
+    app_handle: AppHandle,
+) -> Result<PresetImportResult, String> {
+    let mut current_presets = load_presets(app_handle.clone())?;
+    let mut taken_names = collect_top_level_preset_names(&current_presets);
+
+    let mut failures: Vec<PresetImportFailure> = Vec::new();
+    let mut library_changed = false;
+
+    for file_path in &file_paths {
+        match parse_preset_file(file_path) {
+            Ok(imported) => {
+                library_changed |= !imported.is_empty();
+                merge_imported_items(&mut current_presets, &mut taken_names, imported);
+            }
+            Err(error) => failures.push(PresetImportFailure {
+                file_name: preset_file_display_name(file_path),
+                error,
+            }),
+        }
+    }
+
+    if library_changed {
+        save_presets(current_presets.clone(), app_handle)?;
+    }
+
+    Ok(PresetImportResult {
+        presets: current_presets,
+        failures,
+    })
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2360,6 +2360,7 @@ pub fn run() {
             file_management::apply_auto_adjustments_to_paths,
             file_management::handle_import_presets_from_file,
             file_management::handle_import_legacy_presets_from_file,
+            file_management::handle_import_presets_from_files,
             file_management::handle_export_presets_to_file,
             file_management::save_community_preset,
             file_management::clear_all_sidecars,

--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -11,7 +11,7 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import { useTranslation } from 'react-i18next';
-import { PresetListType, usePresets, UserPreset } from '../../../hooks/usePresets';
+import { PresetImportFailure, PresetListType, usePresets, UserPreset } from '../../../hooks/usePresets';
 import { useContextMenu } from '../../../context/ContextMenuContext';
 import {
   CopyPlus,
@@ -560,8 +560,7 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
     deleteItem,
     duplicatePreset,
     exportPresetsToFile,
-    importPresetsFromFile,
-    importLegacyPresetsFromFile,
+    importPresetsFromFiles,
     isLoading,
     movePreset,
     overwritePreset,
@@ -1052,21 +1051,18 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
       }
 
       const paths = Array.isArray(selectedPaths) ? selectedPaths : [selectedPaths];
-
-      for (const path of paths) {
-        const isLegacy =
-          path.toLowerCase().endsWith('.xmp') ||
-          path.toLowerCase().endsWith('.lrtemplate');
-          
-        if (isLegacy) {
-          await importLegacyPresetsFromFile(path);
-        } else {
-          await importPresetsFromFile(path);
-        }
+      if (paths.length === 0) {
+        return;
       }
+
+      const { failures } = await importPresetsFromFiles(paths);
 
       setFolderPreviewsGenerated(new Set<string>());
       setPreviews({});
+
+      failures.forEach((failure: PresetImportFailure) =>
+        console.error(`Failed to import ${failure.fileName}: ${failure.error}`),
+      );
     } catch (error) {
       console.error('Failed to import presets:', error);
     }

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -68,6 +68,7 @@ export enum Invokes {
   GetSupportedFileTypes = 'get_supported_file_types',
   HandleExportPresetsToFile = 'handle_export_presets_to_file',
   HandleImportPresetsFromFile = 'handle_import_presets_from_file',
+  HandleImportPresetsFromFiles = 'handle_import_presets_from_files',
   HandleImportLegacyPresetsFromFile = 'handle_import_legacy_presets_from_file',
   ImportFiles = 'import_files',
   InvokeGenerativeReplace = 'invoke_generative_replace',

--- a/src/hooks/usePresets.ts
+++ b/src/hooks/usePresets.ts
@@ -16,6 +16,16 @@ export interface UserPreset {
   preset?: Preset;
 }
 
+export interface PresetImportFailure {
+  fileName: string;
+  error: string;
+}
+
+export interface PresetImportResult {
+  presets: Array<UserPreset>;
+  failures: Array<PresetImportFailure>;
+}
+
 function arrayMove(array: any, from: any, to: any) {
   const newArray = array.slice();
   const [item] = newArray.splice(from, 1);
@@ -601,6 +611,23 @@ export function usePresets(currentAdjustments: Adjustments) {
     [setPresets],
   );
 
+  const importPresetsFromFiles = useCallback(
+    async (filePaths: Array<string>): Promise<PresetImportResult> => {
+      setIsLoading(true);
+      try {
+        const result: PresetImportResult = await invoke(Invokes.HandleImportPresetsFromFiles, { filePaths });
+        setPresets(result.presets);
+        return result;
+      } catch (error) {
+        console.error('Failed to import presets from files:', error);
+        throw error;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [setPresets],
+  );
+
   const exportPresetsToFile = useCallback(async (presetsToExport: Array<any>, filePath: string) => {
     try {
       await invoke(Invokes.HandleExportPresetsToFile, { presetsToExport, filePath });
@@ -618,6 +645,7 @@ export function usePresets(currentAdjustments: Adjustments) {
     duplicatePreset,
     exportPresetsToFile,
     importPresetsFromFile,
+    importPresetsFromFiles,
     importLegacyPresetsFromFile,
     isLoading,
     movePreset,


### PR DESCRIPTION
## Description

Preset import was limited to one file per dialog. This allows selecting several at once, mixing `.rrpreset` and legacy `.xmp`/`.lrtemplate` in the same selection, and collects a per-file result instead of aborting on the first file that fails.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Added `handle_import_presets_from_files`, which reads `presets.json` once, merges every selected file, and writes once, instead of N read/write cycles.
- A file that fails to parse no longer aborts the batch. Failures are collected per file with their reason and returned alongside the updated preset list, then logged by file name.
- Extracted the parse and merge logic into shared helpers. The existing single-file commands delegate to them and keep their signatures.
- Replaced an `unwrap()` on the `.lrtemplate` regex with proper error propagation.

Per review feedback: no toasts and no translation keys. Import failures go to the console in English only, and success stays silent since the new presets appear in the panel.

**Behavior change worth flagging:** legacy `.xmp`/`.lrtemplate` import previously checked new preset names against every preset inside every folder, while `.rrpreset` import checked top-level names only. Sharing one helper meant picking one. It now checks top-level names only, matching `.rrpreset`. Presets inside a folder are namespaced by that folder, so a root-level "Vivid" and "Portraits/Vivid" are no longer treated as a collision - this removes spurious `(1)` suffixes on legacy import.

Nested sub-folders remain out of scope; `PresetFolder.children` is unchanged.

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

Multi-selected four files in one dialog: a `.rrpreset` containing one root preset plus a folder of two children, a `.xmp`, a `.lrtemplate`, and a deliberately truncated `.rrpreset`. All five presets imported, the folder kept both children with working previews, and the corrupt file was logged by name with its parse error:

```
Failed to import corrupt.rrpreset: Failed to parse preset file: EOF while parsing an object at line 5 column 0
```

`cargo fmt -p RapidRAW -- --check` and `cargo clippy --all-targets --all-features -- -D warnings` both pass clean.

**Test Configuration:**
- **OS:** Windows 11

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The two single-file commands are kept registered and working. They are now thin wrappers over the shared helpers.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
