### PR TITLE
fix: keep filter menu above left panel

### DIFF
--- a/src/components/panel/MainLibrary.tsx
+++ b/src/components/panel/MainLibrary.tsx
@@ -508,7 +508,7 @@ export default function MainLibrary(props: MainLibraryProps) {
   }
 
   return (
-    <div className="flex-1 flex flex-col h-full min-w-0 bg-bg-secondary rounded-lg overflow-hidden">
+    <div className="relative z-20 flex-1 flex flex-col h-full min-w-0 bg-bg-secondary rounded-lg overflow-visible">
       <header
         className="p-3 shrink-0 flex justify-between items-center border-b border-surface gap-4"
         onMouseEnter={() => setIsProgressHovered(true)}

--- a/src/components/panel/library/LibraryHeader.tsx
+++ b/src/components/panel/library/LibraryHeader.tsx
@@ -65,7 +65,7 @@ function DropdownMenu({ buttonContent, buttonTitle, children, contentClassName =
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            className={`absolute right-0 mt-2 ${contentClassName} origin-top-right z-20`}
+            className={`absolute right-0 mt-2 ${contentClassName} origin-top-right z-50`}
             initial={{ opacity: 0, scale: 0.95 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.95 }}


### PR DESCRIPTION
## Description

Fixes a UI layering issue where the library filter menu was clipped beneath the adjacent left panel.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Allow the library container to display dropdown content outside its bounds.
- Increase the filter menu stacking order so it renders above adjacent panels.

## Screenshots/Videos

**Before and after:**

<img width="1440" height="900" alt="Screenshot 2026-08-20 at 15 12 38" src="https://github.com/user-attachments/assets/bf577cfa-71fe-4b91-9493-13a6d5de829e" />
<img width="1440" height="900" alt="Screenshot 2026-08-20 at 15 15 03" src="https://github.com/user-attachments/assets/67d456e0-529e-4506-9d49-207ef4962b2a" />

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

`npm run build` passes successfully.

Existing unrelated typecheck and lint errors remain elsewhere in the repository.

## AI Disclaimer:

- [ ] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)