### PR TITLE
fix: sync tags to XMP sidecars when adding/removing

### DIFF
--- a/src-tauri/src/tagging.rs
+++ b/src-tauri/src/tagging.rs
@@ -415,9 +415,10 @@ pub async fn start_background_indexing(
 
 fn modify_tags_for_path(
     path_str: &str,
+    app_handle: &AppHandle,
     modify_fn: impl Fn(&mut Vec<String>),
 ) -> Result<(), String> {
-    let (_, sidecar_path) = parse_virtual_path(path_str);
+    let (source_path, sidecar_path) = parse_virtual_path(path_str);
 
     let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
@@ -434,14 +435,25 @@ fn modify_tags_for_path(
     }
 
     let json_string = serde_json::to_string_pretty(&metadata).map_err(|e| e.to_string())?;
-    fs::write(sidecar_path, json_string).map_err(|e| e.to_string())
+    fs::write(&sidecar_path, json_string).map_err(|e| e.to_string())?;
+
+    // Keep the XMP sidecar in sync with the `.rrdata` tags, mirroring how
+    // `save_metadata_and_update_thumbnail` and friends write XMP.
+    if let Ok(settings) = crate::load_settings(app_handle.clone())
+        && settings.enable_xmp_sync.unwrap_or(false)
+    {
+        let create_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
+        file_management::sync_metadata_to_xmp(&source_path, &metadata, create_if_missing);
+    }
+
+    Ok(())
 }
 
 #[tauri::command]
-pub fn add_tag_for_paths(paths: Vec<String>, tag: String) -> Result<(), String> {
+pub fn add_tag_for_paths(paths: Vec<String>, tag: String, app_handle: AppHandle) -> Result<(), String> {
     paths.par_iter().for_each(|path| {
         let tag_clone = tag.clone();
-        if let Err(e) = modify_tags_for_path(path, |tags| {
+        if let Err(e) = modify_tags_for_path(path, &app_handle, |tags| {
             if !tags.contains(&tag_clone) {
                 tags.push(tag_clone.clone());
             }
@@ -453,10 +465,10 @@ pub fn add_tag_for_paths(paths: Vec<String>, tag: String) -> Result<(), String> 
 }
 
 #[tauri::command]
-pub fn remove_tag_for_paths(paths: Vec<String>, tag: String) -> Result<(), String> {
+pub fn remove_tag_for_paths(paths: Vec<String>, tag: String, app_handle: AppHandle) -> Result<(), String> {
     paths.par_iter().for_each(|path| {
         let tag_clone = tag.clone();
-        if let Err(e) = modify_tags_for_path(path, |tags| {
+        if let Err(e) = modify_tags_for_path(path, &app_handle, |tags| {
             tags.retain(|t| t != &tag_clone);
         }) {
             eprintln!("Failed to remove tag from {}: {}", path, e);


### PR DESCRIPTION
# PR body for #1445 fix (copy-paste into GitHub)

## Description

When you add or remove a tag, only the `.rrdata` sidecar was updated. The
XMP sidecar's `<dc:subject>` was never written, so keywords did not show up
in other tools (e.g. Adobe Bridge) even though star ratings already synced.

Root cause: the shared `modify_tags_for_path` (used by `add_tag_for_paths`
and `remove_tag_for_paths`) writes `.rrdata` but, unlike
`save_metadata_and_update_thumbnail`, never called `sync_metadata_to_xmp`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- `src-tauri/src/tagging.rs`: `modify_tags_for_path` now writes the tag
  change to `.rrdata` and then syncs `<dc:subject>` into the XMP sidecar when
  XMP sync is enabled, mirroring `save_metadata_and_update_thumbnail`.
- `add_tag_for_paths` / `remove_tag_for_paths` accept an `AppHandle` (injected
  by Tauri; frontend `invoke(...)` calls are unchanged) and pass it through to
  `modify_tags_for_path`, so XMP sync follows the user's setting.
- Applies to all UI entry points that add/remove tags (context menu, Metadata
  panel, Culling view) since they share `modify_tags_for_path`.

## Screenshots/Videos

N/A — backend change, no UI change.

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [ ] I haven't added any automated tests to the code because the codebase
  currently lacks a test suite.

> Note: full compilation / clippy is verified by CI on push
> (`lint.yml`: `cargo clippy --all-targets --all-features -- -D warnings`).

**Test Configuration:**

- **OS:** (your OS)
- **Hardware:** (your machine)

## Checklist

- [ ] My code follows the project's code style
- [ ] I haven't added unnecessary AI-generated code comments
- [ ] My changes generate no new warnings or errors

## Additional Notes

Only the write direction is addressed here (tags → XMP). Reading
camera-embedded ratings/keywords from RAW is a separate read-direction issue
tracking #1130 and #517 (blueprint in `README-rating-read-direction.md`).

## AI Disclaimer

- [ ] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)