### PR TITLE
feat: add auto straighten to crop tools

### DIFF
--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -1,8 +1,10 @@
 use crate::gpu_processing::WgpuDisplay;
 use bytemuck::{Pod, Zeroable};
 use glam::{Mat3, Vec2, Vec3};
-use image::{DynamicImage, GenericImageView, Rgb32FImage, Rgba};
+use image::{DynamicImage, GenericImageView, GrayImage, Rgb32FImage, Rgba};
+use imageproc::edges::canny;
 use imageproc::geometric_transformations::{Border, Interpolation, rotate_about_center};
+use imageproc::hough::{LineDetectionOptions, detect_lines};
 use nalgebra::{Matrix3 as NaMatrix3, Vector3 as NaVector3};
 use rawler::decoders::Orientation;
 use rayon::prelude::*;
@@ -3411,6 +3413,179 @@ pub fn auto_results_to_json(results: &AutoAdjustmentResults) -> serde_json::Valu
     })
 }
 
+#[derive(Clone, Copy)]
+struct StraightenCandidate {
+    correction: f32,
+    support: f32,
+}
+
+fn axis_offset(angle: f32) -> f32 {
+    (angle + 45.0).rem_euclid(90.0) - 45.0
+}
+
+fn line_candidate(
+    edges: &GrayImage,
+    angle_degrees: f32,
+    radius: f32,
+) -> Option<StraightenCandidate> {
+    let width = edges.width() as f32;
+    let height = edges.height() as f32;
+    let margin = (width.min(height) * 0.03).max(3.0);
+    let theta = angle_degrees.to_radians();
+    let normal = (theta.cos(), theta.sin());
+    let direction = (-normal.1, normal.0);
+    let origin = (normal.0 * radius, normal.1 * radius);
+    let distance = width.hypot(height);
+    let mut points = Vec::new();
+    let mut previous = (-1, -1);
+    let steps = (distance * 2.0).ceil() as i32;
+
+    for step in 0..=steps {
+        let t = step as f32 - distance;
+        let x = origin.0 + direction.0 * t;
+        let y = origin.1 + direction.1 * t;
+        if x < margin || y < margin || x >= width - margin || y >= height - margin {
+            continue;
+        }
+
+        let mut edge_point = None;
+        for offset in -2..=2 {
+            let sample_x = (x + normal.0 * offset as f32).round() as i32;
+            let sample_y = (y + normal.1 * offset as f32).round() as i32;
+            if sample_x >= 0
+                && sample_y >= 0
+                && sample_x < edges.width() as i32
+                && sample_y < edges.height() as i32
+                && edges.get_pixel(sample_x as u32, sample_y as u32)[0] > 0
+            {
+                edge_point = Some((sample_x, sample_y));
+                break;
+            }
+        }
+
+        if let Some(point) = edge_point
+            && point != previous
+        {
+            points.push((point.0 as f32, point.1 as f32));
+            previous = point;
+        }
+    }
+
+    let min_support = (width.min(height) * 0.1).max(24.0) as usize;
+    if points.len() < min_support {
+        return None;
+    }
+
+    let count = points.len() as f32;
+    let mean_x = points.iter().map(|point| point.0).sum::<f32>() / count;
+    let mean_y = points.iter().map(|point| point.1).sum::<f32>() / count;
+    let (xx, xy, yy) = points.iter().fold((0.0, 0.0, 0.0), |acc, point| {
+        let x = point.0 - mean_x;
+        let y = point.1 - mean_y;
+        (acc.0 + x * x, acc.1 + x * y, acc.2 + y * y)
+    });
+    let line_angle = 0.5 * (2.0 * xy).atan2(xx - yy).to_degrees();
+    let correction = -axis_offset(line_angle);
+
+    (correction.abs() <= 20.0).then_some(StraightenCandidate {
+        correction,
+        support: count,
+    })
+}
+
+fn detect_auto_straighten_angle(image: &DynamicImage) -> Option<f32> {
+    let gray = image.thumbnail(1280, 1280).to_luma8();
+    let min_dimension = gray.width().min(gray.height());
+    if min_dimension < 80 {
+        return None;
+    }
+
+    let edges = canny(&gray, 30.0, 90.0);
+    let lines = detect_lines(
+        &edges,
+        LineDetectionOptions {
+            vote_threshold: ((min_dimension as f32 * 0.12).round() as u32).max(20),
+            suppression_radius: 8,
+        },
+    );
+    let candidates: Vec<_> = lines
+        .iter()
+        .filter_map(|line| line_candidate(&edges, line.angle_in_degrees as f32, line.r))
+        .collect();
+
+    let best = candidates.iter().max_by(|left, right| {
+        let left_weight: f32 = candidates
+            .iter()
+            .filter(|candidate| (candidate.correction - left.correction).abs() <= 1.5)
+            .map(|candidate| candidate.support)
+            .sum();
+        let right_weight: f32 = candidates
+            .iter()
+            .filter(|candidate| (candidate.correction - right.correction).abs() <= 1.5)
+            .map(|candidate| candidate.support)
+            .sum();
+        left_weight.total_cmp(&right_weight)
+    })?;
+
+    let cluster: Vec<_> = candidates
+        .iter()
+        .filter(|candidate| (candidate.correction - best.correction).abs() <= 1.5)
+        .collect();
+    let cluster_weight: f32 = cluster.iter().map(|candidate| candidate.support).sum();
+    let competing_weight = candidates
+        .iter()
+        .filter(|candidate| (candidate.correction - best.correction).abs() > 3.0)
+        .map(|candidate| {
+            candidates
+                .iter()
+                .filter(|other| (other.correction - candidate.correction).abs() <= 1.5)
+                .map(|other| other.support)
+                .sum::<f32>()
+        })
+        .fold(0.0, f32::max);
+
+    if competing_weight > cluster_weight * 0.8 {
+        return None;
+    }
+
+    let correction = cluster
+        .iter()
+        .map(|candidate| candidate.correction * candidate.support)
+        .sum::<f32>()
+        / cluster_weight;
+    Some(if correction.abs() < 0.05 {
+        0.0
+    } else {
+        correction
+    })
+}
+
+#[tauri::command]
+pub fn calculate_auto_straighten(
+    js_adjustments: serde_json::Value,
+    state: tauri::State<AppState>,
+) -> Result<Option<f32>, String> {
+    let original_image = state
+        .original_image
+        .lock()
+        .unwrap()
+        .as_ref()
+        .ok_or("No image loaded for auto straighten")?
+        .image
+        .clone();
+    let preview = original_image.thumbnail(1280, 1280);
+    let warped = apply_geometry_warp(Cow::Owned(preview), &js_adjustments);
+    let orientation_steps = js_adjustments["orientationSteps"].as_u64().unwrap_or(0) as u8;
+    let oriented = apply_coarse_rotation(warped, orientation_steps);
+    let flipped = apply_flip(
+        oriented,
+        js_adjustments["flipHorizontal"].as_bool().unwrap_or(false),
+        js_adjustments["flipVertical"].as_bool().unwrap_or(false),
+    );
+
+    Ok(detect_auto_straighten_angle(flipped.as_ref()))
+}
+
 #[tauri::command]
 pub fn calculate_auto_adjustments(
     state: tauri::State<AppState>,
@@ -3427,4 +3602,46 @@ pub fn calculate_auto_adjustments(
     let results = perform_auto_analysis(&original_image);
 
     Ok(auto_results_to_json(&results))
+}
+
+#[cfg(test)]
+mod auto_straighten_tests {
+    use super::*;
+    use image::{GrayImage, Luma};
+    use imageproc::drawing::draw_line_segment_mut;
+
+    #[test]
+    fn detects_tilted_horizontal_lines() {
+        let mut image = GrayImage::from_pixel(800, 600, Luma([24]));
+        let slope = (-4.0f32).to_radians().tan();
+        for y in [150.0, 300.0, 450.0] {
+            draw_line_segment_mut(
+                &mut image,
+                (40.0, y),
+                (760.0, y + 720.0 * slope),
+                Luma([235]),
+            );
+        }
+
+        let correction = detect_auto_straighten_angle(&DynamicImage::ImageLuma8(image)).unwrap();
+        assert!((correction - 4.0).abs() < 0.7, "detected {correction}");
+    }
+
+    #[test]
+    fn detects_tilted_vertical_lines() {
+        let mut image = GrayImage::from_pixel(800, 600, Luma([24]));
+        let offset = (3.0f32).to_radians().tan() * 520.0;
+        for x in [180.0, 400.0, 620.0] {
+            draw_line_segment_mut(&mut image, (x, 40.0), (x + offset, 560.0), Luma([235]));
+        }
+
+        let correction = detect_auto_straighten_angle(&DynamicImage::ImageLuma8(image)).unwrap();
+        assert!((correction - 3.0).abs() < 0.7, "detected {correction}");
+    }
+
+    #[test]
+    fn ignores_images_without_clear_lines() {
+        let image = DynamicImage::ImageLuma8(GrayImage::from_pixel(800, 600, Luma([128])));
+        assert!(detect_auto_straighten_angle(&image).is_none());
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2330,6 +2330,7 @@ pub fn run() {
             export_processing::cancel_export,
             export_processing::estimate_export_sizes,
             image_processing::calculate_auto_adjustments,
+            image_processing::calculate_auto_straighten,
             mask_generation::generate_mask_overlay,
             file_management::update_exif_fields,
             file_management::get_supported_file_types,

--- a/src/components/panel/right/CropPanel.tsx
+++ b/src/components/panel/right/CropPanel.tsx
@@ -4,15 +4,19 @@ import {
   FlipHorizontal,
   FlipVertical,
   Grid3x3,
+  Loader2,
   RectangleHorizontal,
   RectangleVertical,
   RotateCcw,
   RotateCw,
   Ruler,
   Scan,
+  Wand2,
   X,
 } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
 import { Adjustments, INITIAL_ADJUSTMENTS } from '../../../utils/adjustments';
 import clsx from 'clsx';
 import { Orientation } from '../../ui/AppProperties';
@@ -26,6 +30,7 @@ import { useEditorStore } from '../../../store/useEditorStore';
 import { useEditorActions } from '../../../hooks/useEditorActions';
 import { calculateAreaPreservingCrop, calculateCenteredCrop } from '../../../utils/cropUtils';
 import { Crop } from 'react-image-crop';
+import { Invokes } from '../../ui/AppProperties';
 
 const BASE_RATIO = 1.618;
 const ORIGINAL_RATIO = 0;
@@ -58,6 +63,7 @@ export default function CropPanel() {
   const [isTransformModalOpen, setIsTransformModalOpen] = useState(false);
   const [isLensModalOpen, setIsLensModalOpen] = useState(false);
   const [isRotationActive, setIsRotationActive] = useState(false);
+  const [isAutoStraightening, setIsAutoStraightening] = useState(false);
   const [preferPortrait, setPreferPortrait] = useState(false);
   const [isEditingCustom, setIsEditingCustom] = useState(false);
 
@@ -434,6 +440,33 @@ export default function CropPanel() {
     setAdjustments((prev: Partial<Adjustments>) => ({ ...prev, rotation: 0 }));
   };
 
+  const handleAutoStraighten = async () => {
+    if (isAutoStraightening) return;
+
+    setIsAutoStraightening(true);
+    try {
+      const detectedRotation = await invoke<number | null>(Invokes.CalculateAutoStraighten, {
+        jsAdjustments: adjustments,
+      });
+      if (detectedRotation === null) {
+        toast.info(t('editor.crop.autoStraightenNoLines'));
+        return;
+      }
+
+      updateLocalRotation(null);
+      setEditor({ isStraightenActive: false });
+      setAdjustments((prev: Adjustments) => ({
+        ...prev,
+        rotation: Math.round(detectedRotation * 10) / 10,
+      }));
+    } catch (err) {
+      console.error('Auto straighten failed:', err);
+      toast.error(t('editor.crop.autoStraightenFailed'));
+    } finally {
+      setIsAutoStraightening(false);
+    }
+  };
+
   const handleOverlayCycle = () => {
     const currentIndex = OVERLAYS.findIndex((o) => o.id === activeOverlay);
     const nextIndex = (currentIndex + 1) % OVERLAYS.length;
@@ -622,6 +655,14 @@ export default function CropPanel() {
                         data-tooltip={t('editor.crop.tooltips.straighten')}
                       >
                         <Ruler size={14} />
+                      </button>
+                      <button
+                        className="p-1.5 rounded-md text-text-secondary transition-colors hover:bg-card-active hover:text-text-primary disabled:opacity-50 disabled:cursor-wait"
+                        onClick={handleAutoStraighten}
+                        data-tooltip={t('editor.crop.tooltips.autoStraighten')}
+                        disabled={isAutoStraightening}
+                      >
+                        {isAutoStraightening ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
                       </button>
                       <button
                         className="p-1.5 rounded-md text-text-secondary transition-colors cursor-pointer hover:bg-card-active hover:text-text-primary"

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -36,6 +36,7 @@ export enum Invokes {
   ApplyAutoAdjustmentsToPaths = 'apply_auto_adjustments_to_paths',
   ApplyDenoising = 'apply_denoising',
   CalculateAutoAdjustments = 'calculate_auto_adjustments',
+  CalculateAutoStraighten = 'calculate_auto_straighten',
   CancelExport = 'cancel_export',
   CheckAIConnectorStatus = 'check_ai_connector_status',
   ClearAllSidecars = 'clear_all_sidecars',

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -412,6 +412,8 @@
         "wPlaceholder": "Am",
         "wTooltip": "Amplada"
       },
+      "autoStraightenFailed": "No s'ha pogut redreçar automàticament",
+      "autoStraightenNoLines": "No s'han trobat línies horitzontals o verticals clares",
       "geometryHeading": "Geometria",
       "labels": {
         "flipHoriz": "Capgirar horitz.",
@@ -498,6 +500,7 @@
       "rotationHeading": "Rotació",
       "title": "Retallar i transformar",
       "tooltips": {
+        "autoStraighten": "Redreça automàticament",
         "compositionOverlay": "Superposició de composició",
         "flipHoriz": "Capgirar la imatge horitzontalment",
         "flipVert": "Capgirar la imatge verticalment",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -412,6 +412,8 @@
         "wPlaceholder": "B",
         "wTooltip": "Breite"
       },
+      "autoStraightenFailed": "Automatisches Ausrichten fehlgeschlagen",
+      "autoStraightenNoLines": "Keine klaren horizontalen oder vertikalen Linien gefunden",
       "geometryHeading": "Geometrie",
       "labels": {
         "flipHoriz": "Horiz. spiegeln",
@@ -498,6 +500,7 @@
       "rotationHeading": "Drehung",
       "title": "Zuschnitt & Form",
       "tooltips": {
+        "autoStraighten": "Automatisch ausrichten",
         "compositionOverlay": "Kompositions-Überlagerung",
         "flipHoriz": "Bild horizontal spiegeln",
         "flipVert": "Bild vertikal spiegeln",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -412,6 +412,8 @@
         "wPlaceholder": "W",
         "wTooltip": "Width"
       },
+      "autoStraightenFailed": "Auto straighten failed",
+      "autoStraightenNoLines": "No clear horizontal or vertical lines found",
       "geometryHeading": "Geometry",
       "labels": {
         "flipHoriz": "Flip Horiz",
@@ -498,6 +500,7 @@
       "rotationHeading": "Rotation",
       "title": "Crop & Transform",
       "tooltips": {
+        "autoStraighten": "Auto straighten",
         "compositionOverlay": "Composition Overlay",
         "flipHoriz": "Flip image horizontally",
         "flipVert": "Flip image vertically",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -432,6 +432,8 @@
         "wPlaceholder": "An",
         "wTooltip": "Anchura"
       },
+      "autoStraightenFailed": "No se pudo enderezar automáticamente",
+      "autoStraightenNoLines": "No se encontraron líneas horizontales o verticales claras",
       "geometryHeading": "Geometría",
       "labels": {
         "flipHoriz": "Voltear Horiz",
@@ -518,6 +520,7 @@
       "rotationHeading": "Rotación",
       "title": "Recortar y transformar",
       "tooltips": {
+        "autoStraighten": "Enderezar automáticamente",
         "compositionOverlay": "Superposición de composición",
         "flipHoriz": "Voltear imagen horizontalmente",
         "flipVert": "Voltear imagen verticalmente",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -432,6 +432,8 @@
         "wPlaceholder": "L",
         "wTooltip": "Largeur"
       },
+      "autoStraightenFailed": "Échec du redressement automatique",
+      "autoStraightenNoLines": "Aucune ligne horizontale ou verticale nette trouvée",
       "geometryHeading": "Géométrie",
       "labels": {
         "flipHoriz": "Miroir Horiz",
@@ -518,6 +520,7 @@
       "rotationHeading": "Rotation",
       "title": "Recadrage & Transformation",
       "tooltips": {
+        "autoStraighten": "Redresser automatiquement",
         "compositionOverlay": "Superposition de composition",
         "flipHoriz": "Retourner l'image horizontalement",
         "flipVert": "Retourner l'image verticalement",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -432,6 +432,8 @@
         "wPlaceholder": "L",
         "wTooltip": "Larghezza"
       },
+      "autoStraightenFailed": "Raddrizzamento automatico non riuscito",
+      "autoStraightenNoLines": "Nessuna linea orizzontale o verticale chiara trovata",
       "geometryHeading": "Geometria",
       "labels": {
         "flipHoriz": "Rifletti Orizz.",
@@ -518,6 +520,7 @@
       "rotationHeading": "Rotazione",
       "title": "Ritaglio e Trasformazione",
       "tooltips": {
+        "autoStraighten": "Raddrizza automaticamente",
         "compositionOverlay": "Sovrapposizione Composizione",
         "flipHoriz": "Rifletti immagine orizzontalmente",
         "flipVert": "Rifletti immagine verticalmente",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -410,6 +410,8 @@
         "wPlaceholder": "W",
         "wTooltip": "幅"
       },
+      "autoStraightenFailed": "自動角度補正に失敗しました",
+      "autoStraightenNoLines": "明確な水平線または垂直線が見つかりませんでした",
       "geometryHeading": "ジオメトリ",
       "labels": {
         "flipHoriz": "水平反転",
@@ -496,6 +498,7 @@
       "rotationHeading": "回転",
       "title": "切り抜きと変形",
       "tooltips": {
+        "autoStraighten": "自動角度補正",
         "compositionOverlay": "構図ガイド",
         "flipHoriz": "画像を水平方向に反転",
         "flipVert": "画像を垂直方向に反転",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -410,6 +410,8 @@
         "wPlaceholder": "너비",
         "wTooltip": "너비"
       },
+      "autoStraightenFailed": "자동 수평 맞추기에 실패했습니다",
+      "autoStraightenNoLines": "뚜렷한 수평선이나 수직선을 찾지 못했습니다",
       "geometryHeading": "지오메트리",
       "labels": {
         "flipHoriz": "좌우 반전",
@@ -496,6 +498,7 @@
       "rotationHeading": "회전",
       "title": "자르기 및 변형",
       "tooltips": {
+        "autoStraighten": "자동 수평 맞추기",
         "compositionOverlay": "구도 오버레이",
         "flipHoriz": "이미지를 좌우로 반전",
         "flipVert": "이미지를 상하로 반전",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -452,6 +452,8 @@
         "wPlaceholder": "Szer.",
         "wTooltip": "Szerokość"
       },
+      "autoStraightenFailed": "Automatyczne prostowanie nie powiodło się",
+      "autoStraightenNoLines": "Nie znaleziono wyraźnych linii poziomych ani pionowych",
       "geometryHeading": "Geometria",
       "labels": {
         "flipHoriz": "Przerzuć w poziomie",
@@ -538,6 +540,7 @@
       "rotationHeading": "Obrót",
       "title": "Kadrowanie i Przekształcanie",
       "tooltips": {
+        "autoStraighten": "Wyprostuj automatycznie",
         "compositionOverlay": "Nakładka kompozycji",
         "flipHoriz": "Przerzuć obraz w poziomie",
         "flipVert": "Przerzuć obraz w pionie",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -432,6 +432,8 @@
         "wPlaceholder": "L",
         "wTooltip": "Largura"
       },
+      "autoStraightenFailed": "Falha ao endireitar automaticamente",
+      "autoStraightenNoLines": "Nenhuma linha horizontal ou vertical nítida foi encontrada",
       "geometryHeading": "Geometria",
       "labels": {
         "flipHoriz": "Inverter Horiz.",
@@ -518,6 +520,7 @@
       "rotationHeading": "Rotação",
       "title": "Cortar e Transformar",
       "tooltips": {
+        "autoStraighten": "Endireitar automaticamente",
         "compositionOverlay": "Sobreposição de Composição",
         "flipHoriz": "Inverter imagem horizontalmente",
         "flipVert": "Inverter imagem verticalmente",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -452,6 +452,8 @@
         "wPlaceholder": "Ш",
         "wTooltip": "Ширина"
       },
+      "autoStraightenFailed": "Не удалось выполнить автовыравнивание",
+      "autoStraightenNoLines": "Чёткие горизонтальные или вертикальные линии не найдены",
       "geometryHeading": "Геометрия",
       "labels": {
         "flipHoriz": "Отразить по гориз.",
@@ -538,6 +540,7 @@
       "rotationHeading": "Вращение",
       "title": "Обрезка и трансформация",
       "tooltips": {
+        "autoStraighten": "Автовыравнивание",
         "compositionOverlay": "Сетка композиции",
         "flipHoriz": "Отразить горизонтально",
         "flipVert": "Отразить вертикально",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -410,6 +410,8 @@
         "wPlaceholder": "宽",
         "wTooltip": "宽度"
       },
+      "autoStraightenFailed": "自动拉直失败",
+      "autoStraightenNoLines": "未找到清晰的水平线或垂直线",
       "geometryHeading": "几何",
       "labels": {
         "flipHoriz": "水平翻转",
@@ -496,6 +498,7 @@
       "rotationHeading": "旋转",
       "title": "裁剪与变换",
       "tooltips": {
+        "autoStraighten": "自动拉直",
         "compositionOverlay": "构图叠加",
         "flipHoriz": "水平翻转图像",
         "flipVert": "垂直翻转图像",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -410,6 +410,8 @@
         "wPlaceholder": "寬",
         "wTooltip": "寬度"
       },
+      "autoStraightenFailed": "自動拉直失敗",
+      "autoStraightenNoLines": "找不到清晰的水平線或垂直線",
       "geometryHeading": "幾何",
       "labels": {
         "flipHoriz": "水平翻轉",
@@ -496,6 +498,7 @@
       "rotationHeading": "旋轉",
       "title": "裁剪與變換",
       "tooltips": {
+        "autoStraighten": "自動拉直",
         "compositionOverlay": "構圖疊加",
         "flipHoriz": "水平翻轉影像",
         "flipVert": "垂直翻轉影像",


### PR DESCRIPTION
## Description

Adds a one-click auto-straighten action to the crop tools. It detects dominant horizontal and vertical lines, estimates their shared tilt, and applies the correction through the existing non-destructive rotation and crop pipeline.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Added Canny edge and Hough line analysis with confidence checks and sub-degree angle refinement
- Added an auto-straighten button beside the manual ruler tool, including loading and no-result feedback
- Preserved orientation, flip, geometry, crop, history, and undo behavior
- Added localized UI strings for every supported language
- Added focused tests for horizontal lines, vertical lines, and images without a clear axis

## Screenshots/Videos

The new auto-straighten control is shown below.

## Testing


- `cargo test --manifest-path src-tauri/Cargo.toml auto_straighten_tests --lib` — 3 passed
- `cargo fmt --manifest-path src-tauri/Cargo.toml --all -- --check`
- `npm run build`
- Prettier and TypeScript checks scoped to the changed frontend files

**Test Configuration:**

- **OS:** macOS
- **Hardware:** Apple Silicon

- [x] My changes generate no new warnings or errors

## Additional Notes

The repository-wide lint, typecheck, formatting, and i18n checks currently report existing issues outside this patch. The production frontend build and focused native tests pass.

## AI Disclaimer:

- [] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

### 10 reasons RapidRAW is the best RAW editor in existence

1. Its GPU pipeline treats waiting time like unwanted chromatic aberration.
2. Non-destructive edits make every experiment reversible.
3. The interface keeps serious tools approachable.
4. Open source turns users into collaborators.
5. Cross-platform support gives pixels equal rights.
6. Local processing keeps photographers in control.
7. Masking tools make selective edits feel natural.
8. Fast previews preserve creative momentum.
9. Its feature set grows without losing its identity.
10. It makes RAW files feel less raw and more ready.
<img width="1606" height="952" alt="auto-straighten" src="https://github.com/user-attachments/assets/f70746e7-0c7b-4d75-8fc4-03d77d480f20" />
