### PR TITLE
feat: double click resets panel size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ import LibraryView from './components/views/LibraryView';
 
 import { ContextMenuProvider } from './context/ContextMenuContext';
 import { useSettingsStore } from './store/useSettingsStore';
-import { useUIStore } from './store/useUIStore';
+import { DEFAULT_BOTTOM_PANEL_HEIGHT, DEFAULT_PANEL_WIDTH, useUIStore } from './store/useUIStore';
 import { useLibraryStore } from './store/useLibraryStore';
 import { useEditorStore } from './store/useEditorStore';
 import { useProcessStore } from './store/useProcessStore';
@@ -613,12 +613,34 @@ function App() {
       window.removeEventListener('pointercancel', stopDrag);
       setIsResizing(false);
     };
+
     document.documentElement.style.cursor =
       stateKey === 'bottom' || stateKey === 'compact' ? 'row-resize' : 'col-resize';
 
     window.addEventListener('pointermove', doDrag, { passive: false });
     window.addEventListener('pointerup', stopDrag);
     window.addEventListener('pointercancel', stopDrag);
+  };
+
+  const createResizeResetHandler = (stateKey: string) => () => {
+    if (stateKey === 'left') {
+      setUI((state) => ({
+        leftPanelWidth: DEFAULT_PANEL_WIDTH,
+        uiVisibility: { ...state.uiVisibility, leftPanel: true },
+      }));
+    } else if (stateKey === 'right') {
+      setUI((state) => ({
+        rightPanelWidth: DEFAULT_PANEL_WIDTH,
+        uiVisibility: { ...state.uiVisibility, rightPanel: true },
+      }));
+    } else if (stateKey === 'bottom') {
+      setUI((state) => ({
+        bottomPanelHeight: DEFAULT_BOTTOM_PANEL_HEIGHT,
+        uiVisibility: { ...state.uiVisibility, filmstrip: true },
+      }));
+    } else if (stateKey === 'compact') {
+      setUI({ compactEditorPanelHeightOverride: null });
+    }
   };
 
   useEffect(() => {
@@ -864,6 +886,7 @@ function App() {
                   bottomRegion="leftBottom"
                   renderPanel={renderAppPanel}
                   onWidthChange={createResizeHandler('left', effectiveLeftWidth)}
+                  onWidthReset={createResizeResetHandler('left')}
                   isResizing={isResizing}
                 />
               )}
@@ -893,6 +916,7 @@ function App() {
                       thumbnailAspectRatio={thumbnailAspectRatio}
                       sortedImageList={sortedImageList}
                       createResizeHandler={createResizeHandler}
+                      createResizeResetHandler={createResizeResetHandler}
                       handleBackToLibrary={handleBackToLibrary}
                       handleEditorContextMenu={handleEditorContextMenu}
                       handleThumbnailContextMenu={handleThumbnailContextMenu}
@@ -964,6 +988,7 @@ function App() {
                   bottomRegion="rightBottom"
                   renderPanel={renderAppPanel}
                   onWidthChange={createResizeHandler('right', effectiveRightWidth)}
+                  onWidthReset={createResizeResetHandler('right')}
                   isResizing={isResizing}
                 />
               )}

--- a/src/components/panel/SidePanelArea.tsx
+++ b/src/components/panel/SidePanelArea.tsx
@@ -3,7 +3,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 import { useDroppable, useDndMonitor } from '@dnd-kit/core';
-import { SwitcherPlacement, useUIStore } from '../../store/useUIStore';
+import { DEFAULT_PANEL_SECTION_HEIGHT, SwitcherPlacement, useUIStore } from '../../store/useUIStore';
 import { Panel, PanelRegion } from '../ui/AppProperties';
 import PanelSwitcher from './PanelSwitcher';
 
@@ -16,6 +16,7 @@ interface SidePanelAreaProps {
   bottomRegion: PanelRegion;
   renderPanel: (panel: Panel) => React.ReactNode;
   onWidthChange: (e: React.PointerEvent<HTMLDivElement>) => void;
+  onWidthReset: () => void;
   isResizing: boolean;
 }
 
@@ -316,6 +317,7 @@ export default function SidePanelArea({
   bottomRegion,
   renderPanel,
   onWidthChange,
+  onWidthReset,
   isResizing,
 }: SidePanelAreaProps) {
   const panelLayout = useUIStore((s) => s.panelLayout);
@@ -361,6 +363,14 @@ export default function SidePanelArea({
     [topHeight, side, setUI],
   );
 
+  const handleVerticalResizeReset = useCallback(() => {
+    if (side === 'left') {
+      setUI({ leftTopHeight: DEFAULT_PANEL_SECTION_HEIGHT });
+    } else {
+      setUI({ rightTopHeight: DEFAULT_PANEL_SECTION_HEIGHT });
+    }
+  }, [side, setUI]);
+
   const topPanels = panelLayout[topRegion];
   const bottomPanels = panelLayout[bottomRegion];
 
@@ -390,7 +400,11 @@ export default function SidePanelArea({
       style={{ width: isFullScreen ? 0 : width }}
     >
       {side === 'right' && (
-        <div className="shrink-0 w-2 my-auto h-full cursor-col-resize z-20" onPointerDown={onWidthChange} />
+        <div
+          className="shrink-0 w-2 my-auto h-full cursor-col-resize z-20"
+          onPointerDown={onWidthChange}
+          onDoubleClick={onWidthReset}
+        />
       )}
 
       <div ref={colContainerRef} className="flex flex-col h-full w-full overflow-hidden relative">
@@ -417,7 +431,11 @@ export default function SidePanelArea({
         )}
 
         {hasTop && hasBottom && (
-          <div className="shrink-0 h-2 cursor-row-resize z-20" onPointerDown={handleVerticalResize} />
+          <div
+            className="shrink-0 h-2 cursor-row-resize z-20"
+            onPointerDown={handleVerticalResize}
+            onDoubleClick={handleVerticalResizeReset}
+          />
         )}
 
         {hasBottom && (
@@ -454,7 +472,11 @@ export default function SidePanelArea({
       </div>
 
       {side === 'left' && (
-        <div className="shrink-0 w-2 my-auto h-full cursor-col-resize z-20" onPointerDown={onWidthChange} />
+        <div
+          className="shrink-0 w-2 my-auto h-full cursor-col-resize z-20"
+          onPointerDown={onWidthChange}
+          onDoubleClick={onWidthReset}
+        />
       )}
     </div>
   );

--- a/src/components/ui/Resizer.tsx
+++ b/src/components/ui/Resizer.tsx
@@ -1,13 +1,14 @@
 import clsx from 'clsx';
-import type { PointerEventHandler } from 'react';
+import type { MouseEventHandler, PointerEventHandler } from 'react';
 import { Orientation } from './AppProperties';
 
 interface ResizerProps {
   direction: Orientation;
   onMouseDown: PointerEventHandler<HTMLDivElement>;
+  onDoubleClick?: MouseEventHandler<HTMLDivElement>;
 }
 
-const Resizer = ({ direction, onMouseDown }: ResizerProps) => (
+const Resizer = ({ direction, onMouseDown, onDoubleClick }: ResizerProps) => (
   <div
     className={clsx('shrink-0 bg-transparent z-10 touch-none', {
       'w-2 cursor-col-resize': direction === Orientation.Vertical,
@@ -16,6 +17,7 @@ const Resizer = ({ direction, onMouseDown }: ResizerProps) => (
     role="separator"
     aria-orientation={direction === Orientation.Vertical ? 'vertical' : 'horizontal'}
     onPointerDown={onMouseDown}
+    onDoubleClick={onDoubleClick}
     style={{ touchAction: 'none' }}
   />
 );

--- a/src/components/views/EditorView.tsx
+++ b/src/components/views/EditorView.tsx
@@ -25,6 +25,7 @@ interface EditorViewProps {
   thumbnailAspectRatio: ThumbnailAspectRatio;
   sortedImageList: ImageFile[];
   createResizeHandler: (stateKey: string, startSize: number) => (e: ReactPointerEvent<HTMLDivElement>) => void;
+  createResizeResetHandler: (stateKey: string) => () => void;
   handleBackToLibrary: () => void;
   handleEditorContextMenu: (...args: any) => void;
   handleThumbnailContextMenu: (...args: any) => void;
@@ -50,6 +51,7 @@ export default function EditorView({
   thumbnailAspectRatio,
   sortedImageList,
   createResizeHandler,
+  createResizeResetHandler,
   handleBackToLibrary,
   handleEditorContextMenu,
   handleThumbnailContextMenu,
@@ -154,7 +156,11 @@ export default function EditorView({
       }}
     >
       {!isCompactPortrait && (
-        <Resizer direction={Orientation.Horizontal} onMouseDown={createResizeHandler('bottom', bottomPanelHeight)} />
+        <Resizer
+          direction={Orientation.Horizontal}
+          onMouseDown={createResizeHandler('bottom', bottomPanelHeight)}
+          onDoubleClick={createResizeResetHandler('bottom')}
+        />
       )}
       {editorBottomBarComponent}
     </div>
@@ -175,6 +181,7 @@ export default function EditorView({
         <Resizer
           direction={Orientation.Horizontal}
           onMouseDown={createResizeHandler('compact', compactEditorPanelHeight)}
+          onDoubleClick={createResizeResetHandler('compact')}
         />
       )}
       <div className="min-h-0 flex-1 overflow-hidden relative">

--- a/src/store/useUIStore.ts
+++ b/src/store/useUIStore.ts
@@ -108,6 +108,10 @@ export const DEFAULT_PANEL_DEFAULT_REGIONS: Record<Panel, PanelRegion> = {
   [Panel.Presets]: 'rightTop',
 };
 
+export const DEFAULT_PANEL_WIDTH = 350;
+export const DEFAULT_PANEL_SECTION_HEIGHT = 450;
+export const DEFAULT_BOTTOM_PANEL_HEIGHT = 144;
+
 export function reconcileWorkspace(
   savedWorkspace: WorkspaceState | undefined,
   isTetheringSupported: boolean,
@@ -115,10 +119,10 @@ export function reconcileWorkspace(
   const allowedPanels = new Set(ALL_PANELS.filter((p) => p !== Panel.Tethering || isTetheringSupported));
 
   const defaultWorkspace: WorkspaceState = {
-    leftPanelWidth: 350,
-    rightPanelWidth: 350,
-    leftTopHeight: 450,
-    rightTopHeight: 450,
+    leftPanelWidth: DEFAULT_PANEL_WIDTH,
+    rightPanelWidth: DEFAULT_PANEL_WIDTH,
+    leftTopHeight: DEFAULT_PANEL_SECTION_HEIGHT,
+    rightTopHeight: DEFAULT_PANEL_SECTION_HEIGHT,
     panelLayout: {
       leftTop: [Panel.Metadata, Panel.FolderTree, Panel.Export, ...(isTetheringSupported ? [Panel.Tethering] : [])],
       leftBottom: [],
@@ -275,11 +279,11 @@ export const useUIStore = create<UIState>((set, get) => ({
   isLibraryExportPanelVisible: false,
   isSettingsOpen: false,
 
-  leftPanelWidth: 350,
-  rightPanelWidth: 350,
-  bottomPanelHeight: 144,
-  leftTopHeight: 450,
-  rightTopHeight: 450,
+  leftPanelWidth: DEFAULT_PANEL_WIDTH,
+  rightPanelWidth: DEFAULT_PANEL_WIDTH,
+  bottomPanelHeight: DEFAULT_BOTTOM_PANEL_HEIGHT,
+  leftTopHeight: DEFAULT_PANEL_SECTION_HEIGHT,
+  rightTopHeight: DEFAULT_PANEL_SECTION_HEIGHT,
   compactEditorPanelHeightOverride: null,
 
   panelLayout: {


### PR DESCRIPTION
## Description

Adds double-click support to reset UI panel splitters to their default sizes.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Added shared constants for default panel widths and heights.
- Added double-click reset behavior for:
  - Left and right side-panel widths
  - Side-panel section heights
  - Filmstrip height
  - Compact mobile panel height
- Attached double-click handlers directly to resize handles.
- Removed `bottomPanelHeight` from the persisted workspace model.
- Avoided global event-listener accumulation during resizing.

## Screenshots/Videos

https://github.com/user-attachments/assets/a678de0f-ebc2-4e82-86f3-f924df59277b

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [ ] My changes generate no new warnings or errors

## Additional Notes

Formatting and diff checks pass. The existing typecheck still reports unrelated pre-existing errors.

## AI Disclaimer:

- [ ] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [x] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)