### PR TITLE
fix: backfill missing XMP sidecars and avoid filename collisions

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -3934,6 +3934,69 @@ pub fn create_virtual_copy(
     Ok(new_virtual_path)
 }
 
+#[tauri::command]
+pub fn create_missing_xmp_files(root_paths: Vec<String>) -> Result<usize, String> {
+    let mut created = 0;
+
+    for rrdata_path in collect_rrdata(&root_paths) {
+        if create_xmp_from_rrdata(&rrdata_path)? {
+            created += 1;
+        }
+    }
+
+    Ok(created)
+}
+
+fn collect_rrdata(root_paths: &[String]) -> Vec<PathBuf> {
+    let mut matches = Vec::new();
+
+    for root in root_paths {
+        for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+            let path = entry.path();
+
+            if path.is_file() && path.extension().and_then(|ext| ext.to_str()) == Some("rrdata") {
+                matches.push(path.to_path_buf());
+            }
+        }
+    }
+
+    matches
+}
+
+fn create_xmp_from_rrdata(rrdata_path: &Path) -> Result<bool, String> {
+    let Some(source_path) = rrdata_source_path(rrdata_path) else {
+        return Ok(false);
+    };
+
+    if resolve_xmp_path(&source_path).is_some() {
+        return Ok(false);
+    }
+
+    let metadata = crate::exif_processing::load_sidecar(rrdata_path);
+
+    try_sync_metadata_to_xmp(&source_path, &metadata, true)?;
+
+    Ok(true)
+}
+
+pub(crate) fn rrdata_source_path(rrdata: &Path) -> Option<PathBuf> {
+    let name = rrdata.file_name()?.to_str()?;
+    let base = name.strip_suffix(".rrdata")?;
+
+    let source_filename = if base.len() >= 7 && base.as_bytes()[base.len() - 7] == b'.' {
+        let id = &base[base.len() - 6..];
+        if id.chars().all(|c| c.is_ascii_hexdigit()) {
+            &base[..base.len() - 7]
+        } else {
+            base
+        }
+    } else {
+        base
+    };
+
+    Some(rrdata.with_file_name(source_filename))
+}
+
 pub fn extract_xmp_rating(content: &str) -> Option<u8> {
     if let Some(idx) = content.find("xmp:Rating=\"") {
         let start = idx + 12;
@@ -3983,8 +4046,8 @@ pub fn extract_xmp_tags(content: &str) -> Vec<String> {
 }
 
 pub fn resolve_xmp_path(image_path: &Path) -> Option<PathBuf> {
-    let xmp_path = image_path.with_extension("xmp");
-    let xmp_path_upper = image_path.with_extension("XMP");
+    let (xmp_path, xmp_path_upper) = xmp_paths(image_path)?;
+
     if xmp_path.exists() {
         Some(xmp_path)
     } else if xmp_path_upper.exists() {
@@ -3992,6 +4055,21 @@ pub fn resolve_xmp_path(image_path: &Path) -> Option<PathBuf> {
     } else {
         None
     }
+}
+
+fn xmp_paths(image_path: &Path) -> Option<(PathBuf, PathBuf)> {
+    let filename = image_path.file_name()?;
+
+    let mut lower_name = filename.to_os_string();
+    lower_name.push(".xmp");
+
+    let mut upper_name = filename.to_os_string();
+    upper_name.push(".XMP");
+
+    Some((
+        image_path.with_file_name(lower_name),
+        image_path.with_file_name(upper_name),
+    ))
 }
 
 pub fn sync_metadata_from_xmp(source_path: &Path, metadata: &mut ImageMetadata) -> bool {
@@ -4045,8 +4123,18 @@ pub fn sync_metadata_from_xmp(source_path: &Path, metadata: &mut ImageMetadata) 
 }
 
 pub fn sync_metadata_to_xmp(source_path: &Path, metadata: &ImageMetadata, create_if_missing: bool) {
-    let xmp_path = source_path.with_extension("xmp");
-    let xmp_path_upper = source_path.with_extension("XMP");
+    if let Err(error) = try_sync_metadata_to_xmp(source_path, metadata, create_if_missing) {
+        log::error!("Failed to sync XMP: {}", error);
+    }
+}
+
+fn try_sync_metadata_to_xmp(
+    source_path: &Path,
+    metadata: &ImageMetadata,
+    create_if_missing: bool,
+) -> Result<(), String> {
+    let (xmp_path, xmp_path_upper) = xmp_paths(source_path)
+        .ok_or_else(|| format!("Could not derive XMP path for {}", source_path.display()))?;
 
     let mut actual_xmp = if xmp_path.exists() {
         Some(xmp_path.clone())
@@ -4058,7 +4146,7 @@ pub fn sync_metadata_to_xmp(source_path: &Path, metadata: &ImageMetadata, create
 
     if actual_xmp.is_none() {
         if !create_if_missing {
-            return;
+            return Ok(());
         }
         let skeleton = r#"<?xml version="1.0" encoding="UTF-8"?>
 <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="RapidRAW">
@@ -4069,91 +4157,96 @@ pub fn sync_metadata_to_xmp(source_path: &Path, metadata: &ImageMetadata, create
   </rdf:Description>
  </rdf:RDF>
 </x:xmpmeta>"#;
-        if let Err(e) = fs::write(&xmp_path, skeleton) {
-            log::error!("Failed to create skeleton XMP: {}", e);
-            return;
-        }
+
+        fs::write(&xmp_path, skeleton)
+            .map_err(|error| format!("Failed to create skeleton XMP: {}", error))?;
+
         actual_xmp = Some(xmp_path);
     }
 
-    if let Some(xmp_file) = actual_xmp
-        && let Ok(mut content) = fs::read_to_string(&xmp_file)
-    {
-        let rating_str = metadata.rating.to_string();
-        let re_rating_attr = regex!(r#"xmp:Rating\s*=\s*"[^"]*""#);
-        let re_rating_tag = regex!(r#"<xmp:Rating\s*>[^<]*</xmp:Rating>"#);
+    let Some(xmp_file) = actual_xmp else {
+        return Ok(());
+    };
 
-        if re_rating_attr.is_match(&content) {
-            content = re_rating_attr
-                .replace(&content, format!("xmp:Rating=\"{}\"", rating_str))
+    let mut content =
+        fs::read_to_string(&xmp_file).map_err(|error| format!("Failed to read XMP: {}", error))?;
+
+    let rating_str = metadata.rating.to_string();
+    let re_rating_attr = regex!(r#"xmp:Rating\s*=\s*"[^"]*""#);
+    let re_rating_tag = regex!(r#"<xmp:Rating\s*>[^<]*</xmp:Rating>"#);
+
+    if re_rating_attr.is_match(&content) {
+        content = re_rating_attr
+            .replace(&content, format!("xmp:Rating=\"{}\"", rating_str))
+            .to_string();
+    } else if re_rating_tag.is_match(&content) {
+        content = re_rating_tag
+            .replace(&content, format!("<xmp:Rating>{}</xmp:Rating>", rating_str))
+            .to_string();
+    } else if let Some(last_index) = content.rfind("</rdf:Description>") {
+        let (start, end) = content.split_at(last_index);
+        content = format!("{} <xmp:Rating>{}</xmp:Rating>\n{}", start, rating_str, end);
+    }
+
+    let current_tags = metadata.tags.clone().unwrap_or_default();
+    let mut label = None;
+    let mut normal_tags = Vec::new();
+
+    for t in current_tags {
+        if let Some(color) = t.strip_prefix(COLOR_TAG_PREFIX) {
+            let mut c = color.chars();
+            let cap_color = match c.next() {
+                None => String::new(),
+                Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+            };
+            label = Some(cap_color);
+        } else {
+            normal_tags.push(t);
+        }
+    }
+
+    if let Some(lbl) = label {
+        let re_label_attr = regex!(r#"xmp:Label\s*=\s*"[^"]*""#);
+        let re_label_tag = regex!(r#"<xmp:Label\s*>[^<]*</xmp:Label>"#);
+
+        if re_label_attr.is_match(&content) {
+            content = re_label_attr
+                .replace(&content, format!("xmp:Label=\"{}\"", lbl))
                 .to_string();
-        } else if re_rating_tag.is_match(&content) {
-            content = re_rating_tag
-                .replace(&content, format!("<xmp:Rating>{}</xmp:Rating>", rating_str))
+        } else if re_label_tag.is_match(&content) {
+            content = re_label_tag
+                .replace(&content, format!("<xmp:Label>{}</xmp:Label>", lbl))
                 .to_string();
         } else if let Some(last_index) = content.rfind("</rdf:Description>") {
             let (start, end) = content.split_at(last_index);
-            content = format!("{} <xmp:Rating>{}</xmp:Rating>\n{}", start, rating_str, end);
+            content = format!("{} <xmp:Label>{}</xmp:Label>\n{}", start, lbl, end);
         }
-
-        let current_tags = metadata.tags.clone().unwrap_or_default();
-        let mut label = None;
-        let mut normal_tags = Vec::new();
-
-        for t in current_tags {
-            if let Some(color) = t.strip_prefix(COLOR_TAG_PREFIX) {
-                let mut c = color.chars();
-                let cap_color = match c.next() {
-                    None => String::new(),
-                    Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
-                };
-                label = Some(cap_color);
-            } else {
-                normal_tags.push(t);
-            }
-        }
-
-        if let Some(lbl) = label {
-            let re_label_attr = regex!(r#"xmp:Label\s*=\s*"[^"]*""#);
-            let re_label_tag = regex!(r#"<xmp:Label\s*>[^<]*</xmp:Label>"#);
-
-            if re_label_attr.is_match(&content) {
-                content = re_label_attr
-                    .replace(&content, format!("xmp:Label=\"{}\"", lbl))
-                    .to_string();
-            } else if re_label_tag.is_match(&content) {
-                content = re_label_tag
-                    .replace(&content, format!("<xmp:Label>{}</xmp:Label>", lbl))
-                    .to_string();
-            } else if let Some(last_index) = content.rfind("</rdf:Description>") {
-                let (start, end) = content.split_at(last_index);
-                content = format!("{} <xmp:Label>{}</xmp:Label>\n{}", start, lbl, end);
-            }
-        } else {
-            let re_label_attr = regex!(r#"\s*xmp:Label\s*=\s*"[^"]*""#);
-            let re_label_tag = regex!(r#"\s*<xmp:Label\s*>[^<]*</xmp:Label>"#);
-            content = re_label_attr.replace_all(&content, "").to_string();
-            content = re_label_tag.replace_all(&content, "").to_string();
-        }
-
-        let re_subject = regex!(r#"(?s)<dc:subject>\s*<rdf:Bag>.*?</rdf:Bag>\s*</dc:subject>"#);
-        if normal_tags.is_empty() {
-            content = re_subject.replace_all(&content, "").to_string();
-        } else {
-            let mut bag = String::from("<dc:subject>\n    <rdf:Bag>\n");
-            for t in normal_tags {
-                bag.push_str(&format!("     <rdf:li>{}</rdf:li>\n", t));
-            }
-            bag.push_str("    </rdf:Bag>\n   </dc:subject>");
-
-            if re_subject.is_match(&content) {
-                content = re_subject.replace(&content, bag).to_string();
-            } else if let Some(last_index) = content.rfind("</rdf:Description>") {
-                let (start, end) = content.split_at(last_index);
-                content = format!("{} {}\n  {}", start, bag, end);
-            }
-        }
-
-        let _ = fs::write(&xmp_file, content);
+    } else {
+        let re_label_attr = regex!(r#"\s*xmp:Label\s*=\s*"[^"]*""#);
+        let re_label_tag = regex!(r#"\s*<xmp:Label\s*>[^<]*</xmp:Label>"#);
+        content = re_label_attr.replace_all(&content, "").to_string();
+        content = re_label_tag.replace_all(&content, "").to_string();
     }
+
+    let re_subject = regex!(r#"(?s)<dc:subject>\s*<rdf:Bag>.*?</rdf:Bag>\s*</dc:subject>"#);
+    if normal_tags.is_empty() {
+        content = re_subject.replace_all(&content, "").to_string();
+    } else {
+        let mut bag = String::from("<dc:subject>\n    <rdf:Bag>\n");
+        for t in normal_tags {
+            bag.push_str(&format!("     <rdf:li>{}</rdf:li>\n", t));
+        }
+        bag.push_str("    </rdf:Bag>\n   </dc:subject>");
+
+        if re_subject.is_match(&content) {
+            content = re_subject.replace(&content, bag).to_string();
+        } else if let Some(last_index) = content.rfind("</rdf:Description>") {
+            let (start, end) = content.split_at(last_index);
+            content = format!("{} {}\n  {}", start, bag, end);
+        }
+    }
+
+    fs::write(&xmp_file, content).map_err(|error| format!("Failed to write XMP: {}", error))?;
+
+    Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2403,6 +2403,7 @@ pub fn run() {
             file_management::save_albums,
             file_management::add_to_album,
             file_management::get_album_images,
+            file_management::create_missing_xmp_files,
             tagging::start_background_indexing,
             tagging::clear_ai_tags,
             tagging::clear_all_tags,

--- a/src-tauri/src/tagging.rs
+++ b/src-tauri/src/tagging.rs
@@ -483,24 +483,6 @@ pub fn remove_tag_for_paths(
     Ok(())
 }
 
-fn rrdata_source_path(rrdata: &Path) -> Option<PathBuf> {
-    let name = rrdata.file_name()?.to_str()?;
-    let base = name.strip_suffix(".rrdata")?;
-
-    let source_filename = if base.len() >= 7 && base.as_bytes()[base.len() - 7] == b'.' {
-        let id = &base[base.len() - 6..];
-        if id.chars().all(|c| c.is_ascii_hexdigit()) {
-            &base[..base.len() - 7]
-        } else {
-            base
-        }
-    } else {
-        base
-    };
-
-    Some(rrdata.with_file_name(source_filename))
-}
-
 fn sync_xmp_for_rrdata(
     rrdata_path: &Path,
     metadata: &ImageMetadata,
@@ -510,7 +492,7 @@ fn sync_xmp_for_rrdata(
     if !enable_xmp_sync {
         return;
     }
-    if let Some(source_path) = rrdata_source_path(rrdata_path) {
+    if let Some(source_path) = crate::file_management::rrdata_source_path(rrdata_path) {
         file_management::sync_metadata_to_xmp(&source_path, metadata, create_xmp_if_missing);
     }
 }

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -47,6 +47,7 @@ import { useOsPlatform } from '../../hooks/useOsPlatform';
 import { open } from '@tauri-apps/plugin-shell';
 import { RotateCcw } from 'lucide-react';
 import { useUIStore } from '../../store/useUIStore';
+import { toast } from 'react-toastify';
 
 interface ConfirmModalState {
   confirmText: string;
@@ -1164,9 +1165,27 @@ export default function SettingsPanel({
                                     checked={appSettings?.createXmpIfMissing ?? false}
                                     id="create-xmp-missing-toggle"
                                     label={t('settings.general.createXmpMissing')}
-                                    onChange={(checked) =>
-                                      onSettingsChange({ ...appSettings, createXmpIfMissing: checked })
-                                    }
+                                    onChange={async (checked) => {
+                                      const wasEnabled = appSettings?.createXmpIfMissing ?? false;
+                                      const rootPaths = effectiveRootPaths ?? [];
+
+                                      await onSettingsChange({
+                                        ...appSettings,
+                                        createXmpIfMissing: checked,
+                                      });
+
+                                      if (!wasEnabled && checked) {
+                                        try {
+                                          const count = await invoke<number>(Invokes.CreateMissingXmpFiles, {
+                                            rootPaths,
+                                          });
+
+                                          toast.success(t('settings.general.xmpBackfillSuccess', { count }));
+                                        } catch (error) {
+                                          toast.error(t('settings.general.xmpBackfillError', { error: String(error) }));
+                                        }
+                                      }
+                                    }}
                                   />
                                 </SettingItem>
                               </div>

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1179,8 +1179,8 @@ export default function SettingsPanel({
                                           const count = await invoke<number>(Invokes.CreateMissingXmpFiles, {
                                             rootPaths,
                                           });
-
-                                          toast.success(t('settings.general.xmpBackfillSuccess', { count }));
+                                          if (count > 0)
+                                            toast.success(t('settings.general.xmpBackfillSuccess', { count }));
                                         } catch (error) {
                                           toast.error(t('settings.general.xmpBackfillError', { error: String(error) }));
                                         }

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -44,6 +44,7 @@ export enum Invokes {
   ClearThumbnailCache = 'clear_thumbnail_cache',
   CopyFiles = 'copy_files',
   CreateFolder = 'create_folder',
+  CreateMissingXmpFiles = 'create_missing_xmp_files',
   CreateVirtualCopy = 'create_virtual_copy',
   CullImages = 'cull_images',
   DeleteFolder = 'delete_folder',

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -1496,6 +1496,11 @@
     "general": {
       "createXmp": "Crear fitxers XMP que falten",
       "createXmpDesc": "Crear automàticament un nou fitxer sidecar XMP si no n'existeix cap per a una imatge.",
+      "xmpBackfillError": "No s'han pogut crear els fitxers XMP absents: {{error}}",
+      "xmpBackfillSuccess": "S'han creat {{count}} fitxers XMP absents.",
+      "xmpBackfillSuccess_many": "S'han creat {{count}} fitxers XMP absents.",
+      "xmpBackfillSuccess_one": "S'ha creat {{count}} fitxer XMP absent.",
+      "xmpBackfillSuccess_other": "S'han creat {{count}} fitxers XMP absents.",
       "createXmpMissing": "Crear XMP si falta",
       "displayEditIcon": "Mostrar icona d'edició",
       "displayEditIconDesc": "Mostra una petita icona de control lliscant a les miniatures que han estat editades.",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1496,6 +1496,10 @@
     "general": {
       "createXmp": "Fehlende XMP-Dateien erstellen",
       "createXmpDesc": "Erstellt automatisch eine neue XMP-Filialdatei, falls noch keine für ein Bild existiert.",
+      "xmpBackfillError": "Fehlende XMP-Dateien konnten nicht erstellt werden: {{error}}",
+      "xmpBackfillSuccess": "{{count}} fehlende XMP-Dateien wurden erstellt.",
+      "xmpBackfillSuccess_one": "{{count}} fehlende XMP-Datei wurde erstellt.",
+      "xmpBackfillSuccess_other": "{{count}} fehlende XMP-Dateien wurden erstellt.",
       "createXmpMissing": "XMP erstellen, falls fehlend",
       "displayEditIcon": "Bearbeitungssymbol anzeigen",
       "displayEditIconDesc": "Zeigt ein kleines Schieberegler-Symbol auf Miniaturbildern an, die bearbeitet wurden.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1496,6 +1496,10 @@
     "general": {
       "createXmp": "Create Missing XMP Files",
       "createXmpDesc": "Automatically create a new XMP sidecar file if one does not exist for an image.",
+      "xmpBackfillError": "Failed to create missing XMP files: {{error}}",
+      "xmpBackfillSuccess": "Created {{count}} missing XMP files.",
+      "xmpBackfillSuccess_one": "Created {{count}} missing XMP file.",
+      "xmpBackfillSuccess_other": "Created {{count}} missing XMP files.",
       "createXmpMissing": "Create XMP if missing",
       "displayEditIcon": "Display Edit Icon",
       "displayEditIconDesc": "Show a small slider icon on thumbnails that have been edited.",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1529,6 +1529,11 @@
     "general": {
       "createXmp": "Crear archivos XMP faltantes",
       "createXmpDesc": "Crear automáticamente un nuevo archivo sidecar XMP si no existe uno para una imagen.",
+      "xmpBackfillError": "No se pudieron crear los archivos XMP que faltaban: {{error}}",
+      "xmpBackfillSuccess": "Se crearon {{count}} archivos XMP que faltaban.",
+      "xmpBackfillSuccess_many": "Se crearon {{count}} archivos XMP que faltaban.",
+      "xmpBackfillSuccess_one": "Se creó {{count}} archivo XMP que faltaba.",
+      "xmpBackfillSuccess_other": "Se crearon {{count}} archivos XMP que faltaban.",
       "createXmpMissing": "Crear XMP si falta",
       "displayEditIcon": "Mostrar icono de edición",
       "displayEditIconDesc": "Muestra un pequeño icono de control deslizante en las miniaturas que han sido editadas.",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1529,6 +1529,11 @@
     "general": {
       "createXmp": "Créer les fichiers XMP manquants",
       "createXmpDesc": "Créer automatiquement un nouveau fichier annexe XMP s'il n'en existe pas pour une image.",
+      "xmpBackfillError": "Impossible de créer les fichiers XMP manquants : {{error}}",
+      "xmpBackfillSuccess": "{{count}} fichiers XMP manquants ont été créés.",
+      "xmpBackfillSuccess_many": "{{count}} fichiers XMP manquants ont été créés.",
+      "xmpBackfillSuccess_one": "{{count}} fichier XMP manquant a été créé.",
+      "xmpBackfillSuccess_other": "{{count}} fichiers XMP manquants ont été créés.",
       "createXmpMissing": "Créer XMP si manquant",
       "displayEditIcon": "Afficher l'icône de retouche",
       "displayEditIconDesc": "Afficher une petite icône de curseur sur les miniatures qui ont été retouchées.",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1529,6 +1529,11 @@
     "general": {
       "createXmp": "Crea File XMP Mancanti",
       "createXmpDesc": "Crea automaticamente un nuovo file sidecar XMP se non ne esiste uno per un'immagine.",
+      "xmpBackfillError": "Impossibile creare i file XMP mancanti: {{error}}",
+      "xmpBackfillSuccess": "Creati {{count}} file XMP mancanti.",
+      "xmpBackfillSuccess_many": "Creati {{count}} file XMP mancanti.",
+      "xmpBackfillSuccess_one": "Creato {{count}} file XMP mancante.",
+      "xmpBackfillSuccess_other": "Creati {{count}} file XMP mancanti.",
       "createXmpMissing": "Crea XMP se mancante",
       "displayEditIcon": "Mostra Icona Modifica",
       "displayEditIconDesc": "Mostra una piccola icona del cursore sulle miniature che sono state modificate.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1494,6 +1494,10 @@
     "general": {
       "createXmp": "見つからないXMPファイルを作成",
       "createXmpDesc": "画像にXMPサイドカーファイルが存在しない場合、自動的に新規作成します。",
+      "xmpBackfillError": "不足しているXMPファイルを作成できませんでした: {{error}}",
+      "xmpBackfillSuccess": "不足していたXMPファイルを{{count}}個作成しました。",
+      "xmpBackfillSuccess_one": "不足していたXMPファイルを{{count}}個作成しました。",
+      "xmpBackfillSuccess_other": "不足していたXMPファイルを{{count}}個作成しました。",
       "createXmpMissing": "見つからない場合はXMPを作成",
       "displayEditIcon": "編集アイコンを表示",
       "displayEditIconDesc": "編集されたサムネイルに小さなスライダーアイコンを表示します。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1494,6 +1494,10 @@
     "general": {
       "createXmp": "누락된 XMP 파일 생성",
       "createXmpDesc": "이미지에 XMP 사이드카 파일이 없으면 자동으로 새로 생성합니다.",
+      "xmpBackfillError": "누락된 XMP 파일을 만들지 못했습니다: {{error}}",
+      "xmpBackfillSuccess": "누락된 XMP 파일 {{count}}개를 만들었습니다.",
+      "xmpBackfillSuccess_one": "누락된 XMP 파일 {{count}}개를 만들었습니다.",
+      "xmpBackfillSuccess_other": "누락된 XMP 파일 {{count}}개를 만들었습니다.",
       "createXmpMissing": "없는 경우 XMP 생성",
       "displayEditIcon": "편집 아이콘 표시",
       "displayEditIconDesc": "편집된 썸네일에 작은 슬라이더 아이콘을 표시합니다.",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1564,6 +1564,12 @@
     "general": {
       "createXmp": "Twórz brakujące pliki XMP",
       "createXmpDesc": "Automatycznie utwórz nowy plik poboczny XMP, jeśli nie istnieje dla obrazu.",
+      "xmpBackfillError": "Nie udało się utworzyć brakujących plików XMP: {{error}}",
+      "xmpBackfillSuccess": "Utworzono {{count}} brakujących plików XMP.",
+      "xmpBackfillSuccess_few": "Utworzono {{count}} brakujące pliki XMP.",
+      "xmpBackfillSuccess_many": "Utworzono {{count}} brakujących plików XMP.",
+      "xmpBackfillSuccess_one": "Utworzono {{count}} brakujący plik XMP.",
+      "xmpBackfillSuccess_other": "Utworzono {{count}} brakujących plików XMP.",
       "createXmpMissing": "Utwórz XMP, jeśli brakuje",
       "displayEditIcon": "Wyświetl ikonę edycji",
       "displayEditIconDesc": "Pokazuje małą ikonkę suwaków na miniaturach, które były edytowane.",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1530,6 +1530,11 @@
     "general": {
       "createXmp": "Criar Arquivos XMP Ausentes",
       "createXmpDesc": "Cria automaticamente um novo arquivo sidecar XMP se não existir um para uma imagem.",
+      "xmpBackfillError": "Não foi possível criar os ficheiros XMP em falta: {{error}}",
+      "xmpBackfillSuccess": "Foram criados {{count}} ficheiros XMP em falta.",
+      "xmpBackfillSuccess_many": "Foram criados {{count}} ficheiros XMP em falta.",
+      "xmpBackfillSuccess_one": "Foi criado {{count}} ficheiro XMP em falta.",
+      "xmpBackfillSuccess_other": "Foram criados {{count}} ficheiros XMP em falta.",
       "createXmpMissing": "Criar XMP se ausente",
       "displayEditIcon": "Exibir Ícone de Edição",
       "displayEditIconDesc": "Mostrar um pequeno ícone de controle deslizante em miniaturas que foram editadas.",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1564,6 +1564,12 @@
     "general": {
       "createXmp": "Создавать недостающие файлы XMP",
       "createXmpDesc": "Автоматически создавать файл сопутствующих данных XMP, если он отсутствует у изображения.",
+      "xmpBackfillError": "Не удалось создать отсутствующие файлы XMP: {{error}}",
+      "xmpBackfillSuccess": "Создано {{count}} отсутствующих файлов XMP.",
+      "xmpBackfillSuccess_few": "Создано {{count}} отсутствующих файла XMP.",
+      "xmpBackfillSuccess_many": "Создано {{count}} отсутствующих файлов XMP.",
+      "xmpBackfillSuccess_one": "Создан {{count}} отсутствующий файл XMP.",
+      "xmpBackfillSuccess_other": "Создано {{count}} отсутствующих файлов XMP.",
       "createXmpMissing": "Создавать XMP при отсутствии",
       "displayEditIcon": "Показывать индикатор изменений",
       "displayEditIconDesc": "Показывать небольшой значок ползунка на эскизах тех кадров, которые были изменены.",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1494,6 +1494,10 @@
     "general": {
       "createXmp": "创建缺失的 XMP 文件",
       "createXmpDesc": "如果图像没有对应的 XMP 附属文件，则自动创建一个。",
+      "xmpBackfillError": "无法创建缺失的 XMP 文件：{{error}}",
+      "xmpBackfillSuccess": "已创建 {{count}} 个缺失的 XMP 文件。",
+      "xmpBackfillSuccess_one": "已创建 {{count}} 个缺失的 XMP 文件。",
+      "xmpBackfillSuccess_other": "已创建 {{count}} 个缺失的 XMP 文件。",
       "createXmpMissing": "缺失时创建 XMP",
       "displayEditIcon": "显示编辑图标",
       "displayEditIconDesc": "在已编辑的缩略图上显示一个小滑块图标。",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1494,6 +1494,10 @@
     "general": {
       "createXmp": "建立缺失的 XMP 檔案",
       "createXmpDesc": "如果影像沒有對應的 XMP 附屬檔案，則自動建立一個。",
+      "xmpBackfillError": "無法建立缺少的 XMP 檔案：{{error}}",
+      "xmpBackfillSuccess": "已建立 {{count}} 個缺少的 XMP 檔案。",
+      "xmpBackfillSuccess_one": "已建立 {{count}} 個缺少的 XMP 檔案。",
+      "xmpBackfillSuccess_other": "已建立 {{count}} 個缺少的 XMP 檔案。",
       "createXmpMissing": "缺失時建立 XMP",
       "displayEditIcon": "顯示編輯圖示",
       "displayEditIconDesc": "在已編輯的縮圖上顯示一個小滑桿圖示。",


### PR DESCRIPTION
## Description

Fixes #1556.

When “Create XMP if missing” was enabled after images had already been rated or edited, missing XMP sidecars were not generated. This change backfills missing XMP files from existing `.rrdata` sidecars when the setting is enabled.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Added a Rust command to recursively find `.rrdata` files and create missing XMP sidecars.
- Registered the command with Tauri and invoked it when enabling the setting.
- Added success and error toast notifications with translations.
- Changed XMP paths to include the source file extension, preventing RAW and JPEG files with the same filename from sharing one XMP file.
- Existing legacy XMP files are not migrated.

## Screenshots/Videos

<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/04d8d43f-b631-434b-8b16-c95e3782a2bb" />

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

Additional verification:

- `cargo check` passes.
- `cargo test` passes; the repository currently contains no automated tests.
- Prettier and `git diff --check` pass.

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The new sidecar naming prevents collisions:

- `IMG_2280.DNG.xmp`
- `IMG_2280.jpg.xmp`

Existing `IMG_2280.xmp` files are intentionally not migrated.

The repository currently has unrelated existing TypeScript and i18n validation errors.

## AI Disclaimer:

- [ ] This PR is created by an AI agent
- [x] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)