### PR TITLE
ci: sign and notarize macOS releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,6 +140,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NO_STRIP: ${{ startsWith(inputs.platform, 'ubuntu') }}
+          # Configure these repository secrets before publishing macOS releases.
+          # Tauri signs and notarizes only release builds on macOS runners.
+          APPLE_CERTIFICATE: ${{ inputs.release-id != '' && startsWith(inputs.platform, 'macos') && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ inputs.release-id != '' && startsWith(inputs.platform, 'macos') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ inputs.release-id != '' && startsWith(inputs.platform, 'macos') && secrets.APPLE_SIGNING_IDENTITY || '' }}
+          APPLE_ID: ${{ inputs.release-id != '' && startsWith(inputs.platform, 'macos') && secrets.APPLE_ID || '' }}
+          APPLE_PASSWORD: ${{ inputs.release-id != '' && startsWith(inputs.platform, 'macos') && secrets.APPLE_PASSWORD || '' }}
+          APPLE_TEAM_ID: ${{ inputs.release-id != '' && startsWith(inputs.platform, 'macos') && secrets.APPLE_TEAM_ID || '' }}
         with:
           args: --verbose ${{ inputs.build-args }} ${{ inputs.target != '' && '--target' || ''  }} ${{ inputs.target }}
           assetNamePattern: ${{ steps.patch-release-name.outputs.platform }}


### PR DESCRIPTION
## Description

Adds the Apple signing and notarization environment required by Tauri for published macOS release builds. This is the long-term path to Gatekeeper-compliant releases and official Homebrew Cask eligibility.

## Type of Change
- [x] Build/CI or Dependency update

## Changes Made
- Pass Apple signing and notarization secrets to Tauri only for published macOS release jobs.
- Keep pull-request and non-macOS builds unsigned.

## Testing
- [x] Parsed `.github/workflows/build.yml` as YAML.
- [ ] A release build requires maintainers to configure Apple credentials first.

## Checklist
- [x] My code follows the project's code style.
- [x] My changes generate no new warnings or errors in YAML parsing.

## Additional Notes

Before the next macOS release, configure `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, and `APPLE_TEAM_ID` as repository secrets. Apple Developer Program credentials remain maintainer-controlled.