### PR TITLE
fix: keep XMP tags in sync when clearing tags

### DIFF
--- a/src-tauri/src/tagging.rs
+++ b/src-tauri/src/tagging.rs
@@ -465,11 +465,38 @@ pub fn remove_tag_for_paths(paths: Vec<String>, tag: String) -> Result<(), Strin
     Ok(())
 }
 
+/// Derive the source image path from a `.rrdata` sidecar path.
+/// `<base>.jpg.rrdata` -> `.../<base>.jpg`.
+fn rrdata_source_path(rrdata: &Path) -> Option<PathBuf> {
+    let name = rrdata.file_name()?.to_str()?;
+    name.strip_suffix(".rrdata").map(|base| rrdata.with_file_name(base))
+}
+
+/// Mirror a `.rrdata` tag change into its XMP sidecar when XMP sync is
+/// enabled, matching `modify_tags_for_path`. No-op otherwise.
+fn sync_xmp_for_rrdata(
+    rrdata_path: &Path,
+    metadata: &ImageMetadata,
+    enable_xmp_sync: bool,
+    create_xmp_if_missing: bool,
+) {
+    if !enable_xmp_sync {
+        return;
+    }
+    if let Some(source_path) = rrdata_source_path(rrdata_path) {
+        file_management::sync_metadata_to_xmp(&source_path, metadata, create_xmp_if_missing);
+    }
+}
+
 #[tauri::command]
-pub fn clear_ai_tags(root_path: String) -> Result<usize, String> {
+pub fn clear_ai_tags(root_path: String, app_handle: AppHandle) -> Result<usize, String> {
     if !Path::new(&root_path).exists() {
         return Err(format!("Root path does not exist: {}", root_path));
     }
+
+    let settings = crate::load_settings(app_handle.clone()).unwrap_or_default();
+    let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
+    let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
     let mut updated_count = 0;
     let walker = WalkDir::new(root_path).into_iter();
@@ -496,6 +523,7 @@ pub fn clear_ai_tags(root_path: String) -> Result<usize, String> {
                     && fs::write(path, json_string).is_ok()
                 {
                     updated_count += 1;
+                    sync_xmp_for_rrdata(path, &metadata, enable_xmp_sync, create_xmp_if_missing);
                 }
             }
         }
@@ -504,10 +532,14 @@ pub fn clear_ai_tags(root_path: String) -> Result<usize, String> {
 }
 
 #[tauri::command]
-pub fn clear_all_tags(root_path: String) -> Result<usize, String> {
+pub fn clear_all_tags(root_path: String, app_handle: AppHandle) -> Result<usize, String> {
     if !Path::new(&root_path).exists() {
         return Err(format!("Root path does not exist: {}", root_path));
     }
+
+    let settings = crate::load_settings(app_handle.clone()).unwrap_or_default();
+    let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
+    let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
     let mut updated_count = 0;
     let walker = WalkDir::new(root_path).into_iter();
@@ -532,6 +564,7 @@ pub fn clear_all_tags(root_path: String) -> Result<usize, String> {
                     && fs::write(path, json_string).is_ok()
                 {
                     updated_count += 1;
+                    sync_xmp_for_rrdata(path, &metadata, enable_xmp_sync, create_xmp_if_missing);
                 }
             }
         }


### PR DESCRIPTION
# PR body for third PR — clear-tags XMP sync

## Description

`clear_ai_tags` / `clear_all_tags` only rewrote the `.rrdata` sidecars and never
touched the XMP sidecars' `<dc:subject>`, so after clearing tags the XMP files
still carried the old keywords. Like #1445 (add/remove), this branch keeps the
two sidecars in sync for the bulk "clear" operations too.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- `src-tauri/src/tagging.rs`
  - `rrdata_source_path`: derives the source image path from a `.rrdata`
    sidecar (`<base>.jpg.rrdata` -> `.../<base>.jpg`).
  - `sync_xmp_for_rrdata`: mirrors a cleared `.rrdata` write into its XMP
    sidecar when XMP sync is enabled (no-op otherwise), matching the add/remove
    behavior.
  - `clear_ai_tags` / `clear_all_tags` now accept an `AppHandle` (injected by
    Tauri; frontend `invoke(...)` calls are unchanged), read the XMP-sync
    settings once, and call `sync_xmp_for_rrdata` after each `.rrdata` update.

## Screenshots/Videos

backend change

## Testing

- [ ] These changes were tested locally by a human and confirmed to work
  (compiled; unit-tested alongside the read-direction PR).
- [ ] I haven't added any automated tests to the code because the codebase
  currently lacks a test suite for these bulk operations.

**Test Configuration:**

- **OS:** (your OS)
- **Hardware:** (your machine)

## Checklist

- [ ] My code follows the project's code style
- [ ] I haven't added unnecessary AI-generated code comments
- [ ] My changes generate no new warnings or errors (verified by local
  `cargo check`; CI clippy pending)

## Additional Notes

Companion to the read-direction PR for #1130/#517 and the write-direction #1445. Together they make `.rrdata` <-> XMP stay consistent for add, remove,
and clear.

## AI Disclaimer

- [ ] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
