### PR TITLE
fix for issue 1439: preserve linear RAW data during denoising

### DIFF
--- a/src-tauri/src/denoising.rs
+++ b/src-tauri/src/denoising.rs
@@ -312,13 +312,12 @@ fn denoise_image(
     let _ = app_handle.emit("denoise-progress", "Loading image...");
 
     let file_bytes = fs::read(path).map_err(|e| e.to_string())?;
-    let mut dynamic_img =
+    let dynamic_img =
         load_base_image_from_bytes(&file_bytes, &path_str, false, &settings, None)
             .map_err(|e| e.to_string())?;
 
     if is_raw {
         let _ = app_handle.emit("denoise-progress", "Preparing RAW data...");
-        apply_cpu_default_raw_processing(&mut dynamic_img);
     }
 
     let rgb_img_for_denoiser = dynamic_img.to_rgb32f();
@@ -339,25 +338,35 @@ fn denoise_image(
     let _ = app_handle.emit("denoise-progress", "Finalizing data...");
     let _ = app_handle.emit("denoise-progress", "Generating previews...");
 
-    let (w, h) = out_dynamic.dimensions();
-    let (new_w, new_h) = if w > h {
-        if w > 4000 {
-            (4000, (4000.0 * h as f32 / w as f32).round() as u32)
+    let (width, height) = out_dynamic.dimensions();
+    let (new_width, new_height) = if width > height {
+        if width > 4000 {
+            (4000, (4000.0 * height as f32 / width as f32).round() as u32)
         } else {
-            (w, h)
+            (width, height)
         }
     } else {
-        if h > 4000 {
-            ((4000.0 * w as f32 / h as f32).round() as u32, 4000)
+        if height > 4000 {
+            ((4000.0 * width as f32 / height as f32).round() as u32, 4000)
         } else {
-            (w, h)
+            (width, height)
         }
     };
 
-    let denoised_preview = if new_w != w {
-        out_dynamic.resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
+    let mut denoised_preview_source = out_dynamic.clone();
+
+    if is_raw {
+        apply_cpu_default_raw_processing(&mut denoised_preview_source);
+    }
+
+    let denoised_preview = if new_width != width {
+        denoised_preview_source.resize(
+            new_width,
+            new_height,
+            image::imageops::FilterType::Lanczos3,
+        )
     } else {
-        out_dynamic.clone()
+        denoised_preview_source
     };
 
     let mut buf_denoised = Cursor::new(Vec::new());
@@ -368,9 +377,14 @@ fn denoise_image(
     let base64_str_denoised = general_purpose::STANDARD.encode(buf_denoised.get_ref());
     let data_url_denoised = format!("data:image/png;base64,{}", base64_str_denoised);
 
-    let original_dynamic = DynamicImage::ImageRgb32F(rgb_img_for_denoiser);
-    let original_preview = if new_w != w {
-        original_dynamic.resize(new_w, new_h, image::imageops::FilterType::Lanczos3)
+    let mut original_dynamic =
+        DynamicImage::ImageRgb32F(rgb_img_for_denoiser);
+
+    if is_raw {
+        apply_cpu_default_raw_processing(&mut original_dynamic);
+    }
+    let original_preview = if new_width != width {
+        original_dynamic.resize(new_width, new_height, image::imageops::FilterType::Lanczos3)
     } else {
         original_dynamic
     };


### PR DESCRIPTION
This fixes issue https://github.com/CyberTimon/RapidRAW/issues/1439.

Do not apply the default RAW rendering before denoising. Instead, apply the preview gamma/contrast processing only to the preview images, keeping the denoised image linear for export.

## Description
Keep the RAW denoising pipeline in linear RGB by removing the default RAW preview rendering from the denoising input, which is like denoising an already finished image. The gamma and contrast adjustments are now applied only when generating previews, while the exported image (in this case, TIFF) retains the linear denoised image. This prevents baked-in shadow and highlight clipping and preserves the editing latitude of denoised RAW exports.

I also changed the variable names from single-letter variables to words, since there is no shortage of letters in our time anymore ;) But in all seriousness, it makes the code easier to read and write.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Keep the RAW denoising pipeline in linear RGB.
- Apply the default RAW rendering only when generating previews.
- Preserve the linear denoised image for TIFF export.
- Prevent preview rendering from clipping shadow and highlight data in exported images.
- Rename several local variables to improve code readability and maintainability.

## Screenshots/Videos
### Before
Original:
<img width="372" height="255" alt="image" src="https://github.com/user-attachments/assets/1b7e6c92-17f5-46b2-bec1-c663af3edf13" />
Denoised:
<img width="365" height="257" alt="image" src="https://github.com/user-attachments/assets/0743d6d6-dd56-4b10-bd6d-915d30604a84" />
### With fix implemened
Original:
<img width="298" height="190" alt="image" src="https://github.com/user-attachments/assets/932ebcc3-106a-4a36-9d4d-3d72859c5319" />
Denoised:
<img width="298" height="190" alt="image" src="https://github.com/user-attachments/assets/24346798-c031-426c-b165-debb484f2e6b" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Arch Linux 7.1.5-arch1-2
- **Hardware:** AMD Ryzen 7 9800X3D, AMD Radeon RX 9070

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [x] This PR contains only blood, sweat, and coffee (AI-free)
