### PR TITLE
Sync WGPU Refreshes

### DIFF
--- a/src/components/panel/Editor.tsx
+++ b/src/components/panel/Editor.tsx
@@ -1100,6 +1100,7 @@ export default function Editor({ onBackToLibrary, onContextMenu, onImageSelect, 
     bgPrimary: [24 / 255, 24 / 255, 24 / 255, 1.0],
     bgSecondary: [35 / 255, 35 / 255, 35 / 255, 1.0],
   });
+  const syncWgpuRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     const rootStyle = getComputedStyle(document.documentElement);
@@ -1128,8 +1129,31 @@ export default function Editor({ onBackToLibrary, onContextMenu, onImageSelect, 
   ]);
 
   useEffect(() => {
+    syncWgpuRef.current();
+  }, [
+    appSettings?.useWgpuRenderer,
+    selectedImage?.isReady,
+    hasRenderedFirstFrame,
+    isCropping,
+    uncroppedAdjustedPreviewUrl,
+    showOriginal,
+    appSettings?.theme,
+    finalPreviewUrl,
+    transformState,
+    imageRenderSize,
+  ]);
+
+  useEffect(() => {
     let isEffectActive = true;
     let isInvoking = false;
+
+    const scheduleSync = () => {
+      if (!isEffectActive || wgpuSyncRef.current !== null) return;
+      wgpuSyncRef.current = requestAnimationFrame(() => {
+        wgpuSyncRef.current = null;
+        syncWgpu();
+      });
+    };
 
     const syncWgpu = () => {
       if (!isEffectActive) return;
@@ -1138,18 +1162,14 @@ export default function Editor({ onBackToLibrary, onContextMenu, onImageSelect, 
       const container = imageContainerRef.current;
 
       if (!container) {
-        if (isEffectActive) {
-          wgpuSyncRef.current = requestAnimationFrame(syncWgpu);
-        }
+        scheduleSync();
         return;
       }
 
       const currentRect = container.getBoundingClientRect();
 
       if (currentRect.width < 10 || currentRect.height < 10) {
-        if (isEffectActive) {
-          wgpuSyncRef.current = requestAnimationFrame(syncWgpu);
-        }
+        scheduleSync();
         return;
       }
 
@@ -1189,10 +1209,8 @@ export default function Editor({ onBackToLibrary, onContextMenu, onImageSelect, 
             .catch(() => { })
             .finally(() => {
               isInvoking = false;
+              scheduleSync();
             });
-        }
-        if (isEffectActive) {
-          wgpuSyncRef.current = requestAnimationFrame(syncWgpu);
         }
         return;
       }
@@ -1255,21 +1273,29 @@ export default function Editor({ onBackToLibrary, onContextMenu, onImageSelect, 
           .catch((err) => console.warn('WGPU Sync Error:', err))
           .finally(() => {
             isInvoking = false;
+            scheduleSync();
           });
-      }
-
-      if (isEffectActive) {
-        wgpuSyncRef.current = requestAnimationFrame(syncWgpu);
       }
     };
 
-    wgpuSyncRef.current = requestAnimationFrame(syncWgpu);
+    syncWgpuRef.current = scheduleSync;
+    syncWgpu();
+
+    const container = imageContainerRef.current;
+    const resizeObserver = new ResizeObserver(scheduleSync);
+    if (container) {
+      resizeObserver.observe(container);
+    }
+    window.addEventListener('resize', scheduleSync);
 
     return () => {
       isEffectActive = false;
       if (wgpuSyncRef.current !== null) {
         cancelAnimationFrame(wgpuSyncRef.current);
+        wgpuSyncRef.current = null;
       }
+      resizeObserver.disconnect();
+      window.removeEventListener('resize', scheduleSync);
     };
   }, []);
 


### PR DESCRIPTION
## Description
I've wanted to tackle that one for some time, but basically this schedules refreshes for WGPU in the editor on certain events, instead of constantly refreshing the view at whatever polling rate.
In my testing this brought the average CPU usage idling in the editor from ~2.5% down to just ~0.6% according to the dev tools.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [X] Performance improvement
- [X] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Schedule WGPU syncs instead of refreshing on every activity

## Testing
- [X] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** CachyOS
- **Hardware:** Ryzen 9, 64 GB RAM, AMD GPU

## Checklist
- [X] My code follows the project's code style
- [X] I haven't added unnecessary AI-generated code comments
- [X] My changes generate no new warnings or errors

## Additional Notes
Related to #1430, which identified the same issue, but I leave it up to @CyberTimon, whether he wants to close it with this PR or adapt the other proposed change as well.

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [X] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)