### PR TITLE
fix: ignore hidden image files during discovery

### DIFF
--- a/src-tauri/src/formats.rs
+++ b/src-tauri/src/formats.rs
@@ -92,8 +92,6 @@ pub fn is_raw_file<P: AsRef<Path>>(path: P) -> bool {
 pub fn is_supported_image_file<P: AsRef<Path>>(path: P) -> bool {
     let path = path.as_ref();
 
-    // Ignore dotfiles before checking extensions. In particular, macOS creates
-    // AppleDouble metadata files such as `._DSC0001.ARW` on external volumes.
     if path
         .file_name()
         .and_then(|name| name.to_str())
@@ -117,27 +115,4 @@ pub fn is_supported_image_file<P: AsRef<Path>>(path: P) -> bool {
     NON_RAW_EXTENSIONS
         .iter()
         .any(|non_raw_ext| non_raw_ext.eq_ignore_ascii_case(ext))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::is_supported_image_file;
-
-    #[test]
-    fn accepts_visible_supported_images() {
-        assert!(is_supported_image_file("DSC02748.ARW"));
-        assert!(is_supported_image_file("nested/preview.JPEG"));
-    }
-
-    #[test]
-    fn rejects_appledouble_files_with_supported_extensions() {
-        assert!(!is_supported_image_file("._DSC02748.ARW"));
-        assert!(!is_supported_image_file("nested/._preview.JPEG"));
-    }
-
-    #[test]
-    fn rejects_other_hidden_files_with_supported_extensions() {
-        assert!(!is_supported_image_file(".DSC02748.ARW"));
-        assert!(!is_supported_image_file("nested/.preview.JPEG"));
-    }
 }

--- a/src-tauri/src/formats.rs
+++ b/src-tauri/src/formats.rs
@@ -92,6 +92,16 @@ pub fn is_raw_file<P: AsRef<Path>>(path: P) -> bool {
 pub fn is_supported_image_file<P: AsRef<Path>>(path: P) -> bool {
     let path = path.as_ref();
 
+    // Ignore dotfiles before checking extensions. In particular, macOS creates
+    // AppleDouble metadata files such as `._DSC0001.ARW` on external volumes.
+    if path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.starts_with('.'))
+    {
+        return false;
+    }
+
     let ext = match path.extension().and_then(|s| s.to_str()) {
         Some(e) => e,
         None => return false,
@@ -107,4 +117,27 @@ pub fn is_supported_image_file<P: AsRef<Path>>(path: P) -> bool {
     NON_RAW_EXTENSIONS
         .iter()
         .any(|non_raw_ext| non_raw_ext.eq_ignore_ascii_case(ext))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_supported_image_file;
+
+    #[test]
+    fn accepts_visible_supported_images() {
+        assert!(is_supported_image_file("DSC02748.ARW"));
+        assert!(is_supported_image_file("nested/preview.JPEG"));
+    }
+
+    #[test]
+    fn rejects_appledouble_files_with_supported_extensions() {
+        assert!(!is_supported_image_file("._DSC02748.ARW"));
+        assert!(!is_supported_image_file("nested/._preview.JPEG"));
+    }
+
+    #[test]
+    fn rejects_other_hidden_files_with_supported_extensions() {
+        assert!(!is_supported_image_file(".DSC02748.ARW"));
+        assert!(!is_supported_image_file("nested/.preview.JPEG"));
+    }
 }


### PR DESCRIPTION
## Description

RapidRAW currently treats macOS AppleDouble metadata files as supported images when their filenames retain a supported extension, such as `._DSC02748.ARW`. These files contain filesystem metadata rather than image data, so attempting to decode them produces `No decoder found` errors with blank camera make and model values.

In the reproduced folder, 606 real Sony RAW files plus 606 AppleDouble companions appeared as 1,212 library images. After this change, the library correctly discovers only the 606 real images.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Reject dot-prefixed filenames before checking whether their extensions are supported.
- Cover visible RAW/JPEG acceptance, AppleDouble rejection, and general hidden-image rejection with unit tests.

## Screenshots/Videos

Not applicable. The behavior was verified through the library image count and successful rendering of the real RAW files.

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [ ] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 27.0
- **Hardware:** Apple Silicon (arm64)

Checks performed:

- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml formats::tests --lib` (3 passed)
- `npm run build`
- Installed-app CLI smoke test with one real ARW and one AppleDouble companion: one image discovered and one valid JPEG exported
- Installed-app GUI test on the original folder: 606 images shown instead of 1,212, real filenames displayed, and `DSC02748.ARW` rendered successfully

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The current upstream branch has unrelated pre-existing TypeScript, ESLint, Prettier, and Clippy failures. This change touches only `src-tauri/src/formats.rs` and introduces no additional failures.

## AI Disclaimer

- [x] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
