### PR TITLE
Allow for multiple presets to be imported.

### DIFF
--- a/src/components/panel/right/PresetsPanel.tsx
+++ b/src/components/panel/right/PresetsPanel.tsx
@@ -1037,29 +1037,36 @@ export default function PresetsPanel({ onNavigateToCommunity }: PresetsPanelProp
 
   const handleImportPresets = async () => {
     try {
-      const selectedPath = await openDialog({
+      const selectedPaths = await openDialog({
         filters: [
           { name: t('editor.presets.dialog.allPresetFiles'), extensions: ['rrpreset', 'xmp', 'lrtemplate'] },
           { name: t('editor.presets.dialog.rapidRawPreset'), extensions: ['rrpreset'] },
           { name: t('editor.presets.dialog.legacyPreset'), extensions: ['xmp', 'lrtemplate'] },
         ],
-        multiple: false,
+        multiple: true,
         title: t('editor.presets.dialog.importPresetsTitle'),
       });
 
-      if (typeof selectedPath === 'string') {
-        const isLegacy =
-          selectedPath.toLowerCase().endsWith('.xmp') || selectedPath.toLowerCase().endsWith('.lrtemplate');
-
-        if (isLegacy) {
-          await importLegacyPresetsFromFile(selectedPath);
-        } else {
-          await importPresetsFromFile(selectedPath);
-        }
-
-        setFolderPreviewsGenerated(new Set<string>());
-        setPreviews({});
+      if (!selectedPaths) {
+        return;
       }
+
+      const paths = Array.isArray(selectedPaths) ? selectedPaths : [selectedPaths];
+
+      for (const path of paths) {
+        const isLegacy =
+          path.toLowerCase().endsWith('.xmp') ||
+          path.toLowerCase().endsWith('.lrtemplate');
+          
+        if (isLegacy) {
+          await importLegacyPresetsFromFile(path);
+        } else {
+          await importPresetsFromFile(path);
+        }
+      }
+
+      setFolderPreviewsGenerated(new Set<string>());
+      setPreviews({});
     } catch (error) {
       console.error('Failed to import presets:', error);
     }


### PR DESCRIPTION
## Description
I modified `const handleImportPresets` as discussed in https://github.com/CyberTimon/RapidRAW/discussions/832 so that the user is now able to import multiple presets at once.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made
- Most notably: Added a for loop and changed "multiple: false".

## Screenshots/Videos
<img width="1043" height="679" alt="image" src="https://github.com/user-attachments/assets/d6868171-756c-4ec8-a185-a8482a95c819" />
<img width="349" height="540" alt="image" src="https://github.com/user-attachments/assets/c8ec98d3-4e6e-4379-9097-a8669535774b" />

## Testing
- [x] I have tested these changes locally and confirmed that they work as expected without issues

**Test Configuration:**
- **OS:** Arch Linux 7.1.5-arch1-1
- **Hardware:** AMD Ryzen 7 9800X3D; AMD Radeon RX 9070

## Checklist
- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes
This feature was previously briefly discussed in https://github.com/CyberTimon/RapidRAW/discussions/832.
## AI Disclaimer:
Please state the involvement of AI in this PR:
- [ ] This PR is entirely AI-generated
- [ ] This PR is AI-generated but guided by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [x] This PR contains only blood, sweat, and coffee (AI-free)
