### PR TITLE
fix: apply ratings to grouped RAW and JPEG files

### DIFF
--- a/src/components/panel/library/CullingView.tsx
+++ b/src/components/panel/library/CullingView.tsx
@@ -24,9 +24,11 @@ import { Thumbnail } from './LibraryItems';
 import Text from '../../ui/Text';
 import { TextColors, TextVariants, TextWeights } from '../../../types/typography';
 import { useProcessStore } from '../../../store/useProcessStore';
+import { useLibraryStore } from '../../../store/useLibraryStore';
 import { useSettingsStore } from '../../../store/useSettingsStore';
 import { useLibraryActions } from '../../../hooks/useLibraryActions';
 import { COLOR_LABELS, Color } from '../../../utils/adjustments';
+import { expandGroupedPaths } from '../../../utils/imageGrouping';
 import { IconAperture, IconFocalLength, IconIso, IconShutter } from '../editor/ExifIcons';
 
 interface SyncViewport {
@@ -92,6 +94,12 @@ function CullingPreview({
   const [fitScale, setFitScale] = useState<number | null>(null);
   const { handleRate, handleSetColorLabel, handleTagsChanged } = useLibraryActions();
   const USER_TAG_PREFIX = 'user:';
+  const imageList = useLibraryStore((s) => s.imageList);
+  const groupingMode = useSettingsStore((s) => s.appSettings?.grouping ?? 'off');
+  const pathsToUpdate = useMemo(
+    () => expandGroupedPaths(imageList, [image.path], groupingMode),
+    [groupingMode, image.path, imageList],
+  );
 
   const currentColor = useMemo(() => {
     return image.tags?.find((t) => t.startsWith('color:'))?.substring(6) || null;
@@ -161,9 +169,9 @@ function CullingPreview({
     if (newTagValue && !currentTags.some((t) => t.tag === newTagValue)) {
       try {
         const prefixedTag = `${USER_TAG_PREFIX}${newTagValue}`;
-        await invoke(Invokes.AddTagForPaths, { paths: [image.path], tag: prefixedTag });
+        await invoke(Invokes.AddTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
         const newTags = [...currentTags, { tag: newTagValue, isUser: true }];
-        handleTagsChanged([image.path], newTags);
+        handleTagsChanged(pathsToUpdate, newTags);
         setTagInputValue('');
       } catch (err) {
         console.error(`Failed to add tag: ${err}`);
@@ -174,9 +182,9 @@ function CullingPreview({
   const handleRemoveTag = async (tagToRemove: { tag: string; isUser: boolean }) => {
     try {
       const prefixedTag = tagToRemove.isUser ? `${USER_TAG_PREFIX}${tagToRemove.tag}` : tagToRemove.tag;
-      await invoke(Invokes.RemoveTagForPaths, { paths: [image.path], tag: prefixedTag });
+      await invoke(Invokes.RemoveTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
       const newTags = currentTags.filter((t) => t.tag !== tagToRemove.tag);
-      handleTagsChanged([image.path], newTags);
+      handleTagsChanged(pathsToUpdate, newTags);
     } catch (err) {
       console.error(`Failed to remove tag: ${err}`);
     }

--- a/src/components/panel/library/CullingView.tsx
+++ b/src/components/panel/library/CullingView.tsx
@@ -94,12 +94,12 @@ function CullingPreview({
   const [fitScale, setFitScale] = useState<number | null>(null);
   const { handleRate, handleSetColorLabel, handleTagsChanged } = useLibraryActions();
   const USER_TAG_PREFIX = 'user:';
-  const imageList = useLibraryStore((s) => s.imageList);
-  const groupingMode = useSettingsStore((s) => s.appSettings?.grouping ?? 'off');
-  const pathsToUpdate = useMemo(
-    () => expandGroupedPaths(imageList, [image.path], groupingMode),
-    [groupingMode, image.path, imageList],
-  );
+  const getPathsToUpdate = () =>
+    expandGroupedPaths(
+      useLibraryStore.getState().imageList,
+      [image.path],
+      useSettingsStore.getState().appSettings?.grouping ?? 'off',
+    );
 
   const currentColor = useMemo(() => {
     return image.tags?.find((t) => t.startsWith('color:'))?.substring(6) || null;
@@ -169,9 +169,10 @@ function CullingPreview({
     if (newTagValue && !currentTags.some((t) => t.tag === newTagValue)) {
       try {
         const prefixedTag = `${USER_TAG_PREFIX}${newTagValue}`;
+        const pathsToUpdate = getPathsToUpdate();
         await invoke(Invokes.AddTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
         const newTags = [...currentTags, { tag: newTagValue, isUser: true }];
-        handleTagsChanged(pathsToUpdate, newTags);
+        handleTagsChanged([image.path], newTags);
         setTagInputValue('');
       } catch (err) {
         console.error(`Failed to add tag: ${err}`);
@@ -182,9 +183,10 @@ function CullingPreview({
   const handleRemoveTag = async (tagToRemove: { tag: string; isUser: boolean }) => {
     try {
       const prefixedTag = tagToRemove.isUser ? `${USER_TAG_PREFIX}${tagToRemove.tag}` : tagToRemove.tag;
+      const pathsToUpdate = getPathsToUpdate();
       await invoke(Invokes.RemoveTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
       const newTags = currentTags.filter((t) => t.tag !== tagToRemove.tag);
-      handleTagsChanged(pathsToUpdate, newTags);
+      handleTagsChanged([image.path], newTags);
     } catch (err) {
       console.error(`Failed to remove tag: ${err}`);
     }

--- a/src/components/panel/right/MetadataPanel.tsx
+++ b/src/components/panel/right/MetadataPanel.tsx
@@ -42,6 +42,7 @@ interface MetaDataItemProps {
 }
 
 const USER_TAG_PREFIX = 'user:';
+const EMPTY_TAGS: string[] = [];
 
 function formatExifTag(str: string) {
   if (!str) return '';
@@ -238,7 +239,6 @@ export default function MetadataPanel() {
   const [isTagInputFocused, setIsTagInputFocused] = useState(false);
   const selectedImage = useEditorStore((s) => s.selectedImage);
   const multiSelectedPaths = useLibraryStore((s) => s.multiSelectedPaths);
-  const imageList = useLibraryStore((s) => s.imageList);
   const imageRatings = useLibraryStore((s) => s.imageRatings);
   const appSettings = useSettingsStore((s) => s.appSettings);
   const thumbnails = useProcessStore((s) => s.thumbnails);
@@ -246,14 +246,18 @@ export default function MetadataPanel() {
   const { handleRate, handleSetColorLabel, handleTagsChanged, handleUpdateExif } = useLibraryActions();
 
   const rating = selectedImage ? imageRatings[selectedImage.path] || 0 : 0;
-  const tags = selectedImage ? imageList.find((img) => img.path === selectedImage.path)?.tags || [] : [];
+  const tags = useLibraryStore((state) => {
+    if (!selectedImage) return EMPTY_TAGS;
+    return state.imageList.find((img) => img.path === selectedImage.path)?.tags ?? EMPTY_TAGS;
+  });
   const liveThumbnailUrl = selectedImage ? thumbnails[selectedImage.path] : undefined;
 
   const targetPaths = multiSelectedPaths?.length > 0 ? multiSelectedPaths : selectedImage ? [selectedImage.path] : [];
-  const pathsToUpdate = useMemo(
-    () => expandGroupedPaths(imageList, targetPaths, appSettings?.grouping ?? 'off'),
-    [appSettings?.grouping, imageList, targetPaths],
-  );
+  const getPathsToUpdate = () => {
+    const { imageList } = useLibraryStore.getState();
+    const groupingMode = useSettingsStore.getState().appSettings?.grouping ?? 'off';
+    return expandGroupedPaths(imageList, targetPaths, groupingMode);
+  };
 
   const { cameraGridSettings, lensSetting, gpsData, otherExifEntries } = useMemo(() => {
     const exif = selectedImage?.exif || {};
@@ -352,10 +356,11 @@ export default function MetadataPanel() {
     if (newTagValue && !currentTags.some((t) => t.tag === newTagValue)) {
       try {
         const prefixedTag = `${USER_TAG_PREFIX}${newTagValue}`;
+        const pathsToUpdate = getPathsToUpdate();
         await invoke(Invokes.AddTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
 
         const newTags = [...currentTags, { tag: newTagValue, isUser: true }];
-        handleTagsChanged(pathsToUpdate, newTags);
+        handleTagsChanged(targetPaths, newTags);
         setTagInputValue('');
       } catch (err) {
         console.error(`Failed to add tag: ${err}`);
@@ -366,10 +371,11 @@ export default function MetadataPanel() {
   const handleRemoveTag = async (tagToRemove: { tag: string; isUser: boolean }) => {
     try {
       const prefixedTag = tagToRemove.isUser ? `${USER_TAG_PREFIX}${tagToRemove.tag}` : tagToRemove.tag;
+      const pathsToUpdate = getPathsToUpdate();
       await invoke(Invokes.RemoveTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
 
       const newTags = currentTags.filter((t) => t.tag !== tagToRemove.tag);
-      handleTagsChanged(pathsToUpdate, newTags);
+      handleTagsChanged(targetPaths, newTags);
     } catch (err) {
       console.error(`Failed to remove tag: ${err}`);
     }

--- a/src/components/panel/right/MetadataPanel.tsx
+++ b/src/components/panel/right/MetadataPanel.tsx
@@ -14,6 +14,7 @@ import { useLibraryStore } from '../../../store/useLibraryStore';
 import { useSettingsStore } from '../../../store/useSettingsStore';
 import { useProcessStore } from '../../../store/useProcessStore';
 import { useLibraryActions } from '../../../hooks/useLibraryActions';
+import { expandGroupedPaths } from '../../../utils/imageGrouping';
 
 interface CameraSetting {
   format?(value: number): string | number;
@@ -249,6 +250,10 @@ export default function MetadataPanel() {
   const liveThumbnailUrl = selectedImage ? thumbnails[selectedImage.path] : undefined;
 
   const targetPaths = multiSelectedPaths?.length > 0 ? multiSelectedPaths : selectedImage ? [selectedImage.path] : [];
+  const pathsToUpdate = useMemo(
+    () => expandGroupedPaths(imageList, targetPaths, appSettings?.grouping ?? 'off'),
+    [appSettings?.grouping, imageList, targetPaths],
+  );
 
   const { cameraGridSettings, lensSetting, gpsData, otherExifEntries } = useMemo(() => {
     const exif = selectedImage?.exif || {};
@@ -347,10 +352,10 @@ export default function MetadataPanel() {
     if (newTagValue && !currentTags.some((t) => t.tag === newTagValue)) {
       try {
         const prefixedTag = `${USER_TAG_PREFIX}${newTagValue}`;
-        await invoke(Invokes.AddTagForPaths, { paths: targetPaths, tag: prefixedTag });
+        await invoke(Invokes.AddTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
 
         const newTags = [...currentTags, { tag: newTagValue, isUser: true }];
-        handleTagsChanged(targetPaths, newTags);
+        handleTagsChanged(pathsToUpdate, newTags);
         setTagInputValue('');
       } catch (err) {
         console.error(`Failed to add tag: ${err}`);
@@ -361,10 +366,10 @@ export default function MetadataPanel() {
   const handleRemoveTag = async (tagToRemove: { tag: string; isUser: boolean }) => {
     try {
       const prefixedTag = tagToRemove.isUser ? `${USER_TAG_PREFIX}${tagToRemove.tag}` : tagToRemove.tag;
-      await invoke(Invokes.RemoveTagForPaths, { paths: targetPaths, tag: prefixedTag });
+      await invoke(Invokes.RemoveTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
 
       const newTags = currentTags.filter((t) => t.tag !== tagToRemove.tag);
-      handleTagsChanged(targetPaths, newTags);
+      handleTagsChanged(pathsToUpdate, newTags);
     } catch (err) {
       console.error(`Failed to remove tag: ${err}`);
     }

--- a/src/context/TaggingSubMenu.tsx
+++ b/src/context/TaggingSubMenu.tsx
@@ -56,7 +56,7 @@ export default function TaggingSubMenu({
         await invoke(Invokes.AddTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
         const newTags = [...tags, { tag: newTagValue, isUser: true }].sort((a, b) => a.tag.localeCompare(b.tag));
         setTags(newTags);
-        onTagsChanged(pathsToUpdate, newTags);
+        onTagsChanged(paths, newTags);
         setInputValue('');
       } catch (err) {
         console.error(`Failed to add tag: ${err}`);
@@ -71,7 +71,7 @@ export default function TaggingSubMenu({
       await invoke(Invokes.RemoveTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
       const newTags = tags.filter((t) => t.tag !== tagToRemove.tag);
       setTags(newTags);
-      onTagsChanged(pathsToUpdate, newTags);
+      onTagsChanged(paths, newTags);
     } catch (err) {
       console.error(`Failed to remove tag: ${err}`);
     }

--- a/src/context/TaggingSubMenu.tsx
+++ b/src/context/TaggingSubMenu.tsx
@@ -6,6 +6,8 @@ import { useTranslation } from 'react-i18next';
 import { Invokes } from '../components/ui/AppProperties';
 import Text from '../components/ui/Text';
 import { TextVariants } from '../types/typography';
+import { useLibraryStore } from '../store/useLibraryStore';
+import { expandGroupedPaths } from '../utils/imageGrouping';
 
 interface TaggingSubMenuProps {
   paths: string[];
@@ -42,15 +44,19 @@ export default function TaggingSubMenu({
     inputRef.current?.focus();
   }, []);
 
+  const getPathsToUpdate = () =>
+    expandGroupedPaths(useLibraryStore.getState().imageList, paths, appSettings?.grouping ?? 'off');
+
   const handleAddTag = async (tagToAdd: string) => {
     const newTagValue = tagToAdd.trim().toLowerCase();
     if (newTagValue && !tags.some((t) => t.tag === newTagValue)) {
       try {
         const prefixedTag = `${USER_TAG_PREFIX}${newTagValue}`;
-        await invoke(Invokes.AddTagForPaths, { paths, tag: prefixedTag });
+        const pathsToUpdate = getPathsToUpdate();
+        await invoke(Invokes.AddTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
         const newTags = [...tags, { tag: newTagValue, isUser: true }].sort((a, b) => a.tag.localeCompare(b.tag));
         setTags(newTags);
-        onTagsChanged(paths, newTags);
+        onTagsChanged(pathsToUpdate, newTags);
         setInputValue('');
       } catch (err) {
         console.error(`Failed to add tag: ${err}`);
@@ -61,10 +67,11 @@ export default function TaggingSubMenu({
   const handleRemoveTag = async (tagToRemove: { tag: string; isUser: boolean }) => {
     try {
       const prefixedTag = tagToRemove.isUser ? `${USER_TAG_PREFIX}${tagToRemove.tag}` : tagToRemove.tag;
-      await invoke(Invokes.RemoveTagForPaths, { paths, tag: prefixedTag });
+      const pathsToUpdate = getPathsToUpdate();
+      await invoke(Invokes.RemoveTagForPaths, { paths: pathsToUpdate, tag: prefixedTag });
       const newTags = tags.filter((t) => t.tag !== tagToRemove.tag);
       setTags(newTags);
-      onTagsChanged(paths, newTags);
+      onTagsChanged(pathsToUpdate, newTags);
     } catch (err) {
       console.error(`Failed to remove tag: ${err}`);
     }

--- a/src/hooks/useLibraryActions.ts
+++ b/src/hooks/useLibraryActions.ts
@@ -8,17 +8,32 @@ import { Invokes, ImageFile, AlbumItem, Album, AlbumGroup } from '../components/
 import { globalImageCache } from '../utils/ImageLRUCache';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { computeSortedLibrary } from './useSortedLibrary';
+import { findGroupVariants } from '../utils/imageGrouping';
 
 export function useLibraryActions(handleImageSelect?: (path: string, openInEditor?: boolean) => void) {
   const handleRate = useCallback((newRating: number, paths?: string[]) => {
-    const { multiSelectedPaths, imageRatings, setLibrary } = useLibraryStore.getState();
+    const { multiSelectedPaths, imageList, imageRatings, setLibrary } = useLibraryStore.getState();
     const { selectedImage } = useEditorStore.getState();
 
-    const pathsToRate =
+    const selectedPaths =
       paths || (multiSelectedPaths.length > 0 ? multiSelectedPaths : selectedImage ? [selectedImage.path] : []);
-    if (pathsToRate.length === 0) return;
+    if (selectedPaths.length === 0) return;
 
-    const currentRating = imageRatings[pathsToRate[0]] || 0;
+    const groupingMode = useSettingsStore.getState().appSettings?.grouping ?? 'off';
+    const pathsToRate = Array.from(
+      new Set(
+        selectedPaths.flatMap((path) => {
+          if (groupingMode === 'off') return [path];
+
+          const image = imageList.find((item) => item.path === path);
+          return image?.group_id
+            ? findGroupVariants(imageList, image.group_id).map((variant) => variant.path)
+            : [path];
+        }),
+      ),
+    );
+
+    const currentRating = imageRatings[selectedPaths[0]] || 0;
     const finalRating = newRating === currentRating ? 0 : newRating;
 
     setLibrary((state) => {

--- a/src/hooks/useLibraryActions.ts
+++ b/src/hooks/useLibraryActions.ts
@@ -8,7 +8,7 @@ import { Invokes, ImageFile, AlbumItem, Album, AlbumGroup } from '../components/
 import { globalImageCache } from '../utils/ImageLRUCache';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { computeSortedLibrary } from './useSortedLibrary';
-import { findGroupVariants } from '../utils/imageGrouping';
+import { expandGroupedPaths } from '../utils/imageGrouping';
 
 export function useLibraryActions(handleImageSelect?: (path: string, openInEditor?: boolean) => void) {
   const handleRate = useCallback((newRating: number, paths?: string[]) => {
@@ -20,18 +20,7 @@ export function useLibraryActions(handleImageSelect?: (path: string, openInEdito
     if (selectedPaths.length === 0) return;
 
     const groupingMode = useSettingsStore.getState().appSettings?.grouping ?? 'off';
-    const pathsToRate = Array.from(
-      new Set(
-        selectedPaths.flatMap((path) => {
-          if (groupingMode === 'off') return [path];
-
-          const image = imageList.find((item) => item.path === path);
-          return image?.group_id
-            ? findGroupVariants(imageList, image.group_id).map((variant) => variant.path)
-            : [path];
-        }),
-      ),
-    );
+    const pathsToRate = expandGroupedPaths(imageList, selectedPaths, groupingMode);
 
     const currentRating = imageRatings[selectedPaths[0]] || 0;
     const finalRating = newRating === currentRating ? 0 : newRating;
@@ -54,9 +43,12 @@ export function useLibraryActions(handleImageSelect?: (path: string, openInEdito
     const { multiSelectedPaths, libraryActivePath, imageList, setLibrary } = useLibraryStore.getState();
     const { selectedImage } = useEditorStore.getState();
 
-    const pathsToUpdate =
+    const selectedPaths =
       paths || (multiSelectedPaths.length > 0 ? multiSelectedPaths : selectedImage ? [selectedImage.path] : []);
-    if (pathsToUpdate.length === 0) return;
+    if (selectedPaths.length === 0) return;
+
+    const groupingMode = useSettingsStore.getState().appSettings?.grouping ?? 'off';
+    const pathsToUpdate = expandGroupedPaths(imageList, selectedPaths, groupingMode);
 
     const primaryPath = selectedImage?.path || libraryActivePath;
     const primaryImage = imageList.find((img: ImageFile) => img.path === primaryPath);
@@ -85,9 +77,13 @@ export function useLibraryActions(handleImageSelect?: (path: string, openInEdito
   }, []);
 
   const handleTagsChanged = useCallback((changedPaths: string[], newTags: { tag: string; isUser: boolean }[]) => {
+    const { imageList } = useLibraryStore.getState();
+    const groupingMode = useSettingsStore.getState().appSettings?.grouping ?? 'off';
+    const pathsToUpdate = expandGroupedPaths(imageList, changedPaths, groupingMode);
+
     useLibraryStore.getState().setLibrary((state) => ({
       imageList: state.imageList.map((image) => {
-        if (changedPaths.includes(image.path)) {
+        if (pathsToUpdate.includes(image.path)) {
           const colorTags = (image.tags || []).filter((t) => t.startsWith('color:'));
           const prefixedNewTags = newTags.map((t) => (t.isUser ? `user:${t.tag}` : t.tag));
           const finalTags = [...colorTags, ...prefixedNewTags].sort();

--- a/src/utils/imageGrouping.ts
+++ b/src/utils/imageGrouping.ts
@@ -1,4 +1,4 @@
-import { GroupPreference, ImageFile } from '../components/ui/AppProperties';
+import { GroupPreference, GroupingMode, ImageFile } from '../components/ui/AppProperties';
 
 export type GroupId = string;
 
@@ -84,4 +84,20 @@ export function getVariantLabel(path: string): string {
 export function findGroupVariants(images: ImageFile[], groupId: string | null | undefined): ImageFile[] {
   if (!groupId) return [];
   return images.filter((img) => img.group_id === groupId && !img.is_virtual_copy);
+}
+
+export function expandGroupedPaths(images: ImageFile[], paths: string[], groupingMode: GroupingMode): string[] {
+  const expandedPaths = new Set(paths);
+  if (groupingMode === 'off') return Array.from(expandedPaths);
+
+  for (const path of paths) {
+    const image = images.find((item) => item.path === path);
+    if (!image?.group_id) continue;
+
+    for (const variant of findGroupVariants(images, image.group_id)) {
+      expandedPaths.add(variant.path);
+    }
+  }
+
+  return Array.from(expandedPaths);
 }


### PR DESCRIPTION
## Description

Fixes rating synchronization for grouped RAW+JPEG files. When grouping is enabled, ratings are now applied to all files in the group, regardless of the preferred format.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Expanded rating actions to include all non-virtual variants in an active group.
- Deduplicated paths before updating local state and backend metadata.
- Preserved independent ratings when grouping is disabled.

## Screenshots/Videos

Not applicable; this is a metadata behavior fix with no UI changes.

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

Additional validation:
- Production build passed.
- Focused lint and diff checks passed.

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

Resolves #1555.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [ ] This PR is created by an AI agent
- [x] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)