### PR TITLE
Enable white balance picker for WGPU renderer

### DIFF
--- a/src/components/adjustments/Color.tsx
+++ b/src/components/adjustments/Color.tsx
@@ -476,17 +476,12 @@ export default function ColorPanel({
           {!isForMask && toggleWbPicker && (
             <button
               onClick={toggleWbPicker}
-              disabled={isWgpuEnabled}
               className={`p-1.5 rounded-md transition-colors ${
-                isWgpuEnabled
-                  ? 'cursor-not-allowed text-text-secondary hover:bg-transparent'
-                  : isWbPickerActive
-                    ? 'bg-accent text-button-text'
-                    : 'hover:bg-bg-secondary text-text-secondary'
+                isWbPickerActive
+                  ? 'bg-accent text-button-text'
+                  : 'hover:bg-bg-secondary text-text-secondary'
               }`}
-              data-tooltip={
-                isWgpuEnabled ? t('adjustments.color.wbPickerWgpuDisabled') : t('adjustments.color.wbPickerTooltip')
-              }
+              data-tooltip={t('adjustments.color.wbPickerTooltip')}
             >
               <Pipette size={16} />
             </button>

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -1646,7 +1646,8 @@ const ImageCanvas = memo(
 
     const handleWbClick = useCallback(
       (e: any) => {
-        if (!isWbPickerActive || !finalPreviewUrl || !onWbPicked) return;
+        const sampleUrl = selectedImage?.thumbnailUrl || finalPreviewUrl;
+        if (!isWbPickerActive || !sampleUrl || !onWbPicked) return;
 
         const stage = e.target.getStage();
         const pointerPos = getCanvasPointer(stage);
@@ -1662,7 +1663,7 @@ const ImageCanvas = memo(
 
         const img = new Image();
         img.crossOrigin = 'Anonymous';
-        img.src = finalPreviewUrl;
+        img.src = sampleUrl;
 
         img.onload = () => {
           const radius = 5;
@@ -1724,14 +1725,14 @@ const ImageCanvas = memo(
 
           setAdjustments((prev: Adjustments) => ({
             ...prev,
-            temperature: Math.max(-100, Math.min(100, (prev.temperature || 0) + deltaTemp)),
-            tint: Math.max(-100, Math.min(100, (prev.tint || 0) + deltaTint)),
+            temperature: Math.max(-100, Math.min(100, deltaTemp)),
+            tint: Math.max(-100, Math.min(100, deltaTint)),
           }));
 
           onWbPicked();
         };
       },
-      [isWbPickerActive, finalPreviewUrl, imageRenderSize, onWbPicked, setAdjustments, getCanvasPointer],
+      [isWbPickerActive, selectedImage?.thumbnailUrl, finalPreviewUrl, imageRenderSize, onWbPicked, setAdjustments, getCanvasPointer],
     );
 
     const handleStart = useCallback(


### PR DESCRIPTION
## Description
This change enables the use of the WB picker when WGPU acceleration is enabled.

I also noticed an unexpected behaviour where the picker doesn't use the source image, but instead uses the image in its current form, repeatedly clicking on a spot causes the image to drift to extreme colour temperatures instead of just setting the white balance.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
<!-- List the specific changes made in this PR -->
- Remove WGPU restriction from white balance pipette button in Color.tsx
- Sample from unadjusted thumbnail source (selectedImage.thumbnailUrl) in ImageCanvas.tsx
- Set target white balance values directly instead of accumulating incremental deltas 

## Screenshots/Videos
<!-- If applicable, add screenshots or videos to demonstrate UI changes -->

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Windows 11
- **Hardware:** AMD Ryzen 9 7950X / NVIDIA RTX 4080

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
<!-- Add any additional information that reviewers should know -->

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [x] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

