### PR TITLE
style: align folder image counts

### DIFF
--- a/src/components/panel/right/FolderTree.tsx
+++ b/src/components/panel/right/FolderTree.tsx
@@ -363,22 +363,23 @@ function AlbumTreeNode({
           </AnimatePresence>
         </div>
 
-        <span onDoubleClick={() => isGroup && onToggle(item.id)} className="truncate flex-1 select-none">
-          <span className="truncate">{item.name}</span>
-          {imageCount > 0 && (
-            <Text
-              as="span"
-              variant={TextVariants.small}
-              color={TextColors.secondary}
-              className={clsx(
-                'inline-block ml-1 transition-all ease-in-out duration-300',
-                showImageCounts ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-2',
-              )}
-            >
-              ({imageCount})
-            </Text>
-          )}
+        <span onDoubleClick={() => isGroup && onToggle(item.id)} className="min-w-0 flex-1 select-none">
+          <span className="block truncate">{item.name}</span>
         </span>
+
+        {imageCount > 0 && (
+          <Text
+            as="span"
+            variant={TextVariants.small}
+            color={TextColors.secondary}
+            className={clsx(
+              'ml-auto min-w-8 shrink-0 text-right tabular-nums transition-opacity ease-in-out duration-300',
+              showImageCounts ? 'opacity-100' : 'opacity-0',
+            )}
+          >
+            {imageCount}
+          </Text>
+        )}
 
         {isGroup && (
           <div
@@ -391,6 +392,7 @@ function AlbumTreeNode({
             {isExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
           </div>
         )}
+        {!isGroup && <div className="w-5 h-5 shrink-0" aria-hidden="true" />}
       </div>
 
       <AnimatePresence>
@@ -524,22 +526,23 @@ function TreeNode({
           </AnimatePresence>
         </div>
 
-        <span onDoubleClick={handleNameDoubleClick} className="truncate select-none flex-1">
-          <span className="truncate">{node.name}</span>
-          {typeof node.imageCount === 'number' && node.imageCount > 0 && (
-            <Text
-              as="span"
-              variant={TextVariants.small}
-              color={TextColors.secondary}
-              className={clsx(
-                'inline-block ml-1 transition-all ease-in-out duration-300',
-                showImageCounts ? 'opacity-100 translate-x-0' : 'opacity-0 translate-x-2',
-              )}
-            >
-              ({node.imageCount})
-            </Text>
-          )}
+        <span onDoubleClick={handleNameDoubleClick} className="min-w-0 flex-1 select-none">
+          <span className="block truncate">{node.name}</span>
         </span>
+
+        {typeof node.imageCount === 'number' && node.imageCount > 0 && (
+          <Text
+            as="span"
+            variant={TextVariants.small}
+            color={TextColors.secondary}
+            className={clsx(
+              'ml-auto min-w-8 shrink-0 text-right tabular-nums transition-opacity ease-in-out duration-300',
+              showImageCounts ? 'opacity-100' : 'opacity-0',
+            )}
+          >
+            {node.imageCount}
+          </Text>
+        )}
 
         {hasChildren && (
           <Text
@@ -551,6 +554,7 @@ function TreeNode({
             {isExpanded ? <ChevronUp size={16} className="shrink-0" /> : <ChevronDown size={16} className="shrink-0" />}
           </Text>
         )}
+        {!hasChildren && <div className="w-5 h-5 shrink-0" aria-hidden="true" />}
       </div>
 
       <AnimatePresence initial={false}>


### PR DESCRIPTION
## Description

Improves the readability of existing folder and album image counts by placing them in a consistent right-aligned column and removing the surrounding parentheses. The counting logic and hover preference are unchanged.

Related to #1433.

## Type of Change

- [x] UI/UX improvement

## Changes Made

- Move folder and album image counts out of the inline name text into a right-aligned column.
- Use tabular numerals and reserve disclosure-control space so counts align across parent and leaf rows.
- Remove parentheses and retain the existing muted color and hover behavior.

## Screenshots/Videos

Current view before change:

<img width="330" height="526" alt="FileCounts-current" src="https://github.com/user-attachments/assets/76a48911-dfde-4ba6-8f46-b4132e283c8e" />

New layout:

<img width="311" height="533" alt="FileCounts-new" src="https://github.com/user-attachments/assets/51dd01fe-2206-422d-b521-ba6a42a1aff1" />


## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.4
- **Hardware:** Apple M5 Pro

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [x] This PR was handwritten with AI assistance
