### PR TITLE
feat: read camera-embedded rating from RAW/EXIF & XMP

### DIFF
--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -217,6 +217,58 @@ pub fn read_raw_metadata(file_bytes: &[u8]) -> Option<RawMetadata> {
     decoder.raw_metadata(&raw_source, &Default::default()).ok()
 }
 
+/// Map an XMP `xmp:Rating` textual value onto a star rating.
+/// `-1` ("rejected") is intentionally not a star rating, so it yields `None`.
+fn parse_xmp_rating(raw: &str) -> Option<u8> {
+    let v: i32 = raw.trim().parse().ok()?;
+    match v {
+        -1 => None,
+        0..=5 => Some(v as u8),
+        _ => None,
+    }
+}
+
+/// Rating (0..=5) written by a camera or another tool.
+///
+/// Reads from embedded XMP `xmp:Rating` (the interoperable carrier used by
+/// Lightroom / digikam / many cameras) and, as a fallback, the private EXIF
+/// `Rating` tag (0x4746). Returns `None` when no rating is present so callers
+/// can fall back to 0.
+pub fn read_image_rating(file_bytes: &[u8]) -> Option<u8> {
+    // Embedded XMP `xmp:Rating`, attribute or element form.
+    let attr = regex::bytes::Regex::new(r#"xmp:Rating\s*=\s*["'](-?[0-9]+)["']"#).ok()?;
+    if let Some(caps) = attr.captures(file_bytes) {
+        if let Some(m) = caps.get(1) {
+            if let Ok(s) = std::str::from_utf8(m.as_bytes())
+                && let Some(r) = parse_xmp_rating(s)
+            {
+                return Some(r);
+            }
+        }
+    }
+    let elem = regex::bytes::Regex::new(r#"<xmp:Rating>(-?[0-9]+)</xmp:Rating>"#).ok()?;
+    if let Some(caps) = elem.captures(file_bytes) {
+        if let Some(m) = caps.get(1) {
+            if let Ok(s) = std::str::from_utf8(m.as_bytes())
+                && let Some(r) = parse_xmp_rating(s)
+            {
+                return Some(r);
+            }
+        }
+    }
+
+    // Private EXIF Rating tag (0x4746).
+    if let Some(exif) = read_exif(file_bytes) {
+        for field in exif.fields() {
+            if field.tag.number() == 0x4746 {
+                return field.value.get_uint(0).and_then(|v| (v <= 5).then_some(v as u8));
+            }
+        }
+    }
+
+    None
+}
+
 pub fn read_exposure_time_secs(path: &str, file_bytes: &[u8]) -> Option<f32> {
     if let Some(map) = read_rrexif_sidecar(Path::new(path))
         && let Some(val_str) = map.get("ExposureTime").or(map.get("ShutterSpeedValue"))
@@ -1437,4 +1489,48 @@ pub fn write_rrexif_sidecar(source_path_str: &str, target_image_path: &Path) -> 
     metadata.exif = Some(exif_data);
     save_primary_metadata(target_image_path, &metadata)
         .map_err(|e| format!("Failed to write sidecar: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_xmp_rating, read_image_rating};
+
+    #[test]
+    fn xmp_attribute_rating() {
+        let bytes = b"<rdf:RDF><rdf:Description xmp:Rating=\"4\"></rdf:Description></rdf:RDF>".to_vec();
+        assert_eq!(read_image_rating(&bytes), Some(4));
+    }
+
+    #[test]
+    fn xmp_attribute_rating_single_quote() {
+        let bytes = b"<rdf:Description xmp:Rating='2'/>".to_vec();
+        assert_eq!(read_image_rating(&bytes), Some(2));
+    }
+
+    #[test]
+    fn xmp_element_rating() {
+        let bytes = b"<rdf:Description><xmp:Rating>3</xmp:Rating></rdf:Description>".to_vec();
+        assert_eq!(read_image_rating(&bytes), Some(3));
+    }
+
+    #[test]
+    fn xmp_rating_mapping() {
+        assert_eq!(parse_xmp_rating("-1"), None); // rejected is not a star
+        assert_eq!(parse_xmp_rating("0"), Some(0));
+        assert_eq!(parse_xmp_rating("5"), Some(5));
+        assert_eq!(parse_xmp_rating("7"), None);
+        assert_eq!(parse_xmp_rating("abc"), None);
+    }
+
+    #[test]
+    fn explicit_zero_rating() {
+        let bytes = b"<rdf:Description xmp:Rating=\"0\"/>".to_vec();
+        assert_eq!(read_image_rating(&bytes), Some(0));
+    }
+
+    #[test]
+    fn no_rating_returns_none() {
+        let bytes = b"<rdf:RDF></rdf:RDF> no rating present".to_vec();
+        assert_eq!(read_image_rating(&bytes), None);
+    }
 }

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -103,6 +103,16 @@ fn resolve_image_metadata(
         let _ = fs::write(sidecar_path, json);
     }
 
+    // Read a camera/software rating the user never edited in RapidRAW
+    // (no rated `.rrdata`). In-memory only — we do not grow `.rrdata` here.
+    if metadata.rating == 0 {
+        if let Ok(mm) = read_file_mapped(image_path)
+            && let Some(rating) = crate::exif_processing::read_image_rating(mm.as_ref())
+        {
+            metadata.rating = rating;
+        }
+    }
+
     let is_raw = crate::formats::is_raw_file(image_path);
     let tm_override = crate::image_processing::resolve_tonemapper_override(settings, is_raw);
     let is_edited =


### PR DESCRIPTION
# PR body for read-direction fix (#1130 / #517)

## Description

Star ratings assigned in-camera (e.g. Lumix/Panasonic, Sony) were not shown
in RapidRAW because the read path only looked at the `.rrdata` sidecar (and
an optional `.xmp` file). For images never edited in RapidRAW the `.rrdata`
has `rating: 0`, and nothing ever pulled the camera's rating back in.

This makes the read path fall back to the two interoperable carriers that
cameras/other tools actually use: embedded XMP `xmp:Rating` and the private
EXIF `Rating` tag (0x4746).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- `src-tauri/src/exif_processing.rs`
  - new `read_image_rating(path, bytes)`: tries embedded XMP `xmp:Rating`
    (attribute and element forms) first, then the private EXIF `Rating` tag
    (0x4746).
  - `xmp:Rating` `-1` (rejected) is treated as "not a star" (`None`), so a
    rejected photo never shows up as a 1-star.
  - unit tests for the XMP/rating mapping.
- `src-tauri/src/file_management.rs`
  - `resolve_image_metadata` now, when `rating == 0`, memory-maps the file and
    calls `read_image_rating` to hydrate the rating for display.
  - in-memory only — it does **not** grow the `.rrdata` sidecar (avoids #1514).

## Screenshots/Videos

N/A — backend change; no UI change.

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [ ] I haven't added any automated tests to the code because the codebase
  currently lacks a test suite.

> Unit tests were added for the new `read_image_rating`/`parse_xmp_rating`
> functions; full compile/clippy is verified by CI on push.

**Test Configuration:**

- **OS:** (your OS)
- **Hardware:** (your machine)

## Checklist

- [ ] My code follows the project's code style
- [ ] I haven't added unnecessary AI-generated code comments
- [ ] My changes generate no new warnings or errors

## Additional Notes

- Coverage depends on where each camera writes the rating (embedded XMP vs
  EXIF 0x4746). Reported #1130 (RW2) and #517 (Sony) are the targets; if a
  specific camera writes elsewhere (e.g. `RatingPercent` 0x4749), that can be
  a small follow-up once we have a sample.
- This is the read-direction companion to the write-direction
  `#1445` fix (`fix/tags-xmp-sync`).

## AI Disclaimer

- [ ] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
