### PR TITLE
Enable no-unnecessary-condition lint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ const react = require('eslint-plugin-react');
 const i18next = require('eslint-plugin-i18next');
 
 const tsFiles = ['**/*.{ts,tsx}'];
+const noUnnecessaryConditionErrorFiles = ['src/hooks/useSortedLibrary.ts'];
 
 const jsRecommendedForTs = {
   ...js.configs.recommended,
@@ -40,6 +41,7 @@ module.exports = [
         ecmaFeatures: {
           jsx: true,
         },
+        projectService: true,
       },
     },
     settings: {
@@ -48,6 +50,7 @@ module.exports = [
       },
     },
     rules: {
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
       'no-unused-vars': 'off',
       '@typescript-eslint/no-unused-vars': [
         'warn',
@@ -78,6 +81,12 @@ module.exports = [
           ],
         },
       ],
+    },
+  },
+  {
+    files: noUnnecessaryConditionErrorFiles,
+    rules: {
+      '@typescript-eslint/no-unnecessary-condition': 'error',
     },
   },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,9 @@ module.exports = [
         ecmaFeatures: {
           jsx: true,
         },
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['i18next.config.ts'],
+        },
       },
     },
     settings: {

--- a/src/hooks/useSortedLibrary.ts
+++ b/src/hooks/useSortedLibrary.ts
@@ -142,7 +142,7 @@ export function computeGroupedLibrary(libraryState: any, settingsState: any): Gr
     if (!isSearchActive) return true;
 
     const lowerCaseImageTags = (image.tags || []).map((t) => t.toLowerCase().replace('user:', ''));
-    const filename = image?.path?.split(/[\\/]/)?.pop()?.toLowerCase() || '';
+    const filename = image.path.split(/[\\/]/).pop()?.toLowerCase() || '';
 
     let tagsMatch = true;
     if (parsedTags.length > 0) {


### PR DESCRIPTION
## Summary

| Change | Details |
| --- | --- |
| Enable typed lint rule | Enables `@typescript-eslint/no-unnecessary-condition` as a warning. |
| Error enforcement | Adds `src/hooks/useSortedLibrary.ts` to the error-enforced file list. |
| Remove redundant checks | Removes unnecessary chaining from `ImageFile.path` and `split()`. |
| Root config support | Allows `i18next.config.ts` in the TypeScript project service. |

## Remaining warnings

| Warning type | Count |
| --- | ---: |
| Unnecessary optional chain | 149 |
| Always-truthy conditional | 147 |
| Unnecessary `??` fallback | 101 |
| Always-falsy conditional | 47 |
| Types have no overlap | 10 |
| Always-true literal comparison | 4 |
| **Total** | **458** |

## Validation

- Production build: passes
- Changed-file formatting: passes
- Selected file: zero `no-unnecessary-condition` findings
- Full lint/typecheck/i18n checks still report pre-existing repository issues outside this change
