### PR TITLE
Fix white balance picker persisting across panels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,7 +167,6 @@ function App() {
     rightPanelWidth,
     compactEditorPanelHeightOverride,
     activePanel,
-    activePanels,
     activeLayoutDragItem,
     isSettingsOpen,
     setUI,
@@ -187,7 +186,6 @@ function App() {
       rightPanelWidth: state.rightPanelWidth,
       compactEditorPanelHeightOverride: state.compactEditorPanelHeightOverride,
       activePanel: state.activePanel,
-      activePanels: state.activePanels,
       activeLayoutDragItem: state.activeLayoutDragItem,
       isSettingsOpen: state.isSettingsOpen,
       setUI: state.setUI,
@@ -656,17 +654,6 @@ function App() {
       unlistenPromise.then((unlisten: any) => unlisten());
     };
   }, [setUI]);
-
-  useEffect(() => {
-    const visiblePanels = Object.values(activePanels);
-    const canvasToolIsVisible = visiblePanels.some(
-      (panel) => panel === Panel.Masks || panel === Panel.Ai || panel === Panel.Crop,
-    );
-
-    if (canvasToolIsVisible || !visiblePanels.includes(Panel.Adjustments)) {
-      setEditor({ isWbPickerActive: false });
-    }
-  }, [activePanels, setEditor]);
 
   const handlePanelSelect = useCallback(
     (panelId: Panel) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -167,6 +167,7 @@ function App() {
     rightPanelWidth,
     compactEditorPanelHeightOverride,
     activePanel,
+    activePanels,
     activeLayoutDragItem,
     isSettingsOpen,
     setUI,
@@ -186,6 +187,7 @@ function App() {
       rightPanelWidth: state.rightPanelWidth,
       compactEditorPanelHeightOverride: state.compactEditorPanelHeightOverride,
       activePanel: state.activePanel,
+      activePanels: state.activePanels,
       activeLayoutDragItem: state.activeLayoutDragItem,
       isSettingsOpen: state.isSettingsOpen,
       setUI: state.setUI,
@@ -654,6 +656,17 @@ function App() {
       unlistenPromise.then((unlisten: any) => unlisten());
     };
   }, [setUI]);
+
+  useEffect(() => {
+    const visiblePanels = Object.values(activePanels);
+    const canvasToolIsVisible = visiblePanels.some(
+      (panel) => panel === Panel.Masks || panel === Panel.Ai || panel === Panel.Crop,
+    );
+
+    if (canvasToolIsVisible || !visiblePanels.includes(Panel.Adjustments)) {
+      setEditor({ isWbPickerActive: false });
+    }
+  }, [activePanels, setEditor]);
 
   const handlePanelSelect = useCallback(
     (panelId: Panel) => {

--- a/src/components/panel/editor/ImageCanvas.tsx
+++ b/src/components/panel/editor/ImageCanvas.tsx
@@ -1751,7 +1751,7 @@ const ImageCanvas = memo(
 
         if (e.evt && e.evt.cancelable) e.evt.preventDefault();
 
-        if (isWbPickerActive) {
+        if (isWbPickerActive && !isMasking && !isAiEditing) {
           handleWbClick(e);
           return;
         }
@@ -2192,6 +2192,7 @@ const ImageCanvas = memo(
         effectiveImageDimensions,
         brushSettings,
         isMasking,
+        isAiEditing,
         localInitialDrawParams,
         brushImageSpaceSize,
         baseTool,

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -555,7 +555,8 @@ export const useKeyboardShortcuts = ({
         match: (e: KeyboardEvent) => e.code === 'Escape',
         execute: (e: KeyboardEvent, s: any) => {
           e.preventDefault();
-          if (s.editor.isStraightenActive) s.editor.setEditor({ isStraightenActive: false });
+          if (s.editor.isWbPickerActive) s.editor.setEditor({ isWbPickerActive: false });
+          else if (s.editor.isStraightenActive) s.editor.setEditor({ isStraightenActive: false });
           else if (s.ui.customEscapeHandler) s.ui.customEscapeHandler();
           else if (s.editor.activeAiSubMaskId) s.editor.setEditor({ activeAiSubMaskId: null });
           else if (s.editor.activeAiPatchContainerId) s.editor.setEditor({ activeAiPatchContainerId: null });

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -7,6 +7,7 @@ import {
   PanelRegion,
   WorkspaceState,
 } from '../components/ui/AppProperties';
+import { useEditorStore } from './useEditorStore';
 
 export type SwitcherPlacement = 'bottom' | 'right' | 'left' | 'top';
 
@@ -111,6 +112,17 @@ export const DEFAULT_PANEL_DEFAULT_REGIONS: Record<Panel, PanelRegion> = {
 export const DEFAULT_PANEL_WIDTH = 350;
 export const DEFAULT_PANEL_SECTION_HEIGHT = 450;
 export const DEFAULT_BOTTOM_PANEL_HEIGHT = 144;
+
+const resetWbPickerForActivePanels = (activePanels: Record<PanelRegion, Panel | null>) => {
+  const visiblePanels = Object.values(activePanels);
+  const canvasToolIsVisible = visiblePanels.some(
+    (panel) => panel === Panel.Masks || panel === Panel.Ai || panel === Panel.Crop,
+  );
+
+  if (canvasToolIsVisible || !visiblePanels.includes(Panel.Adjustments)) {
+    useEditorStore.getState().setEditor({ isWbPickerActive: false });
+  }
+};
 
 export function reconcileWorkspace(
   savedWorkspace: WorkspaceState | undefined,
@@ -369,19 +381,25 @@ export const useUIStore = create<UIState>((set, get) => ({
   cullingModalState: { isOpen: false, suggestions: null, progress: null, error: null, pathsToCull: [] },
   collageModalState: { isOpen: false, sourceImages: [] },
 
-  setUI: (updater) => set((state) => (typeof updater === 'function' ? updater(state) : updater)),
+  setUI: (updater) => {
+    const updates = typeof updater === 'function' ? updater(get()) : updater;
+    set(updates);
+    if (updates.activePanels) resetWbPickerForActivePanels(updates.activePanels);
+  },
 
   setLayoutDragItem: (panel) => set({ activeLayoutDragItem: panel }),
 
-  movePanel: (panel, toRegion) =>
+  movePanel: (panel, toRegion) => {
+    let nextActivePanels: Record<PanelRegion, Panel | null> | undefined;
+
     set((state) => {
-      const layout = {
+      const layout: Record<PanelRegion, Panel[]> = {
         leftTop: [...state.panelLayout.leftTop],
         leftBottom: [...state.panelLayout.leftBottom],
         rightTop: [...state.panelLayout.rightTop],
         rightBottom: [...state.panelLayout.rightBottom],
       };
-      const active = { ...state.activePanels };
+      const active: Record<PanelRegion, Panel | null> = { ...state.activePanels };
 
       let fromRegion: PanelRegion | null = null;
       (Object.keys(layout) as PanelRegion[]).forEach((r) => {
@@ -393,11 +411,13 @@ export const useUIStore = create<UIState>((set, get) => ({
 
       if (!layout[toRegion].includes(panel)) layout[toRegion].push(panel);
 
-      if (fromRegion && active[fromRegion] === panel) {
-        active[fromRegion] = layout[fromRegion].length > 0 ? layout[fromRegion][0] : null;
+      const sourceRegion = fromRegion as PanelRegion | null;
+      if (sourceRegion && active[sourceRegion] === panel) {
+        active[sourceRegion] = layout[sourceRegion].length > 0 ? layout[sourceRegion][0] : null;
       }
 
       active[toRegion] = panel;
+      nextActivePanels = active;
 
       return {
         panelLayout: layout,
@@ -406,17 +426,22 @@ export const useUIStore = create<UIState>((set, get) => ({
         activePanel: panel,
         renderedPanel: panel,
       };
-    }),
+    });
 
-  movePanelToIndex: (panel, toRegion, index) =>
+    if (nextActivePanels) resetWbPickerForActivePanels(nextActivePanels);
+  },
+
+  movePanelToIndex: (panel, toRegion, index) => {
+    let nextActivePanels: Record<PanelRegion, Panel | null> | undefined;
+
     set((state) => {
-      const layout = {
+      const layout: Record<PanelRegion, Panel[]> = {
         leftTop: [...state.panelLayout.leftTop],
         leftBottom: [...state.panelLayout.leftBottom],
         rightTop: [...state.panelLayout.rightTop],
         rightBottom: [...state.panelLayout.rightBottom],
       };
-      const active = { ...state.activePanels };
+      const active: Record<PanelRegion, Panel | null> = { ...state.activePanels };
 
       let fromRegion: PanelRegion | null = null;
       (Object.keys(layout) as PanelRegion[]).forEach((r) => {
@@ -429,10 +454,12 @@ export const useUIStore = create<UIState>((set, get) => ({
       const clampedIndex = Math.max(0, Math.min(index, layout[toRegion].length));
       layout[toRegion].splice(clampedIndex, 0, panel);
 
-      if (fromRegion && active[fromRegion] === panel) {
-        active[fromRegion] = layout[fromRegion].length > 0 ? layout[fromRegion][0] : null;
+      const sourceRegion = fromRegion as PanelRegion | null;
+      if (sourceRegion && active[sourceRegion] === panel) {
+        active[sourceRegion] = layout[sourceRegion].length > 0 ? layout[sourceRegion][0] : null;
       }
       active[toRegion] = panel;
+      nextActivePanels = active;
 
       return {
         panelLayout: layout,
@@ -441,36 +468,43 @@ export const useUIStore = create<UIState>((set, get) => ({
         activePanel: panel,
         renderedPanel: panel,
       };
-    }),
+    });
 
-  setActivePanel: (region, panel) =>
-    set((state) => {
-      if (!panel) return state;
-      const updates: Partial<UIState> = {
-        activePanels: { ...state.activePanels, [region]: panel },
-        activePanel: panel,
-        renderedPanel: panel,
+    if (nextActivePanels) resetWbPickerForActivePanels(nextActivePanels);
+  },
+
+  setActivePanel: (region, panel) => {
+    if (!panel) return;
+    const state = get();
+    const activePanels = { ...state.activePanels, [region]: panel };
+    const updates: Partial<UIState> = {
+      activePanels,
+      activePanel: panel,
+      renderedPanel: panel,
+    };
+
+    const isLeft = region === 'leftTop' || region === 'leftBottom';
+    const isRight = region === 'rightTop' || region === 'rightBottom';
+
+    if ((isLeft && !state.uiVisibility.leftPanel) || (isRight && !state.uiVisibility.rightPanel)) {
+      updates.uiVisibility = {
+        ...state.uiVisibility,
+        leftPanel: isLeft ? true : state.uiVisibility.leftPanel,
+        rightPanel: isRight ? true : state.uiVisibility.rightPanel,
       };
+    }
 
-      const isLeft = region === 'leftTop' || region === 'leftBottom';
-      const isRight = region === 'rightTop' || region === 'rightBottom';
+    if (isLeft && !state.uiVisibility.leftPanel && state.leftPanelWidth < DEFAULT_PANEL_WIDTH) {
+      updates.leftPanelWidth = DEFAULT_PANEL_WIDTH;
+    }
 
-      if (isLeft && !state.uiVisibility.leftPanel) {
-        updates.uiVisibility = { ...state.uiVisibility, leftPanel: true };
-        if (state.leftPanelWidth < DEFAULT_PANEL_WIDTH) {
-          updates.leftPanelWidth = DEFAULT_PANEL_WIDTH;
-        }
-      }
+    if (isRight && !state.uiVisibility.rightPanel && state.rightPanelWidth < DEFAULT_PANEL_WIDTH) {
+      updates.rightPanelWidth = DEFAULT_PANEL_WIDTH;
+    }
 
-      if (isRight && !state.uiVisibility.rightPanel) {
-        updates.uiVisibility = { ...state.uiVisibility, rightPanel: true };
-        if (state.rightPanelWidth < DEFAULT_PANEL_WIDTH) {
-          updates.rightPanelWidth = DEFAULT_PANEL_WIDTH;
-        }
-      }
-
-      return updates;
-    }),
+    set(updates);
+    resetWbPickerForActivePanels(activePanels);
+  },
 
   setPanel: (panelId) => {
     const state = get();


### PR DESCRIPTION
## Description

Fix follows the approach proposed by @QuirkyTurtle94 in #1550.

The white balance eyedropper could remain active after switching away from the Adjustments panel on desktop. The next canvas click was then consumed as a white balance sample instead of starting a mask interaction.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Deactivate the white balance picker when panel state changes away from Adjustments or shows Crop, Masks, or AI tools.
- Prevent a stale picker state from taking precedence over mask and AI editing interactions.
- Allow `Escape` to cancel the active white balance picker.
- Use `activePanels` so the cleanup also works with docked panels and alternate panel-switching paths.

## Screenshots/Videos

Not applicable. This is an interaction-state fix with no visual UI change.

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

Validation performed:

- `npm run build` passes.
- Prettier check passes.
- `git diff --check` passes.

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [ ] My changes generate no new warnings or errors

## Additional Notes

The repository currently reports unrelated pre-existing typecheck and lint errors. No new errors were reported for the changed code paths.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [ ] This PR is created by an AI agent
- [x] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)