### PR TITLE
ci: add name to release asset name patch step for readability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,8 @@ jobs:
         if: ${{ inputs.target != '' }}
         run: rustup target add ${{ inputs.target }}
 
-      - id: patch-release-name
+      - name: Patch release asset name pattern
+        id: patch-release-name
         shell: bash
         if: ${{ inputs.release-id != '' }}
         run: |


### PR DESCRIPTION
## Problem

In `.github/workflows/build.yml`, the `patch-release-name` step is an unnamed `run` block longer than **300 characters**. In the GitHub Actions UI that collapses into a generic label, which hurts readability when release asset naming fails.

## Changes

Semantics are unchanged: same `id: patch-release-name`, same `if` condition, same `platform` output, and the same step output wiring used by later build/upload steps.

- Add `name: Patch release asset name pattern` to the existing `patch-release-name` step

## Test plan
- [ ] Confirm `steps.patch-release-name.outputs.platform` is still consumed by tauri-action / Android asset prep
- [ ] Confirm the platform replacement script is unchanged
