### PR TITLE
docs: add Homebrew tap scaffold

### DIFF
--- a/packaging/homebrew/Casks/rapidraw.rb
+++ b/packaging/homebrew/Casks/rapidraw.rb
@@ -1,0 +1,21 @@
+cask "rapidraw" do
+  arch arm: "macos-14_aarch64", intel: "macos-15-intel_x64"
+
+  version "1.6.0"
+  sha256 arm:   "badcd5c35b39e57fde91c88b54fd94c89b403db84666beb4c39d6ca9cc5ee826",
+         intel: "3cdf964c5488e00c139dc3d1e1fe639a2c9bf3ef71b6bbe14fc12149aaa3062e"
+
+  url "https://github.com/CyberTimon/RapidRAW/releases/download/v#{version}/02_RapidRAW_v#{version}_#{arch}.dmg"
+  name "RapidRAW"
+  desc "Open-source RAW photo editor"
+  homepage "https://github.com/CyberTimon/RapidRAW"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :ventura
+
+  app "RapidRAW.app"
+end

--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,20 @@
+# Homebrew Tap
+
+This directory contains the RapidRAW Cask for an upstream-maintained Homebrew tap.
+
+## Publishing
+
+1. Create the public repository `CyberTimon/homebrew-rapidraw`.
+2. Copy `Casks/rapidraw.rb` from this directory into that repository.
+3. On each release, update the Cask version and SHA-256 values from the uploaded macOS DMGs.
+
+## Installation
+
+After publishing the tap, users can install RapidRAW with:
+
+```sh
+brew tap CyberTimon/rapidraw
+brew install --cask rapidraw
+```
+
+Until macOS releases are signed and notarized, users may receive a Gatekeeper warning on first launch. The signing and notarization workflow is the long-term solution for official Homebrew Cask inclusion.


### PR DESCRIPTION
## Description

Adds a versioned RapidRAW Cask and publishing instructions for a maintainer-owned `CyberTimon/homebrew-rapidraw` tap. This provides an interim Homebrew installation channel while signed and notarized macOS releases remain the long-term goal.

## Type of Change
- [x] Documentation update

## Changes Made
- Add Cask definition for the current macOS ARM and Intel release assets.
- Document creation and maintenance of an upstream Homebrew tap.
- Document the user-facing Gatekeeper limitation until notarization is enabled.

## Testing
- [x] Validated Cask Ruby syntax.

## Checklist
- [x] My code follows the project's code style.
- [x] My changes generate no new warnings or errors in syntax validation.

## Additional Notes

Maintainers retain ownership of the tap repository and release-update process.