### PR TITLE
fix(android): restore side panels on tablets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,7 @@ const insertChildrenIntoTree = (node: any, targetPath: string, newChildren: any[
 
 function App() {
   const COMPACT_EDITOR_MAX_WIDTH = 900;
+  const ANDROID_PHONE_MAX_WIDTH = 600;
 
   const { appSettings, theme, osPlatform, handleSettingsChange } = useSettingsStore(
     useShallow((state) => ({
@@ -229,10 +230,7 @@ function App() {
 
   const isAndroid = osPlatform === 'android';
   const isPortraitViewport = viewportSize.width > 0 && viewportSize.height > viewportSize.width;
-  // Phones use the compact bottom panel; tablets need the normal side panels
-  // in both orientations. Android tablets commonly expose ~800 CSS pixels in
-  // portrait, while phones are usually below 600 CSS pixels.
-  const compactEditorMaxWidth = isAndroid ? 600 : COMPACT_EDITOR_MAX_WIDTH;
+  const compactEditorMaxWidth = isAndroid ? ANDROID_PHONE_MAX_WIDTH : COMPACT_EDITOR_MAX_WIDTH;
   const isCompactPortrait = viewportSize.width > 0 && viewportSize.width <= compactEditorMaxWidth && isPortraitViewport;
   const useCompactAndroidPanels = isAndroid && isCompactPortrait;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -229,8 +229,12 @@ function App() {
 
   const isAndroid = osPlatform === 'android';
   const isPortraitViewport = viewportSize.width > 0 && viewportSize.height > viewportSize.width;
-  const isCompactPortrait =
-    viewportSize.width > 0 && viewportSize.width <= COMPACT_EDITOR_MAX_WIDTH && isPortraitViewport;
+  // Phones use the compact bottom panel; tablets need the normal side panels
+  // in both orientations. Android tablets commonly expose ~800 CSS pixels in
+  // portrait, while phones are usually below 600 CSS pixels.
+  const compactEditorMaxWidth = isAndroid ? 600 : COMPACT_EDITOR_MAX_WIDTH;
+  const isCompactPortrait = viewportSize.width > 0 && viewportSize.width <= compactEditorMaxWidth && isPortraitViewport;
+  const useCompactAndroidPanels = isAndroid && isCompactPortrait;
 
   const compactEditorPanelMinHeight = 220;
   const compactEditorPanelMaxHeight =
@@ -695,7 +699,7 @@ function App() {
   const hasRoots = rootPaths && rootPaths.length > 0;
   const hasMainContent = hasRoots || (activeView === 'editor' && !!selectedImage);
 
-  const shouldHideFolderTree = isAndroid;
+  const shouldHideFolderTree = useCompactAndroidPanels;
   const isWgpuActive =
     activeView === 'editor' &&
     appSettings?.useWgpuRenderer !== false &&
@@ -856,7 +860,7 @@ function App() {
                   </div>
                 )}
               </div>
-              {!isAndroid && hasMainContent && (
+              {!useCompactAndroidPanels && hasMainContent && (
                 <SidePanelArea
                   side="right"
                   width={effectiveRightWidth}


### PR DESCRIPTION
## What changed

On Android tablets, the left and right side panels were hidden in both portrait and landscape mode. This made the Library/Folder panel and the Adjustments panel inaccessible.

This change keeps the compact bottom-panel layout for small Android phones, while restoring the normal side panels on wider Android tablet layouts.

## Testing

Tested manually on:

- Samsung Tab S10+
- OnePlus Pad 2

Checked:

- Library View
- Editor View
- Portrait orientation
- Landscape orientation
- RAW image editing
- Bottom filmstrip

Before/after screenshots were captured during testing.

## Scope

This PR changes only `src/App.tsx`.

No new buttons, panel toggles, or unrelated features are included.

## AI disclosure

AI-assisted implementation, manually reviewed and tested by Robin Fitzek.
