### PR TITLE
Fix Texture/Denoise blending, speed up thumbnails, dedicated Denoise panel, centralize sidecars

### DIFF
--- a/src-tauri/src/ai_processing.rs
+++ b/src-tauri/src/ai_processing.rs
@@ -680,6 +680,20 @@ struct SeamlessBlend {
     overlap: usize,
 }
 
+/// Raised-cosine ramp used by [`apply_seamless`] to cross-fade overlapping
+/// denoise tiles: `w(0) = 0`, `w(1) = 1`, and `w(t) + w(1 - t) = 1` for any
+/// `t` in `[0, 1]`. That symmetry is what matters here — two neighboring
+/// tiles, each fading via this same curve from opposite ends of their shared
+/// overlap band, always sum to exactly 1.0 at every pixel, but ramp smoothly
+/// instead of meeting at a flat 0.5/0.5 step (the previous behavior, which
+/// could show as a faint seam on strongly denoised, detail-crossing edges).
+/// `t = 0` is the edge touching the neighboring tile (trust it least);
+/// `t = 1` is deep in this tile's own territory (trust it fully).
+#[inline]
+fn seam_weight(t: f32) -> f32 {
+    0.5 - 0.5 * (std::f32::consts::PI * t).cos()
+}
+
 fn apply_seamless(tile: &mut Array4<f32>, blend: &SeamlessBlend) {
     let SeamlessBlend {
         ud0,
@@ -693,20 +707,22 @@ fn apply_seamless(tile: &mut Array4<f32>, blend: &SeamlessBlend) {
         overlap,
     } = *blend;
     let ol = overlap;
-    if absx0 > 0 {
+    if absx0 > 0 && ol > 0 {
         for c in 0..3 {
             for y in ud1..ud3 {
                 for x in ud0..(ud0 + ol).min(ud2) {
-                    tile[[0, c, y, x]] *= 0.5;
+                    let t = (x - ud0) as f32 / ol as f32;
+                    tile[[0, c, y, x]] *= seam_weight(t);
                 }
             }
         }
     }
-    if absy0 > 0 {
+    if absy0 > 0 && ol > 0 {
         for c in 0..3 {
             for y in ud1..(ud1 + ol).min(ud3) {
                 for x in ud0..ud2 {
-                    tile[[0, c, y, x]] *= 0.5;
+                    let t = (y - ud1) as f32 / ol as f32;
+                    tile[[0, c, y, x]] *= seam_weight(t);
                 }
             }
         }
@@ -716,7 +732,8 @@ fn apply_seamless(tile: &mut Array4<f32>, blend: &SeamlessBlend) {
         for c in 0..3 {
             for y in ud1..ud3 {
                 for x in right_start..ud2 {
-                    tile[[0, c, y, x]] *= 0.5;
+                    let t = (ud2 - 1 - x) as f32 / ol as f32;
+                    tile[[0, c, y, x]] *= seam_weight(t);
                 }
             }
         }
@@ -726,9 +743,25 @@ fn apply_seamless(tile: &mut Array4<f32>, blend: &SeamlessBlend) {
         for c in 0..3 {
             for y in bottom_start..ud3 {
                 for x in ud0..ud2 {
-                    tile[[0, c, y, x]] *= 0.5;
+                    let t = (ud3 - 1 - y) as f32 / ol as f32;
+                    tile[[0, c, y, x]] *= seam_weight(t);
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod seam_weight_tests {
+    use super::*;
+
+    #[test]
+    fn seam_weight_endpoints_and_symmetry() {
+        assert!((seam_weight(0.0) - 0.0).abs() < 1e-6);
+        assert!((seam_weight(1.0) - 1.0).abs() < 1e-6);
+        for i in 1..10 {
+            let t = i as f32 / 10.0;
+            assert!((seam_weight(t) + seam_weight(1.0 - t) - 1.0).abs() < 1e-5);
         }
     }
 }

--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -530,7 +530,12 @@ impl Default for AppSettings {
             last_root_path: None,
             root_folders: Vec::new(),
             pinned_folders: Vec::new(),
-            thumbnail_resolution: Some(720),
+            // Lowered from 720 — this value drives both the final JPEG size and
+            // the GPU/CPU decode target resolution (`processing_dim`), so the win
+            // compounds: a typical library-grid tile is 150-400px, and 360 cuts
+            // decode/resize/encode cost by roughly 4x versus 720 while staying
+            // comfortably above what a grid thumbnail actually needs on screen.
+            thumbnail_resolution: Some(360),
             #[cfg(target_os = "android")]
             editor_preview_resolution: Some(1280),
             #[cfg(not(target_os = "android"))]
@@ -589,8 +594,18 @@ impl Default for AppSettings {
             keybinds: HashMap::new(),
             #[cfg(target_os = "android")]
             thumbnail_worker_threads: Some(2),
+            // Scales with the machine instead of a flat 4 — same
+            // available_parallelism() pattern export_processing.rs already uses
+            // for its own worker count. Clamped 4-12 so very-low-core machines
+            // still get a reasonable floor and very-high-core ones don't jump
+            // straight to the setting's own max (16) by default.
             #[cfg(not(target_os = "android"))]
-            thumbnail_worker_threads: Some(4),
+            thumbnail_worker_threads: Some(
+                std::thread::available_parallelism()
+                    .map(|n| n.get() as u32)
+                    .unwrap_or(4)
+                    .clamp(4, 12),
+            ),
             #[cfg(target_os = "android")]
             image_cache_size: Some(2),
             #[cfg(not(target_os = "android"))]

--- a/src-tauri/src/culling.rs
+++ b/src-tauri/src/culling.rs
@@ -135,8 +135,9 @@ fn analyze_image(
 
     let file_bytes = std::fs::read(path).map_err(|e| e.to_string())?;
 
-    let img = image_loader::load_base_image_from_bytes(&file_bytes, path, true, settings, None)
-        .map_err(|e| e.to_string())?;
+    let img =
+        image_loader::load_base_image_from_bytes(&file_bytes, path, true, settings, None, None)
+            .map_err(|e| e.to_string())?;
 
     let (width, height) = img.dimensions();
     let thumbnail = img.thumbnail(ANALYSIS_DIM, ANALYSIS_DIM);

--- a/src-tauri/src/denoising.rs
+++ b/src-tauri/src/denoising.rs
@@ -120,8 +120,11 @@ pub async fn batch_denoise_images(
                 }),
             );
 
-            let (source_path, source_sidecar_path) =
-                crate::file_management::parse_virtual_path(path_str);
+            let Ok((source_path, source_sidecar_path)) =
+                crate::file_management::sidecar_path_for_virtual(&app_handle, path_str)
+            else {
+                continue;
+            };
             let real_path = source_path.to_string_lossy().to_string();
 
             match crate::denoising::denoise_image(
@@ -160,13 +163,23 @@ pub async fn batch_denoise_images(
                         continue;
                     }
 
-                    let _ = crate::exif_processing::write_rrexif_sidecar(&real_path, &output_path);
+                    let _ = crate::exif_processing::write_rrexif_sidecar(
+                        &app_handle,
+                        &real_path,
+                        &output_path,
+                    );
 
                     if source_sidecar_path.exists()
                         && let Some(output_path_str) = output_path.to_str()
+                        && let Ok((_, dest_sidecar_path)) =
+                            crate::file_management::sidecar_path_for_virtual(
+                                &app_handle,
+                                output_path_str,
+                            )
                     {
-                        let (_, dest_sidecar_path) =
-                            crate::file_management::parse_virtual_path(output_path_str);
+                        if let Some(parent) = dest_sidecar_path.parent() {
+                            let _ = std::fs::create_dir_all(parent);
+                        }
                         if let Err(e) = std::fs::copy(&source_sidecar_path, &dest_sidecar_path) {
                             log::warn!("Failed to copy sidecar file for denoised image: {}", e);
                         }
@@ -192,6 +205,7 @@ pub async fn batch_denoise_images(
 #[tauri::command]
 pub async fn save_denoised_image(
     original_path_str: String,
+    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let denoised_image = state.denoise_result.lock().unwrap().take().ok_or_else(|| {
@@ -202,7 +216,7 @@ pub async fn save_denoised_image(
     let is_raw = crate::formats::is_raw_file(&original_path_str);
 
     let (first_path, source_sidecar_path) =
-        crate::file_management::parse_virtual_path(&original_path_str);
+        crate::file_management::sidecar_path_for_virtual(&app_handle, &original_path_str)?;
     let parent_dir = first_path
         .parent()
         .ok_or_else(|| "Could not determine parent directory.".to_string())?;
@@ -229,13 +243,20 @@ pub async fn save_denoised_image(
         .map_err(|e| format!("Failed to save image: {}", e))?;
 
     let (real_path, _) = crate::file_management::parse_virtual_path(&original_path_str);
-    let _ =
-        crate::exif_processing::write_rrexif_sidecar(&real_path.to_string_lossy(), &output_path);
+    let _ = crate::exif_processing::write_rrexif_sidecar(
+        &app_handle,
+        &real_path.to_string_lossy(),
+        &output_path,
+    );
 
     if source_sidecar_path.exists()
         && let Some(output_path_str) = output_path.to_str()
+        && let Ok((_, dest_sidecar_path)) =
+            crate::file_management::sidecar_path_for_virtual(&app_handle, output_path_str)
     {
-        let (_, dest_sidecar_path) = crate::file_management::parse_virtual_path(output_path_str);
+        if let Some(parent) = dest_sidecar_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
         if let Err(e) = std::fs::copy(&source_sidecar_path, &dest_sidecar_path) {
             log::warn!("Failed to copy sidecar file for denoised image: {}", e);
         }
@@ -312,8 +333,15 @@ fn denoise_image(
     let _ = app_handle.emit("denoise-progress", "Loading image...");
 
     let file_bytes = fs::read(path).map_err(|e| e.to_string())?;
-    let dynamic_img = load_base_image_from_bytes(&file_bytes, &path_str, false, &settings, None)
-        .map_err(|e| e.to_string())?;
+    let dynamic_img = load_base_image_from_bytes(
+        &file_bytes,
+        &path_str,
+        false,
+        &settings,
+        None,
+        Some(&app_handle),
+    )
+    .map_err(|e| e.to_string())?;
 
     let rgb_img_for_denoiser = dynamic_img.to_rgb32f();
 

--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -217,8 +217,12 @@ pub fn read_raw_metadata(file_bytes: &[u8]) -> Option<RawMetadata> {
     decoder.raw_metadata(&raw_source, &Default::default()).ok()
 }
 
-pub fn read_exposure_time_secs(path: &str, file_bytes: &[u8]) -> Option<f32> {
-    if let Some(map) = read_rrexif_sidecar(Path::new(path))
+pub fn read_exposure_time_secs(
+    app_handle: &tauri::AppHandle,
+    path: &str,
+    file_bytes: &[u8],
+) -> Option<f32> {
+    if let Some(map) = read_rrexif_sidecar(app_handle, Path::new(path))
         && let Some(val_str) = map.get("ExposureTime").or(map.get("ShutterSpeedValue"))
     {
         let cleaned = val_str.replace(" s", "");
@@ -288,8 +292,12 @@ pub fn read_exposure_time_secs(path: &str, file_bytes: &[u8]) -> Option<f32> {
     None
 }
 
-pub fn read_iso(path: &str, file_bytes: &[u8]) -> Option<u32> {
-    if let Some(map) = read_rrexif_sidecar(Path::new(path))
+pub fn read_iso(
+    app_handle: &tauri::AppHandle,
+    path: &str,
+    file_bytes: &[u8],
+) -> Option<u32> {
+    if let Some(map) = read_rrexif_sidecar(app_handle, Path::new(path))
         && let Some(val_str) = map
             .get("ISOSpeed")
             .or(map.get("PhotographicSensitivity"))
@@ -724,8 +732,11 @@ pub fn extract_metadata(file_bytes: &[u8]) -> Option<HashMap<String, String>> {
     Some(map)
 }
 
-pub fn get_creation_date_from_path(path: &Path) -> DateTime<Utc> {
-    if let Some(dt) = try_get_exif_creation_date(path) {
+pub fn get_creation_date_from_path(
+    app_handle: Option<&tauri::AppHandle>,
+    path: &Path,
+) -> DateTime<Utc> {
+    if let Some(dt) = try_get_exif_creation_date(app_handle, path) {
         return dt;
     }
 
@@ -736,8 +747,17 @@ pub fn get_creation_date_from_path(path: &Path) -> DateTime<Utc> {
         .unwrap_or_else(Utc::now)
 }
 
-pub fn try_get_exif_creation_date(path: &Path) -> Option<DateTime<Utc>> {
-    if let Some(map) = read_rrexif_sidecar(path)
+/// `app_handle` is optional: when available it's used to check the
+/// centralized `.rrdata`/legacy `.rrexif` sidecar cache first (the fast
+/// path); when not (a caller without easy access to one, e.g. a sort
+/// comparator), this falls straight through to reading real EXIF/RAW
+/// metadata from the file itself — slower, but exactly as correct.
+pub fn try_get_exif_creation_date(
+    app_handle: Option<&tauri::AppHandle>,
+    path: &Path,
+) -> Option<DateTime<Utc>> {
+    if let Some(handle) = app_handle
+        && let Some(map) = read_rrexif_sidecar(handle, path)
         && let Some(dt_str) = map.get("DateTimeOriginal").or(map.get("CreateDate"))
         && let Some(dt) = parse_creation_datetime(dt_str)
     {
@@ -875,6 +895,7 @@ fn apply_sidecar_field_overrides(metadata: &mut Metadata, map: &HashMap<String, 
 }
 
 pub fn write_image_with_metadata(
+    app_handle: &tauri::AppHandle,
     image_bytes: &mut Vec<u8>,
     original_path_str: &str,
     output_format: &str,
@@ -917,7 +938,9 @@ pub fn write_image_with_metadata(
         && copy_full_exif_from_source(&mut metadata, original_path, strip_gps);
     let mut source_read_success = full_exif_copied;
 
-    if !source_read_success && let Some(map) = read_rrexif_sidecar(original_path) {
+    if !source_read_success
+        && let Some(map) = read_rrexif_sidecar(app_handle, original_path)
+    {
         source_read_success = true;
 
         let clean_s = |s: &String| s.replace('"', "").trim().to_string();
@@ -1272,7 +1295,9 @@ pub fn write_image_with_metadata(
         }
     }
 
-    if full_exif_copied && let Some(map) = read_rrexif_sidecar(original_path) {
+    if full_exif_copied
+        && let Some(map) = read_rrexif_sidecar(app_handle, original_path)
+    {
         apply_sidecar_field_overrides(&mut metadata, &map);
     }
 
@@ -1295,31 +1320,48 @@ pub fn write_image_with_metadata(
     Ok(())
 }
 
-pub fn get_primary_sidecar_path(image_path: &Path) -> PathBuf {
-    let mut filename = image_path.file_name().unwrap_or_default().to_os_string();
-    filename.push(".rrdata");
-    image_path.with_file_name(filename)
+/// The centralized `.rrdata` path for `image_path` (see `sidecar_paths.rs`)
+/// — falls back to the legacy adjacent-to-photo location on any resolution
+/// failure (e.g. `app_data_dir()` unavailable) rather than panicking or
+/// erroring, since every caller here treats "no sidecar found/writable" as
+/// a perfectly normal case already (a fresh, never-edited photo).
+pub fn get_primary_sidecar_path(app_handle: &tauri::AppHandle, image_path: &Path) -> PathBuf {
+    crate::sidecar_paths::sidecar_path_for(app_handle, image_path, None, "rrdata")
+        .unwrap_or_else(|_| crate::sidecar_paths::legacy_sidecar_path(image_path, None, "rrdata"))
 }
 
+/// Legacy `.rrexif` is never relocated — it only ever lives next to the
+/// photo, and only until `read_rrexif_sidecar` finds and migrates it into
+/// the (now centralized) `.rrdata`'s `exif` field.
 pub fn get_rrexif_path(image_path: &Path) -> PathBuf {
     let mut filename = image_path.file_name().unwrap_or_default().to_os_string();
     filename.push(".rrexif");
     image_path.with_file_name(filename)
 }
 
-fn load_primary_metadata(image_path: &Path) -> ImageMetadata {
-    let primary = get_primary_sidecar_path(image_path);
+fn load_primary_metadata(app_handle: &tauri::AppHandle, image_path: &Path) -> ImageMetadata {
+    let primary = get_primary_sidecar_path(app_handle, image_path);
     load_sidecar(&primary)
 }
 
-fn save_primary_metadata(image_path: &Path, metadata: &ImageMetadata) -> std::io::Result<()> {
-    let primary = get_primary_sidecar_path(image_path);
+fn save_primary_metadata(
+    app_handle: &tauri::AppHandle,
+    image_path: &Path,
+    metadata: &ImageMetadata,
+) -> std::io::Result<()> {
+    let primary = get_primary_sidecar_path(app_handle, image_path);
+    if let Some(parent) = primary.parent() {
+        fs::create_dir_all(parent)?;
+    }
     let json = serde_json::to_string_pretty(metadata).map_err(std::io::Error::other)?;
     fs::write(&primary, json)
 }
 
-pub fn read_rrexif_sidecar(image_path: &Path) -> Option<HashMap<String, String>> {
-    let metadata = load_primary_metadata(image_path);
+pub fn read_rrexif_sidecar(
+    app_handle: &tauri::AppHandle,
+    image_path: &Path,
+) -> Option<HashMap<String, String>> {
+    let metadata = load_primary_metadata(app_handle, image_path);
     if let Some(exif) = metadata.exif {
         return Some(exif);
     }
@@ -1329,9 +1371,9 @@ pub fn read_rrexif_sidecar(image_path: &Path) -> Option<HashMap<String, String>>
         && let Ok(content) = fs::read_to_string(&legacy)
         && let Ok(map) = serde_json::from_str::<HashMap<String, String>>(&content)
     {
-        let mut migrated = load_primary_metadata(image_path);
+        let mut migrated = load_primary_metadata(app_handle, image_path);
         migrated.exif = Some(map.clone());
-        if save_primary_metadata(image_path, &migrated).is_ok() {
+        if save_primary_metadata(app_handle, image_path, &migrated).is_ok() {
             let _ = fs::remove_file(&legacy);
         }
         return Some(map);
@@ -1369,24 +1411,33 @@ pub fn read_exif_data_from_bytes(path: &str, file_bytes: &[u8]) -> HashMap<Strin
     exif_data
 }
 
-pub fn read_exif_data(path: &str, file_bytes: &[u8]) -> HashMap<String, String> {
+pub fn read_exif_data(
+    app_handle: &tauri::AppHandle,
+    path: &str,
+    file_bytes: &[u8],
+) -> HashMap<String, String> {
     let source_path = Path::new(path);
-    if let Some(sidecar_exif) = read_rrexif_sidecar(source_path) {
+    if let Some(sidecar_exif) = read_rrexif_sidecar(app_handle, source_path) {
         return sidecar_exif;
     }
 
     let exif_map = read_exif_data_from_bytes(path, file_bytes);
     if !exif_map.is_empty() {
-        let mut metadata = load_primary_metadata(source_path);
+        let mut metadata = load_primary_metadata(app_handle, source_path);
         metadata.exif = Some(exif_map.clone());
-        let _ = save_primary_metadata(source_path, &metadata);
+        let _ = save_primary_metadata(app_handle, source_path, &metadata);
     }
     exif_map
 }
 
-pub fn persist_exif_if_missing(source_path: &Path, source_path_str: &str, file_bytes: &[u8]) {
+pub fn persist_exif_if_missing(
+    app_handle: &tauri::AppHandle,
+    source_path: &Path,
+    source_path_str: &str,
+    file_bytes: &[u8],
+) {
     {
-        let metadata = load_primary_metadata(source_path);
+        let metadata = load_primary_metadata(app_handle, source_path);
         if metadata.exif.is_some() {
             return;
         }
@@ -1397,9 +1448,9 @@ pub fn persist_exif_if_missing(source_path: &Path, source_path_str: &str, file_b
         && let Ok(content) = fs::read_to_string(&legacy)
         && let Ok(map) = serde_json::from_str::<HashMap<String, String>>(&content)
     {
-        let mut metadata = load_primary_metadata(source_path);
+        let mut metadata = load_primary_metadata(app_handle, source_path);
         metadata.exif = Some(map);
-        if save_primary_metadata(source_path, &metadata).is_ok() {
+        if save_primary_metadata(app_handle, source_path, &metadata).is_ok() {
             let _ = fs::remove_file(&legacy);
         }
         return;
@@ -1410,18 +1461,22 @@ pub fn persist_exif_if_missing(source_path: &Path, source_path_str: &str, file_b
         return;
     }
 
-    let mut metadata = load_primary_metadata(source_path);
+    let mut metadata = load_primary_metadata(app_handle, source_path);
 
     if metadata.exif.is_none() {
         metadata.exif = Some(exif_map);
-        let _ = save_primary_metadata(source_path, &metadata);
+        let _ = save_primary_metadata(app_handle, source_path, &metadata);
     }
 }
 
-pub fn write_rrexif_sidecar(source_path_str: &str, target_image_path: &Path) -> Result<(), String> {
+pub fn write_rrexif_sidecar(
+    app_handle: &tauri::AppHandle,
+    source_path_str: &str,
+    target_image_path: &Path,
+) -> Result<(), String> {
     let source_path = Path::new(source_path_str);
 
-    let exif_data = if let Some(existing) = read_rrexif_sidecar(source_path) {
+    let exif_data = if let Some(existing) = read_rrexif_sidecar(app_handle, source_path) {
         existing
     } else if let Ok(bytes) = fs::read(source_path) {
         read_exif_data_from_bytes(source_path_str, &bytes)
@@ -1433,8 +1488,8 @@ pub fn write_rrexif_sidecar(source_path_str: &str, target_image_path: &Path) -> 
         return Ok(());
     }
 
-    let mut metadata = load_primary_metadata(target_image_path);
+    let mut metadata = load_primary_metadata(app_handle, target_image_path);
     metadata.exif = Some(exif_data);
-    save_primary_metadata(target_image_path, &metadata)
+    save_primary_metadata(app_handle, target_image_path, &metadata)
         .map_err(|e| format!("Failed to write sidecar: {}", e))
 }

--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -463,8 +463,8 @@ fn process_image_for_export_pipeline(
     )
 }
 
-fn set_timestamps_from_exif(src: &Path, dst: &Path) {
-    let capture_dt = exif_processing::get_creation_date_from_path(src);
+fn set_timestamps_from_exif(app_handle: &tauri::AppHandle, src: &Path, dst: &Path) {
+    let capture_dt = exif_processing::get_creation_date_from_path(Some(app_handle), src);
     let ft = filetime::FileTime::from_unix_time(
         capture_dt.timestamp(),
         capture_dt.timestamp_subsec_nanos(),
@@ -475,6 +475,7 @@ fn set_timestamps_from_exif(src: &Path, dst: &Path) {
 }
 
 fn save_image_with_metadata(
+    app_handle: &tauri::AppHandle,
     image: &DynamicImage,
     output_path: &std::path::Path,
     source_path_str: &str,
@@ -489,6 +490,7 @@ fn save_image_with_metadata(
     let mut image_bytes = encode_image_to_bytes(image, &extension, export_settings.jpeg_quality)?;
 
     exif_processing::write_image_with_metadata(
+        app_handle,
         &mut image_bytes,
         source_path_str,
         &extension,
@@ -755,6 +757,7 @@ fn export_masks_for_image(
             let mask_alpha_path = output_dir.join(format!("{}_mask_{}_alpha.png", stem, i));
 
             save_image_with_metadata(
+                app_handle,
                 &with_options,
                 &mask_image_path,
                 source_path_str,
@@ -763,7 +766,7 @@ fn export_masks_for_image(
             ensure_export_not_cancelled(cancellation_token)?;
 
             if export_settings.preserve_timestamps {
-                set_timestamps_from_exif(Path::new(source_path_str), &mask_image_path);
+                set_timestamps_from_exif(app_handle, Path::new(source_path_str), &mask_image_path);
             }
 
             let alpha_bytes = encode_grayscale_to_png(&alpha_resized)?;
@@ -970,7 +973,12 @@ pub(crate) async fn export_images_impl(
                 ensure_export_not_cancelled(&cancellation_token_clone)?;
 
                 let state = app_handle_clone.state::<AppState>();
-                let (source_path, sidecar_path) = parse_virtual_path(&image_path_str);
+                let (source_path, sidecar_path) =
+                    crate::file_management::sidecar_path_for_virtual(
+                        &app_handle_clone,
+                        &image_path_str,
+                    )
+                    .map_err(|e| format!("Failed to resolve sidecar path: {}", e))?;
                 let source_path_str = source_path.to_string_lossy().to_string();
 
                 let is_current_edit = match &adjustments_mode {
@@ -1000,7 +1008,10 @@ pub(crate) async fn export_images_impl(
                 hydrate_adjustments(&state, &mut js_adjustments);
                 let is_raw = is_raw_file(&source_path_str);
                 let original_path = std::path::Path::new(&source_path_str);
-                let file_date = exif_processing::get_creation_date_from_path(original_path);
+                let file_date = exif_processing::get_creation_date_from_path(
+                    Some(&app_handle_clone),
+                    original_path,
+                );
 
                 let filename_template = export_settings
                     .filename_template
@@ -1139,6 +1150,7 @@ pub(crate) async fn export_images_impl(
                     )?;
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
                     save_image_with_metadata(
+                        &app_handle_clone,
                         &final_image,
                         &output_path,
                         &source_path_str,
@@ -1147,7 +1159,11 @@ pub(crate) async fn export_images_impl(
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
 
                     if export_settings.preserve_timestamps {
-                        set_timestamps_from_exif(Path::new(&source_path_str), &output_path);
+                        set_timestamps_from_exif(
+                            &app_handle_clone,
+                            Path::new(&source_path_str),
+                            &output_path,
+                        );
                     }
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
 
@@ -1424,7 +1440,8 @@ pub async fn estimate_export_sizes(
     }
 
     let first_path = &paths[0];
-    let (source_path, sidecar_path) = parse_virtual_path(first_path);
+    let (source_path, sidecar_path) =
+        crate::file_management::sidecar_path_for_virtual(&app_handle, first_path)?;
     let source_path_str = source_path.to_string_lossy().to_string();
 
     let context = get_or_init_gpu_context(&state, &app_handle)?;
@@ -1568,9 +1585,15 @@ pub async fn estimate_export_sizes(
             }
         };
 
-        let original_image =
-            load_base_image_from_bytes(file_data, &source_path_str, true, &settings, None)
-                .map_err(|e| e.to_string())?;
+        let original_image = load_base_image_from_bytes(
+            file_data,
+            &source_path_str,
+            true,
+            &settings,
+            None,
+            Some(&app_handle),
+        )
+        .map_err(|e| e.to_string())?;
 
         let raw_scale_factor = if is_raw {
             crate::raw_processing::get_fast_demosaic_scale_factor(

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -2678,7 +2678,7 @@ pub fn save_metadata_and_update_thumbnail(
     if let Some(parent) = sidecar_path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    std::fs::write(&sidecar_path, json_string).map_err(|e| e.to_string())?;
+    crate::sidecar_paths::write_sidecar(&app_handle, &sidecar_path, &json_string).map_err(|e| e.to_string())?;
 
     if let Ok(settings) = load_settings(app_handle.clone())
         && settings.enable_xmp_sync.unwrap_or(false)
@@ -2803,7 +2803,7 @@ pub async fn apply_adjustments_to_paths(
                 if let Some(parent) = sidecar_path.parent() {
                     let _ = std::fs::create_dir_all(parent);
                 }
-                let _ = std::fs::write(&sidecar_path, json_string);
+                let _ = crate::sidecar_paths::write_sidecar(&app_handle, &sidecar_path, &json_string);
             }
 
             if enable_xmp_sync {
@@ -2877,7 +2877,7 @@ pub async fn reset_adjustments_for_paths(
                 if let Some(parent) = sidecar_path.parent() {
                     let _ = std::fs::create_dir_all(parent);
                 }
-                let _ = std::fs::write(&sidecar_path, json_string);
+                let _ = crate::sidecar_paths::write_sidecar(&app_handle, &sidecar_path, &json_string);
             }
 
             if enable_xmp_sync {
@@ -3006,7 +3006,7 @@ pub async fn apply_auto_adjustments_to_paths(
                     if let Some(parent) = sidecar_path.parent() {
                         let _ = std::fs::create_dir_all(parent);
                     }
-                    let _ = std::fs::write(&sidecar_path, json_string);
+                    let _ = crate::sidecar_paths::write_sidecar(&app_handle, &sidecar_path, &json_string);
                 }
 
                 if enable_xmp_sync {
@@ -3074,7 +3074,7 @@ pub fn set_color_label_for_paths(
             if let Some(parent) = sidecar_path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
-            let _ = std::fs::write(&sidecar_path, json_string);
+            let _ = crate::sidecar_paths::write_sidecar(&app_handle, &sidecar_path, &json_string);
         }
 
         if enable_xmp_sync {
@@ -3108,7 +3108,7 @@ pub fn set_rating_for_paths(
             if let Some(parent) = sidecar_path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
-            let _ = std::fs::write(&sidecar_path, json_string);
+            let _ = crate::sidecar_paths::write_sidecar(&app_handle, &sidecar_path, &json_string);
         }
 
         if enable_xmp_sync {

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -343,7 +343,7 @@ fn assign_group_ids(files: &mut [ImageFile], settings: &crate::app_settings::App
             .map(|p| {
                 (
                     p.clone(),
-                    crate::exif_processing::try_get_exif_creation_date(p),
+                    crate::exif_processing::try_get_exif_creation_date(None, p),
                 )
             })
             .collect();
@@ -384,41 +384,53 @@ pub struct ImportSettings {
     pub delete_after_import: bool,
 }
 
-pub fn parse_virtual_path(virtual_path: &str) -> (PathBuf, PathBuf) {
-    let (source_path_str, copy_id) = if let Some((base, id)) = virtual_path.rsplit_once("?vc=") {
-        (base.to_string(), Some(id.to_string()))
+/// Strips the `?vc=<id>` virtual-copy suffix (if present) from a "virtual
+/// path" string, returning the real filesystem path plus the copy id (if
+/// any). Pure string parsing, no filesystem access — use this whenever only
+/// the underlying photo's real path matters, not its sidecar. For the
+/// sidecar path itself, see `sidecar_path_for_virtual` below, which needs
+/// an `AppHandle` since sidecars now live under the app's data directory
+/// (see `sidecar_paths.rs`) rather than next to the photo.
+pub fn split_virtual_path(virtual_path: &str) -> (PathBuf, Option<String>) {
+    if let Some((base, id)) = virtual_path.rsplit_once("?vc=") {
+        (PathBuf::from(base), Some(id.to_string()))
     } else {
-        (virtual_path.to_string(), None)
-    };
+        (PathBuf::from(virtual_path), None)
+    }
+}
 
-    let source_path = PathBuf::from(source_path_str);
+/// Back-compat shape for the many call sites that only ever wanted the real
+/// source path and discarded the sidecar path `parse_virtual_path` used to
+/// also return — every one of those didn't need an `AppHandle` before and
+/// still doesn't.
+pub fn parse_virtual_path(virtual_path: &str) -> (PathBuf, Option<String>) {
+    split_virtual_path(virtual_path)
+}
 
-    let sidecar_filename = if let Some(id) = copy_id {
-        format!(
-            "{}.{}.rrdata",
-            source_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy(),
-            &id
-        )
-    } else {
-        format!(
-            "{}.rrdata",
-            source_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy()
-        )
-    };
-
-    let sidecar_path = source_path.with_file_name(sidecar_filename);
-    (source_path, sidecar_path)
+/// The centralized sidecar path (see `sidecar_paths.rs`) for a "virtual
+/// path" string — resolves the `?vc=` copy id the same way
+/// `split_virtual_path` does, then defers to `sidecar_paths::sidecar_path_for`
+/// for the actual (mirrored-directory) location. Returns the real source
+/// path alongside it, matching the old `parse_virtual_path`'s two-value
+/// shape for callers that need both.
+pub fn sidecar_path_for_virtual(
+    app_handle: &AppHandle,
+    virtual_path: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let (source_path, copy_id) = split_virtual_path(virtual_path);
+    let sidecar_path = crate::sidecar_paths::sidecar_path_for(
+        app_handle,
+        &source_path,
+        copy_id.as_deref(),
+        "rrdata",
+    )?;
+    Ok((source_path, sidecar_path))
 }
 
 #[tauri::command]
 pub async fn read_exif_for_paths(
     paths: Vec<String>,
+    app_handle: AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<HashMap<String, HashMap<String, String>>, String> {
     let is_hdd = state
@@ -432,15 +444,15 @@ pub async fn read_exif_for_paths(
             let source_path_str = source_path.to_string_lossy().to_string();
 
             let map = if let Some(sidecar_exif) =
-                crate::exif_processing::read_rrexif_sidecar(&source_path)
+                crate::exif_processing::read_rrexif_sidecar(&app_handle, &source_path)
             {
                 sidecar_exif
             } else if is_cloud_placeholder(&source_path) {
                 HashMap::new()
             } else if let Ok(mmap) = read_file_mapped(&source_path) {
-                crate::exif_processing::read_exif_data(&source_path_str, &mmap)
+                crate::exif_processing::read_exif_data(&app_handle, &source_path_str, &mmap)
             } else if let Ok(bytes) = fs::read(&source_path) {
-                crate::exif_processing::read_exif_data(&source_path_str, &bytes)
+                crate::exif_processing::read_exif_data(&app_handle, &source_path_str, &bytes)
             } else {
                 HashMap::new()
             };
@@ -468,15 +480,19 @@ pub async fn read_exif_for_paths(
 pub async fn update_exif_fields(
     paths: Vec<String>,
     updates: HashMap<String, String>,
+    app_handle: AppHandle,
 ) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         paths.par_iter().for_each(|path| {
             let original_path = Path::new(&path);
-            let primary_path = crate::exif_processing::get_primary_sidecar_path(original_path);
+            let primary_path =
+                crate::exif_processing::get_primary_sidecar_path(&app_handle, original_path);
             let temp_metadata = crate::exif_processing::load_sidecar(&primary_path);
 
             let mut exif_data = temp_metadata.exif.unwrap_or_else(|| {
-                if let Some(existing) = crate::exif_processing::read_rrexif_sidecar(original_path) {
+                if let Some(existing) =
+                    crate::exif_processing::read_rrexif_sidecar(&app_handle, original_path)
+                {
                     existing
                 } else if let Ok(mmap) = read_file_mapped(original_path) {
                     crate::exif_processing::read_exif_data_from_bytes(path, &mmap)
@@ -570,7 +586,6 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
 
     let entries = fs::read_dir(&path).map_err(|e| e.to_string())?;
     let mut images = Vec::new();
-    let mut sidecars_by_filename: HashMap<String, Vec<Option<String>>> = HashMap::new();
 
     for entry in entries.filter_map(Result::ok) {
         let entry_path = entry.path();
@@ -579,9 +594,13 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
             .into_string()
             .unwrap_or_else(|os| os.to_string_lossy().into_owned());
 
-        if file_name.ends_with(".rrdata") {
-            let base = &file_name[..file_name.len() - 7];
-
+        if is_supported_image_file(&file_name) {
+            images.push((file_name, entry_path));
+        } else if let Some(base) = file_name.strip_suffix(".rrdata") {
+            // A .rrdata found directly in the photo folder is always a
+            // pre-relocation leftover (the app never writes new ones
+            // here) — migrate it to its centralized, mirrored location
+            // now, incrementally, on ordinary folder browsing.
             let (source_filename, copy_id) =
                 if base.len() >= 7 && base.as_bytes()[base.len() - 7] == b'.' {
                     let id = &base[base.len() - 6..];
@@ -593,13 +612,52 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
                 } else {
                     (base, None)
                 };
+            let photo_path = Path::new(&path).join(source_filename);
+            crate::sidecar_paths::migrate_legacy_rrdata(
+                &app_handle,
+                &entry_path,
+                &photo_path,
+                copy_id.as_deref(),
+            );
+        }
+    }
 
-            sidecars_by_filename
-                .entry(source_filename.to_string())
-                .or_default()
-                .push(copy_id);
-        } else if is_supported_image_file(&file_name) {
-            images.push((file_name, entry_path));
+    // .rrdata sidecars are centralized (sidecar_paths.rs) but mirror this
+    // folder's own structure, so a single scan of the mirrored directory
+    // finds exactly the same set of sidecars (including virtual copies)
+    // a scan of this folder itself used to find pre-relocation — same
+    // bucket-and-match logic, just pointed at a different root. A missing
+    // mirrored directory (nothing has ever been edited in this folder
+    // since relocating) is a normal, empty-bucket case, not an error.
+    let mut sidecars_by_filename: HashMap<String, Vec<Option<String>>> = HashMap::new();
+    let sidecar_dir = crate::sidecar_paths::mirrored_root_for_source_dir(&app_handle, Path::new(&path))
+        .map(|(dir, _)| dir)
+        .unwrap_or_default();
+    if let Ok(sidecar_entries) = fs::read_dir(&sidecar_dir) {
+        for entry in sidecar_entries.filter_map(Result::ok) {
+            let file_name = entry
+                .file_name()
+                .into_string()
+                .unwrap_or_else(|os| os.to_string_lossy().into_owned());
+
+            if let Some(base) = file_name.strip_suffix(".rrdata") {
+                let (source_filename, copy_id) =
+                    if base.len() >= 7 && base.as_bytes()[base.len() - 7] == b'.' {
+                        let id = &base[base.len() - 6..];
+                        if id.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) {
+                            (&base[..base.len() - 7], Some(id.to_string()))
+                        } else {
+                            (base, None)
+                        }
+                    } else {
+                        (base, None)
+                    };
+
+                sidecars_by_filename
+                    .entry(source_filename.to_string())
+                    .or_default()
+                    .push(copy_id);
+            }
         }
     }
 
@@ -638,7 +696,7 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
                     None => (path_str.clone(), false, format!("{}.rrdata", file_name)),
                 };
 
-                let sidecar_path = path_buf.with_file_name(sidecar_filename);
+                let sidecar_path = sidecar_dir.join(sidecar_filename);
 
                 let xmp_is_placeholder = enable_xmp_sync
                     && resolve_xmp_path(&path_buf)
@@ -698,16 +756,74 @@ pub fn list_images_recursive(
     let root_path = Path::new(&path);
     let mut images = Vec::new();
 
-    let mut sidecars_by_path: HashMap<PathBuf, Vec<Option<String>>> = HashMap::new();
-
     for entry in WalkDir::new(root_path).into_iter().filter_map(Result::ok) {
         let entry_path = entry.path();
         if !entry_path.is_file() {
             continue;
         }
 
-        let file_name = entry_path.file_name().unwrap_or_default().to_string_lossy();
-        if let Some(base) = file_name.strip_suffix(".rrdata") {
+        if is_supported_image_file(entry_path.to_string_lossy().as_ref()) {
+            images.push(entry_path.to_path_buf());
+        } else if let Some(parent) = entry_path.parent()
+            && let Some(base) = entry_path
+                .file_name()
+                .and_then(|f| f.to_str())
+                .and_then(|f| f.strip_suffix(".rrdata"))
+        {
+            // Same incremental migration as list_images_in_dir, just
+            // walking the whole subtree instead of one folder.
+            let (source_filename, copy_id) =
+                if base.len() >= 7 && base.as_bytes()[base.len() - 7] == b'.' {
+                    let id = &base[base.len() - 6..];
+                    if id.chars().all(|c| matches!(c, '0'..='9' | 'a'..='f')) {
+                        (&base[..base.len() - 7], Some(id.to_string()))
+                    } else {
+                        (base, None)
+                    }
+                } else {
+                    (base, None)
+                };
+            let photo_path = parent.join(source_filename);
+            crate::sidecar_paths::migrate_legacy_rrdata(
+                &app_handle,
+                entry_path,
+                &photo_path,
+                copy_id.as_deref(),
+            );
+        }
+    }
+
+    // .rrdata sidecars are centralized (sidecar_paths.rs) but mirror the
+    // source tree's own structure, so a walk of root_path's mirrored
+    // sidecar tree finds exactly the same sidecars (including virtual
+    // copies) a walk of root_path itself used to find pre-relocation.
+    // Every discovered sidecar's *source* path is reconstructed by
+    // reversing the mirror (stripping the mirrored root's prefix, then
+    // re-joining the remaining relative path onto the canonicalized
+    // source root) — both this and the image-walk side below are keyed
+    // off the same canonicalized root so the two HashMap key sets agree
+    // exactly regardless of how `path` was itself spelled/cased.
+    let mut sidecars_by_path: HashMap<PathBuf, Vec<Option<String>>> = HashMap::new();
+    if let Ok((mirrored_root, canonical_root)) =
+        crate::sidecar_paths::mirrored_root_for_source_dir(&app_handle, root_path)
+    {
+        for entry in WalkDir::new(&mirrored_root).into_iter().filter_map(Result::ok) {
+            let entry_path = entry.path();
+            if !entry_path.is_file() {
+                continue;
+            }
+
+            let file_name = entry_path.file_name().unwrap_or_default().to_string_lossy();
+            let Some(base) = file_name.strip_suffix(".rrdata") else {
+                continue;
+            };
+            let Some(relative_dir) = entry_path
+                .parent()
+                .and_then(|p| p.strip_prefix(&mirrored_root).ok())
+            else {
+                continue;
+            };
+
             let (source_filename, copy_id) =
                 if base.len() >= 7 && base.as_bytes()[base.len() - 7] == b'.' {
                     let id = &base[base.len() - 6..];
@@ -720,22 +836,24 @@ pub fn list_images_recursive(
                     (base, None)
                 };
 
-            if let Some(parent) = entry_path.parent() {
-                sidecars_by_path
-                    .entry(parent.join(source_filename))
-                    .or_default()
-                    .push(copy_id);
-            }
-        } else if is_supported_image_file(entry_path.to_string_lossy().as_ref()) {
-            images.push(entry_path.to_path_buf());
+            let source_key = canonical_root.join(relative_dir).join(source_filename);
+            sidecars_by_path
+                .entry(source_key)
+                .or_default()
+                .push(copy_id);
         }
     }
 
     let tasks: Vec<_> = images
         .into_iter()
         .map(|path_buf| {
+            // sidecars_by_path's keys are canonicalized (see above) —
+            // canonicalize this image's own path the same way before
+            // looking it up, so the two sides agree regardless of how
+            // `path` was itself spelled/cased.
+            let lookup_key = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
             let sidecars = sidecars_by_path
-                .remove(&path_buf)
+                .remove(&lookup_key)
                 .unwrap_or_else(|| vec![None]);
             let path_str = path_buf.to_string_lossy().into_owned();
             let file_name = path_buf
@@ -771,7 +889,9 @@ pub fn list_images_recursive(
                     None => (path_str.clone(), false, format!("{}.rrdata", file_name)),
                 };
 
-                let sidecar_path = path_buf.with_file_name(sidecar_filename);
+                let sidecar_path = crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, &path_buf)
+                    .map(|dir| dir.join(&sidecar_filename))
+                    .unwrap_or_else(|_| path_buf.with_file_name(sidecar_filename));
 
                 let xmp_is_placeholder = enable_xmp_sync
                     && resolve_xmp_path(&path_buf)
@@ -1029,7 +1149,7 @@ pub fn get_album_images(
     let mut result_list: Vec<ImageFile> = paths
         .into_par_iter()
         .filter_map(|virtual_path| {
-            let (source_path, sidecar_path) = parse_virtual_path(&virtual_path);
+            let (source_path, sidecar_path) = sidecar_path_for_virtual(&app_handle, &virtual_path).ok()?;
             if !source_path.exists() {
                 return None;
             }
@@ -1454,7 +1574,8 @@ pub fn generate_thumbnail_data(
     preloaded_image: Option<&DynamicImage>,
     app_handle: &AppHandle,
 ) -> anyhow::Result<DynamicImage> {
-    let (source_path, sidecar_path) = parse_virtual_path(path_str);
+    let (source_path, sidecar_path) =
+        sidecar_path_for_virtual(app_handle, path_str).map_err(|e| anyhow::anyhow!(e))?;
     let source_path_str = source_path.to_string_lossy().to_string();
     let is_raw = is_raw_file(&source_path_str);
 
@@ -1783,7 +1904,7 @@ fn generate_single_thumbnail_and_cache(
     app_handle: &AppHandle,
     settings: &AppSettings,
 ) -> Option<(String, u8, bool)> {
-    let (source_path, sidecar_path) = parse_virtual_path(path_str);
+    let (source_path, sidecar_path) = sidecar_path_for_virtual(app_handle, path_str).ok()?;
 
     let (rating, is_edited, adjustments_bytes) = if is_cloud_placeholder(&sidecar_path) {
         enqueue_metadata(
@@ -2220,7 +2341,7 @@ pub fn duplicate_file(
     target_album_id: Option<String>,
     app_handle: AppHandle,
 ) -> Result<String, String> {
-    let (source_path, source_sidecar_path) = parse_virtual_path(&path);
+    let (source_path, source_sidecar_path) = sidecar_path_for_virtual(&app_handle, &path)?;
     if !source_path.is_file() {
         return Err("Source path is not a file.".to_string());
     }
@@ -2257,7 +2378,10 @@ pub fn duplicate_file(
     if source_sidecar_path.exists()
         && let Some(dest_str) = dest_path.to_str()
     {
-        let (_, dest_sidecar_path) = parse_virtual_path(dest_str);
+        let (_, dest_sidecar_path) = sidecar_path_for_virtual(&app_handle, dest_str)?;
+        if let Some(parent) = dest_sidecar_path.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
         fs::copy(&source_sidecar_path, &dest_sidecar_path).map_err(|e| e.to_string())?;
     }
 
@@ -2281,23 +2405,21 @@ pub fn duplicate_file(
     Ok(dest_path_str)
 }
 
-fn find_all_associated_files(source_image_path: &Path) -> Result<Vec<PathBuf>, String> {
+fn find_all_associated_files(
+    app_handle: &AppHandle,
+    source_image_path: &Path,
+) -> Result<Vec<PathBuf>, String> {
     let mut associated_files = vec![source_image_path.to_path_buf()];
 
-    let mut rrexif_name = source_image_path
-        .file_name()
-        .unwrap_or_default()
-        .to_os_string();
-    rrexif_name.push(".rrexif");
-    let rrexif_path = source_image_path.with_file_name(rrexif_name);
-
+    // Legacy .rrexif is never relocated — it only ever lives next to the
+    // photo (see sidecar_paths.rs's legacy_sidecar_path doc comment); by
+    // the time a fresh .rrdata exists, any .rrexif has already been merged
+    // into it and deleted (exif_processing.rs's read_rrexif_sidecar).
+    let rrexif_path = crate::sidecar_paths::legacy_sidecar_path(source_image_path, None, "rrexif");
     if rrexif_path.exists() {
         associated_files.push(rrexif_path);
     }
 
-    let parent_dir = source_image_path
-        .parent()
-        .ok_or("Could not determine parent directory")?;
     let source_filename = source_image_path
         .file_name()
         .ok_or("Could not get source filename")?
@@ -2306,7 +2428,8 @@ fn find_all_associated_files(source_image_path: &Path) -> Result<Vec<PathBuf>, S
     let primary_sidecar_name = format!("{}.rrdata", source_filename);
     let virtual_copy_prefix = format!("{}.", source_filename);
 
-    if let Ok(entries) = fs::read_dir(parent_dir) {
+    let sidecar_dir = crate::sidecar_paths::sidecar_dir_for_photo(app_handle, source_image_path)?;
+    if let Ok(entries) = fs::read_dir(&sidecar_dir) {
         for entry in entries.filter_map(Result::ok) {
             let entry_path = entry.path();
             if !entry_path.is_file() {
@@ -2329,7 +2452,11 @@ fn find_all_associated_files(source_image_path: &Path) -> Result<Vec<PathBuf>, S
 }
 
 #[tauri::command]
-pub fn copy_files(source_paths: Vec<String>, destination_folder: String) -> Result<(), String> {
+pub fn copy_files(
+    source_paths: Vec<String>,
+    destination_folder: String,
+    app_handle: AppHandle,
+) -> Result<(), String> {
     let dest_path = Path::new(&destination_folder);
     if !dest_path.is_dir() {
         return Err(format!(
@@ -2346,7 +2473,9 @@ pub fn copy_files(source_paths: Vec<String>, destination_folder: String) -> Resu
     let mut operations_to_perform = Vec::new();
 
     for source_image_path in &unique_source_images {
-        let all_files_to_copy = find_all_associated_files(source_image_path)?;
+        let all_files_to_copy = find_all_associated_files(&app_handle, source_image_path)?;
+        let sidecar_source_dir =
+            crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, source_image_path)?;
 
         let source_parent = source_image_path
             .parent()
@@ -2372,6 +2501,8 @@ pub fn copy_files(source_paths: Vec<String>, destination_folder: String) -> Resu
                 counter += 1;
             };
             let new_filename = new_base_path.file_name().unwrap().to_string_lossy();
+            let dest_sidecar_dir =
+                crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, &new_base_path)?;
 
             for original_file in all_files_to_copy {
                 let original_full_filename = original_file.file_name().unwrap().to_string_lossy();
@@ -2379,13 +2510,30 @@ pub fn copy_files(source_paths: Vec<String>, destination_folder: String) -> Resu
                 let new_dest_filename =
                     original_full_filename.replacen(&*source_base_filename, &new_filename, 1);
 
-                let final_dest_path = dest_path.join(new_dest_filename);
+                let final_dest_path =
+                    if original_file.parent() == Some(sidecar_source_dir.as_path()) {
+                        dest_sidecar_dir.join(new_dest_filename)
+                    } else {
+                        dest_path.join(new_dest_filename)
+                    };
                 operations_to_perform.push((original_file, final_dest_path));
             }
         } else {
+            let dest_image_path = dest_path.join(source_image_path.file_name().unwrap());
+            let dest_sidecar_dir =
+                crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, &dest_image_path)?;
+
             for file_to_copy in all_files_to_copy {
                 if let Some(file_name) = file_to_copy.file_name() {
-                    let dest_file_path = dest_path.join(file_name);
+                    // A .rrdata sidecar re-mirrors to the destination's own
+                    // mirrored directory; everything else (the photo, a
+                    // legacy adjacent .rrexif) copies into dest_path as before.
+                    let dest_file_path =
+                        if file_to_copy.parent() == Some(sidecar_source_dir.as_path()) {
+                            dest_sidecar_dir.join(file_name)
+                        } else {
+                            dest_path.join(file_name)
+                        };
 
                     if dest_file_path.exists() {
                         return Err(format!(
@@ -2401,6 +2549,9 @@ pub fn copy_files(source_paths: Vec<String>, destination_folder: String) -> Resu
     }
 
     for (source, dest) in operations_to_perform {
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
         fs::copy(&source, &dest)
             .map_err(|e| format!("Copy failed for {}: {}", source.display(), e))?;
     }
@@ -2439,11 +2590,26 @@ pub fn move_files(
             return Err("Cannot move files into the same folder they are already in.".to_string());
         }
 
-        let all_files_to_move = find_all_associated_files(source_image_path)?;
+        let all_files_to_move = find_all_associated_files(&app_handle, source_image_path)?;
+        let sidecar_source_dir =
+            crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, source_image_path)?;
+        let dest_image_path = dest_path.join(source_image_path.file_name().unwrap());
+        let dest_sidecar_dir =
+            crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, &dest_image_path)?;
 
         for file_to_move in &all_files_to_move {
             if let Some(file_name) = file_to_move.file_name() {
-                let dest_file_path = dest_path.join(file_name);
+                // A .rrdata sidecar (whose parent is the source's mirrored
+                // sidecar directory, not the photo's own folder) re-mirrors
+                // to the destination's own mirrored directory — everything
+                // else (the photo itself, a legacy adjacent .rrexif) moves
+                // into dest_path exactly as before.
+                let dest_file_path = if file_to_move.parent() == Some(sidecar_source_dir.as_path())
+                {
+                    dest_sidecar_dir.join(file_name)
+                } else {
+                    dest_path.join(file_name)
+                };
 
                 if dest_file_path.exists() {
                     return Err(format!(
@@ -2456,7 +2622,6 @@ pub fn move_files(
             }
         }
 
-        let dest_image_path = dest_path.join(source_image_path.file_name().unwrap());
         renames.insert(
             source_image_path.to_string_lossy().into_owned(),
             dest_image_path.to_string_lossy().into_owned(),
@@ -2464,6 +2629,9 @@ pub fn move_files(
     }
 
     for (source, dest) in operations_to_perform {
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
         if fs::rename(&source, &dest).is_err() {
             fs::copy(&source, &dest)
                 .map_err(|e| format!("Move failed during copy for {}: {}", source.display(), e))?;
@@ -2490,7 +2658,7 @@ pub fn save_metadata_and_update_thumbnail(
     app_handle: AppHandle,
     state: tauri::State<AppState>,
 ) -> Result<(), String> {
-    let (source_path, sidecar_path) = parse_virtual_path(&path);
+    let (source_path, sidecar_path) = sidecar_path_for_virtual(&app_handle, &path)?;
 
     let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
@@ -2507,6 +2675,9 @@ pub fn save_metadata_and_update_thumbnail(
     metadata.adjustments = final_adjustments;
 
     let json_string = serde_json::to_string_pretty(&metadata).map_err(|e| e.to_string())?;
+    if let Some(parent) = sidecar_path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
     std::fs::write(&sidecar_path, json_string).map_err(|e| e.to_string())?;
 
     if let Ok(settings) = load_settings(app_handle.clone())
@@ -2600,7 +2771,10 @@ pub async fn apply_adjustments_to_paths(
             .clone();
 
         paths.par_iter().for_each(|path| {
-            let (_, sidecar_path) = parse_virtual_path(path);
+            let Ok((source_path, sidecar_path)) = sidecar_path_for_virtual(&app_handle, path)
+            else {
+                return;
+            };
 
             let mut existing_metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
@@ -2626,11 +2800,13 @@ pub async fn apply_adjustments_to_paths(
             existing_metadata.adjustments = new_adjustments;
 
             if let Ok(json_string) = serde_json::to_string_pretty(&existing_metadata) {
+                if let Some(parent) = sidecar_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
                 let _ = std::fs::write(&sidecar_path, json_string);
             }
 
             if enable_xmp_sync {
-                let source_path = parse_virtual_path(path).0;
                 sync_metadata_to_xmp(&source_path, &existing_metadata, create_xmp_if_missing);
             }
         });
@@ -2688,18 +2864,23 @@ pub async fn reset_adjustments_for_paths(
         let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
         paths.par_iter().for_each(|path| {
-            let (_, sidecar_path) = parse_virtual_path(path);
+            let Ok((source_path, sidecar_path)) = sidecar_path_for_virtual(&app_handle, path)
+            else {
+                return;
+            };
 
             let mut existing_metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
             existing_metadata.adjustments = serde_json::json!({});
 
             if let Ok(json_string) = serde_json::to_string_pretty(&existing_metadata) {
+                if let Some(parent) = sidecar_path.parent() {
+                    let _ = std::fs::create_dir_all(parent);
+                }
                 let _ = std::fs::write(&sidecar_path, json_string);
             }
 
             if enable_xmp_sync {
-                let source_path = parse_virtual_path(path).0;
                 sync_metadata_to_xmp(&source_path, &existing_metadata, create_xmp_if_missing);
             }
         });
@@ -2775,7 +2956,7 @@ pub async fn apply_auto_adjustments_to_paths(
 
         paths.par_iter().for_each(|path| {
             let loaded_image: Option<DynamicImage> = (|| -> Result<DynamicImage, String> {
-                let (source_path, sidecar_path) = parse_virtual_path(path);
+                let (source_path, sidecar_path) = sidecar_path_for_virtual(&app_handle, path)?;
                 let source_path_str = source_path.to_string_lossy().to_string();
 
                 let file_bytes = fs::read(&source_path).map_err(|e| e.to_string())?;
@@ -2785,6 +2966,7 @@ pub async fn apply_auto_adjustments_to_paths(
                     true,
                     &settings,
                     None,
+                    Some(&app_handle),
                 )
                 .map_err(|e| e.to_string())?;
 
@@ -2821,6 +3003,9 @@ pub async fn apply_auto_adjustments_to_paths(
                 }
 
                 if let Ok(json_string) = serde_json::to_string_pretty(&existing_metadata) {
+                    if let Some(parent) = sidecar_path.parent() {
+                        let _ = std::fs::create_dir_all(parent);
+                    }
                     let _ = std::fs::write(&sidecar_path, json_string);
                 }
 
@@ -2864,7 +3049,9 @@ pub fn set_color_label_for_paths(
     let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
     paths.par_iter().for_each(|path| {
-        let (_, sidecar_path) = parse_virtual_path(path);
+        let Ok((source_path, sidecar_path)) = sidecar_path_for_virtual(&app_handle, path) else {
+            return;
+        };
 
         let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
@@ -2884,11 +3071,13 @@ pub fn set_color_label_for_paths(
         }
 
         if let Ok(json_string) = serde_json::to_string_pretty(&metadata) {
+            if let Some(parent) = sidecar_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
             let _ = std::fs::write(&sidecar_path, json_string);
         }
 
         if enable_xmp_sync {
-            let source_path = parse_virtual_path(path).0;
             sync_metadata_to_xmp(&source_path, &metadata, create_xmp_if_missing);
         }
     });
@@ -2907,18 +3096,22 @@ pub fn set_rating_for_paths(
     let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
     paths.par_iter().for_each(|path| {
-        let (_, sidecar_path) = parse_virtual_path(path);
+        let Ok((source_path, sidecar_path)) = sidecar_path_for_virtual(&app_handle, path) else {
+            return;
+        };
 
         let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
         metadata.rating = rating;
 
         if let Ok(json_string) = serde_json::to_string_pretty(&metadata) {
+            if let Some(parent) = sidecar_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
             let _ = std::fs::write(&sidecar_path, json_string);
         }
 
         if enable_xmp_sync {
-            let source_path = parse_virtual_path(path).0;
             sync_metadata_to_xmp(&source_path, &metadata, create_xmp_if_missing);
         }
     });
@@ -2928,16 +3121,19 @@ pub fn set_rating_for_paths(
 
 #[tauri::command]
 pub fn load_metadata(path: String, app_handle: AppHandle) -> Result<ImageMetadata, String> {
-    let settings = load_settings(app_handle).unwrap_or_default();
+    let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
 
-    let (source_path, sidecar_path) = parse_virtual_path(&path);
+    let (source_path, sidecar_path) = sidecar_path_for_virtual(&app_handle, &path)?;
     let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
     if enable_xmp_sync
         && sync_metadata_from_xmp(&source_path, &mut metadata)
         && let Ok(json) = serde_json::to_string_pretty(&metadata)
     {
+        if let Some(parent) = sidecar_path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
         let _ = fs::write(&sidecar_path, json);
     }
 
@@ -3321,7 +3517,10 @@ pub fn delete_files_from_disk(paths: Vec<String>, app_handle: AppHandle) -> Resu
     let mut deletions = HashSet::new();
 
     for path_str in paths {
-        let (source_path, sidecar_path) = parse_virtual_path(&path_str);
+        let Ok((source_path, sidecar_path)) = sidecar_path_for_virtual(&app_handle, &path_str)
+        else {
+            continue;
+        };
         deletions.insert(path_str.clone());
 
         if path_str.contains("?vc=") {
@@ -3330,7 +3529,7 @@ pub fn delete_files_from_disk(paths: Vec<String>, app_handle: AppHandle) -> Resu
             }
         } else {
             if source_path.exists() {
-                match find_all_associated_files(&source_path) {
+                match find_all_associated_files(&app_handle, &source_path) {
                     Ok(associated_files) => {
                         for file in associated_files {
                             files_to_trash.insert(file);
@@ -3427,6 +3626,7 @@ pub fn delete_files_with_associated(
 
     let mut stems_to_delete = HashSet::new();
     let mut parent_dirs = HashSet::new();
+    let mut sidecar_dirs = HashSet::new();
     let mut deletions = HashSet::new();
 
     for path_str in &paths {
@@ -3438,6 +3638,12 @@ pub fn delete_files_with_associated(
         if let Some(parent) = source_path.parent() {
             parent_dirs.insert(parent.to_path_buf());
         }
+        // .rrdata sidecars are centralized (sidecar_paths.rs) — scan their
+        // mirrored directory too, not just the photo's own folder (which
+        // only ever has the image itself and a legacy .rrexif now).
+        if let Ok(dir) = crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, &source_path) {
+            sidecar_dirs.insert(dir);
+        }
     }
 
     if stems_to_delete.is_empty() {
@@ -3446,8 +3652,8 @@ pub fn delete_files_with_associated(
 
     let mut files_to_trash = HashSet::new();
 
-    for parent_dir in parent_dirs {
-        if let Ok(entries) = fs::read_dir(parent_dir) {
+    for dir in parent_dirs.iter().chain(sidecar_dirs.iter()) {
+        if let Ok(entries) = fs::read_dir(dir) {
             for entry in entries.filter_map(Result::ok) {
                 let entry_path = entry.path();
                 if !entry_path.is_file() {
@@ -3513,8 +3719,8 @@ pub fn get_thumb_cache_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
     Ok(thumb_cache_dir)
 }
 
-pub fn get_cache_key_hash(path_str: &str) -> Option<String> {
-    let (_, sidecar_path) = parse_virtual_path(path_str);
+pub fn get_cache_key_hash(path_str: &str, app_handle: &AppHandle) -> Option<String> {
+    let (_, sidecar_path) = sidecar_path_for_virtual(app_handle, path_str).ok()?;
 
     let adjustments_bytes = if let Ok(content) = fs::read_to_string(&sidecar_path) {
         if let Ok(meta) = serde_json::from_str::<ImageMetadata>(&content) {
@@ -3538,7 +3744,7 @@ pub fn get_cached_or_generate_thumbnail_image(
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
     let target_width = settings.thumbnail_resolution.unwrap_or(720);
 
-    if let Some(cache_hash) = get_cache_key_hash(path_str) {
+    if let Some(cache_hash) = get_cache_key_hash(path_str, app_handle) {
         let cache_filename = format!("{}.jpg", cache_hash);
         let cache_path = thumb_cache_dir.join(cache_filename);
 
@@ -3637,12 +3843,17 @@ pub async fn import_files(
                     return Ok(());
                 }
 
-                let (source_path, source_sidecar) = parse_virtual_path(source_path_str);
+                let (source_path, source_sidecar) =
+                    sidecar_path_for_virtual(&app_handle, source_path_str)
+                        .map_err(|e| e.to_string())?;
                 if !source_path.exists() {
                     return Err(format!("Source file not found: {}", source_path_str));
                 }
 
-                let file_date = exif_processing::get_creation_date_from_path(&source_path);
+                let file_date = exif_processing::get_creation_date_from_path(
+                    Some(&app_handle),
+                    &source_path,
+                );
 
                 let mut final_dest_folder = PathBuf::from(&destination_folder);
                 if settings.organize_by_date {
@@ -3683,7 +3894,11 @@ pub async fn import_files(
                 if source_sidecar.exists()
                     && let Some(dest_str) = dest_file_path.to_str()
                 {
-                    let (_, dest_sidecar) = parse_virtual_path(dest_str);
+                    let (_, dest_sidecar) = sidecar_path_for_virtual(&app_handle, dest_str)
+                        .map_err(|e| e.to_string())?;
+                    if let Some(parent) = dest_sidecar.parent() {
+                        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                    }
                     fs::copy(&source_sidecar, &dest_sidecar).map_err(|e| e.to_string())?;
                 }
 
@@ -3815,7 +4030,10 @@ pub fn rename_files(
             .and_then(|s| s.to_str())
             .unwrap_or("");
 
-        let file_date = exif_processing::get_creation_date_from_path(&original_path);
+        let file_date = exif_processing::get_creation_date_from_path(
+            Some(&app_handle),
+            &original_path,
+        );
 
         let new_stem = generate_filename_from_template(
             &name_template,
@@ -3839,13 +4057,17 @@ pub fn rename_files(
 
     let mut sidecar_operations: Vec<(PathBuf, PathBuf)> = Vec::new();
     for (original_path, new_path) in &operations {
-        let parent = original_path
-            .parent()
-            .ok_or("Could not get parent directory")?;
         let original_filename_str = original_path.file_name().unwrap().to_string_lossy();
         let new_filename_str = new_path.file_name().unwrap().to_string_lossy();
 
-        if let Ok(entries) = fs::read_dir(parent) {
+        // .rrdata sidecars are centralized now (sidecar_paths.rs) — this is
+        // a same-folder rename, so the mirrored sidecar directory is the
+        // same for both the old and new name, only the filename inside it
+        // changes.
+        if let Ok(sidecar_dir) =
+            crate::sidecar_paths::sidecar_dir_for_photo(&app_handle, original_path)
+            && let Ok(entries) = fs::read_dir(&sidecar_dir)
+        {
             for entry in entries.filter_map(Result::ok) {
                 let entry_path = entry.path();
                 let entry_os_filename = entry.file_name();
@@ -3856,12 +4078,11 @@ pub fn rename_files(
                 {
                     let new_sidecar_filename =
                         entry_filename.replacen(&*original_filename_str, &new_filename_str, 1);
-                    let new_sidecar_path = parent.join(new_sidecar_filename);
+                    let new_sidecar_path = sidecar_dir.join(new_sidecar_filename);
                     sidecar_operations.push((entry_path, new_sidecar_path));
                 } else if entry_filename == format!("{}.rrdata", original_filename_str) {
-                    let mut new_sidecar_name = new_path.file_name().unwrap().to_os_string();
-                    new_sidecar_name.push(".rrdata");
-                    let new_sidecar_path = new_path.with_file_name(new_sidecar_name);
+                    let new_sidecar_name = format!("{}.rrdata", new_filename_str);
+                    let new_sidecar_path = sidecar_dir.join(new_sidecar_name);
 
                     sidecar_operations.push((entry_path, new_sidecar_path));
                 }
@@ -3913,11 +4134,15 @@ pub fn create_virtual_copy(
     target_album_id: Option<String>,
     app_handle: AppHandle,
 ) -> Result<String, String> {
-    let (source_path, source_sidecar_path) = parse_virtual_path(&source_virtual_path);
+    let (source_path, source_sidecar_path) =
+        sidecar_path_for_virtual(&app_handle, &source_virtual_path)?;
 
     let new_copy_id = Uuid::new_v4().to_string()[..6].to_string();
     let new_virtual_path = format!("{}?vc={}", source_path.to_string_lossy(), new_copy_id);
-    let (_, new_sidecar_path) = parse_virtual_path(&new_virtual_path);
+    let (_, new_sidecar_path) = sidecar_path_for_virtual(&app_handle, &new_virtual_path)?;
+    if let Some(parent) = new_sidecar_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
 
     if source_sidecar_path.exists() {
         fs::copy(&source_sidecar_path, &new_sidecar_path)

--- a/src-tauri/src/focus_stacking.rs
+++ b/src-tauri/src/focus_stacking.rs
@@ -2088,7 +2088,7 @@ fn decode_frame(
 ) -> Result<PlanarRgb, String> {
     let bytes = fs::read(path).map_err(|e| format!("Failed to read {}: {}", path, e))?;
     let mut dyn_img =
-        crate::image_loader::load_base_image_from_bytes(&bytes, path, false, settings, None)
+        crate::image_loader::load_base_image_from_bytes(&bytes, path, false, settings, None, None)
             .map_err(|e| format!("Failed to decode {}: {}", path, e))?;
     if is_raw_file(path) {
         apply_cpu_default_raw_processing(&mut dyn_img);
@@ -2137,6 +2137,7 @@ fn make_depth_preview(result: &StackResult, n_frames: usize) -> Result<String, S
 #[tauri::command]
 pub async fn save_focus_stack(
     first_path_str: String,
+    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let focus_image = state
@@ -2159,7 +2160,7 @@ pub async fn save_focus_stack(
         .save_with_format(&output_path, ImageFormat::Tiff)
         .map_err(|e| format!("Failed to save {}: {}", output_path.display(), e))?;
 
-    crate::exif_processing::write_rrexif_sidecar(&first_path_str, &output_path).ok();
+    crate::exif_processing::write_rrexif_sidecar(&app_handle, &first_path_str, &output_path).ok();
 
     Ok(output_path.to_string_lossy().to_string())
 }

--- a/src-tauri/src/gpu_processing.rs
+++ b/src-tauri/src/gpu_processing.rs
@@ -1414,7 +1414,13 @@ impl GpuProcessor {
                 let did_create_sharpness_blur = run_blur(1.0, &self.sharpness_blur_view);
                 let did_create_tonal_blur = run_blur(3.5, &self.tonal_blur_view);
                 let did_create_clarity_blur = run_blur(8.0, &self.clarity_blur_view);
-                let did_create_structure_blur = run_blur(40.0, &self.structure_blur_view);
+                // Radius intentionally small (below Clarity's 8.0, in the same
+                // family as sharpness's 1.0 / tonal's 3.5) so this slider behaves
+                // like Lightroom's fine-detail "Texture" instead of a second,
+                // exaggerated Clarity — see preset_converter.rs's own
+                // ("Texture", "structure") XMP mapping, which already treats this
+                // field as Texture; only the radius (and the UI label) were wrong.
+                let did_create_structure_blur = run_blur(2.5, &self.structure_blur_view);
 
                 let mut main_encoder = device.create_command_encoder(&Default::default());
 

--- a/src-tauri/src/hdr_deghosting.rs
+++ b/src-tauri/src/hdr_deghosting.rs
@@ -55,16 +55,16 @@ pub fn load_hdr_frames(
             let file_bytes =
                 fs::read(path).map_err(|e| format!("Failed to read image {}: {}", path, e))?;
             let mut dynamic_image =
-                load_base_image_from_bytes(&file_bytes, path, false, settings, None)
+                load_base_image_from_bytes(&file_bytes, path, false, settings, None, Some(app_handle))
                     .map_err(|e| format!("Failed to load image {}: {}", path, e))?;
             if !is_raw_file(path) {
                 dynamic_image = apply_srgb_to_linear(dynamic_image);
             }
-            let gains = match read_iso(path, &file_bytes) {
+            let gains = match read_iso(app_handle, path, &file_bytes) {
                 None => return Err(format!("Image {} is missing ISO/Sensitivity data", path)),
                 Some(gains) => gains as f32,
             };
-            let exposure = match read_exposure_time_secs(path, &file_bytes) {
+            let exposure = match read_exposure_time_secs(app_handle, path, &file_bytes) {
                 None => return Err(format!("Image {} is missing ExposureTime data", path)),
                 Some(exp) => Duration::from_secs_f32(exp),
             };

--- a/src-tauri/src/image_loader.rs
+++ b/src-tauri/src/image_loader.rs
@@ -72,8 +72,14 @@ pub fn load_and_composite(
     settings: &AppSettings,
     cancel_token: Option<(Arc<AtomicUsize>, usize)>,
 ) -> Result<DynamicImage> {
-    let base_image =
-        load_base_image_from_bytes(base_image, path, use_fast_raw_dev, settings, cancel_token)?;
+    let base_image = load_base_image_from_bytes(
+        base_image,
+        path,
+        use_fast_raw_dev,
+        settings,
+        cancel_token,
+        None,
+    )?;
     composite_patches_on_image(&base_image, adjustments)
 }
 
@@ -83,6 +89,7 @@ pub fn load_base_image_from_bytes(
     use_fast_raw_dev: bool,
     settings: &AppSettings,
     cancel_token: Option<(Arc<AtomicUsize>, usize)>,
+    app_handle: Option<&tauri::AppHandle>,
 ) -> Result<DynamicImage> {
     let highlight_compression = settings.raw_highlight_compression.unwrap_or(2.5);
     let linear_mode = settings.linear_raw_mode.clone();
@@ -96,11 +103,14 @@ pub fn load_base_image_from_bytes(
     let sharpening_amount = settings.raw_preprocessing_sharpening.unwrap_or(0.35);
     let apply_to_non_raws = settings.apply_preprocessing_to_non_raws.unwrap_or(false);
 
-    crate::exif_processing::persist_exif_if_missing(
-        Path::new(path_for_ext_check),
-        path_for_ext_check,
-        bytes,
-    );
+    if let Some(handle) = app_handle {
+        crate::exif_processing::persist_exif_if_missing(
+            handle,
+            Path::new(path_for_ext_check),
+            path_for_ext_check,
+            bytes,
+        );
+    }
 
     if is_raw_file(path_for_ext_check) {
         match panic::catch_unwind(move || {
@@ -770,7 +780,10 @@ pub async fn load_image(
         *state.panorama_result.lock().unwrap() = None;
     }
 
-    let (source_path, sidecar_path) = parse_virtual_path(&path);
+    let (source_path, sidecar_path) = crate::file_management::sidecar_path_for_virtual(
+        &app_handle,
+        &path,
+    )?;
     let source_path_str = source_path.to_string_lossy().to_string();
 
     let metadata: ImageMetadata = crate::exif_processing::load_sidecar(&sidecar_path);
@@ -813,9 +826,10 @@ pub async fn load_image(
                             false,
                             &settings,
                             cancel_token.clone(),
+                            Some(&app_handle),
                         )
                         .map_err(|e| e.to_string())?;
-                        let exif = exif_processing::read_exif_data(&path_clone, &mmap);
+                        let exif = exif_processing::read_exif_data(&app_handle, &path_clone, &mmap);
                         Ok((img, exif))
                     }
                     Err(e) => {
@@ -838,9 +852,10 @@ pub async fn load_image(
                             false,
                             &settings,
                             cancel_token.clone(),
+                            Some(&app_handle),
                         )
                         .map_err(|e| e.to_string())?;
-                        let exif = exif_processing::read_exif_data(&path_clone, &bytes);
+                        let exif = exif_processing::read_exif_data(&app_handle, &path_clone, &bytes);
                         Ok((img, exif))
                     }
                 })();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -37,6 +37,7 @@ mod panorama_stitching;
 mod panorama_utils;
 mod preset_converter;
 mod raw_processing;
+mod sidecar_paths;
 mod tagging;
 mod tagging_utils;
 mod window_customizer;
@@ -1249,6 +1250,7 @@ async fn generate_all_community_previews(
             true,
             &settings,
             None,
+            Some(&app_handle),
         )
         .map_err(|e| e.to_string())?;
 
@@ -1463,6 +1465,7 @@ async fn merge_hdr(
 #[tauri::command]
 async fn save_hdr(
     first_path_str: String,
+    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let hdr_image = state.hdr_result.lock().unwrap().take().ok_or_else(|| {
@@ -1500,8 +1503,11 @@ async fn save_hdr(
         .map_err(|e| format!("Failed to save hdr image: {}", e))?;
 
     let (real_path, _) = crate::file_management::parse_virtual_path(&first_path_str);
-    let _ =
-        crate::exif_processing::write_rrexif_sidecar(&real_path.to_string_lossy(), &output_path);
+    let _ = crate::exif_processing::write_rrexif_sidecar(
+        &app_handle,
+        &real_path.to_string_lossy(),
+        &output_path,
+    );
 
     Ok(output_path.to_string_lossy().to_string())
 }

--- a/src-tauri/src/negative_conversion.rs
+++ b/src-tauri/src/negative_conversion.rs
@@ -216,6 +216,7 @@ pub async fn preview_negative_conversion(
                                 false,
                                 &settings,
                                 None,
+                                Some(&app_handle),
                             )
                             .map_err(|e| e.to_string())?,
                             Err(_e) => {
@@ -227,6 +228,7 @@ pub async fn preview_negative_conversion(
                                     false,
                                     &settings,
                                     None,
+                                    Some(&app_handle),
                                 )
                                 .map_err(|e| e.to_string())?
                             }
@@ -243,6 +245,7 @@ pub async fn preview_negative_conversion(
                             false,
                             &settings,
                             None,
+                            Some(&app_handle),
                         )
                         .map_err(|e| e.to_string())?,
                         Err(_e) => {
@@ -254,6 +257,7 @@ pub async fn preview_negative_conversion(
                                 false,
                                 &settings,
                                 None,
+                                Some(&app_handle),
                             )
                             .map_err(|e| e.to_string())?
                         }
@@ -305,10 +309,24 @@ pub async fn convert_negatives(
             let settings = load_settings(app_handle.clone()).unwrap_or_default();
 
             let img = match read_file_mapped(Path::new(&real_path)) {
-                Ok(mmap) => load_base_image_from_bytes(&mmap, &real_path, false, &settings, None),
+                Ok(mmap) => load_base_image_from_bytes(
+                    &mmap,
+                    &real_path,
+                    false,
+                    &settings,
+                    None,
+                    Some(&app_handle),
+                ),
                 Err(_) => {
                     let bytes = fs::read(&real_path).unwrap_or_default();
-                    load_base_image_from_bytes(&bytes, &real_path, false, &settings, None)
+                    load_base_image_from_bytes(
+                        &bytes,
+                        &real_path,
+                        false,
+                        &settings,
+                        None,
+                        Some(&app_handle),
+                    )
                 }
             }
             .map_err(|e| e.to_string())?;
@@ -336,7 +354,8 @@ pub async fn convert_negatives(
                 .save(&out_path)
                 .map_err(|e| format!("Failed to save {}: {}", filename, e))?;
 
-            let _ = crate::exif_processing::write_rrexif_sidecar(&real_path, &out_path);
+            let _ =
+                crate::exif_processing::write_rrexif_sidecar(&app_handle, &real_path, &out_path);
             results.push(out_path.to_string_lossy().to_string());
         }
 

--- a/src-tauri/src/panorama_stitching.rs
+++ b/src-tauri/src/panorama_stitching.rs
@@ -124,6 +124,7 @@ pub async fn stitch_panorama(
 #[tauri::command]
 pub async fn save_panorama(
     first_path_str: String,
+    app_handle: AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<String, String> {
     let panorama_image = state
@@ -167,8 +168,11 @@ pub async fn save_panorama(
         .map_err(|e| format!("Failed to save panorama image: {}", e))?;
 
     let (real_path, _) = crate::file_management::parse_virtual_path(&first_path_str);
-    let _ =
-        crate::exif_processing::write_rrexif_sidecar(&real_path.to_string_lossy(), &output_path);
+    let _ = crate::exif_processing::write_rrexif_sidecar(
+        &app_handle,
+        &real_path.to_string_lossy(),
+        &output_path,
+    );
 
     Ok(output_path.to_string_lossy().to_string())
 }
@@ -216,6 +220,7 @@ fn stitch_images(image_paths: Vec<String>, app_handle: AppHandle) -> Result<Dyna
                 false,
                 &settings,
                 None,
+                Some(&app_handle),
             )
             .map_err(|e| format!("Failed to load image {}: {}", filename, e))?;
 

--- a/src-tauri/src/sidecar_paths.rs
+++ b/src-tauri/src/sidecar_paths.rs
@@ -2,21 +2,119 @@ use std::path::{Component, Path, PathBuf};
 
 use tauri::{AppHandle, Manager};
 
-/// Root directory every relocated `.rrdata`/`.rrexif` sidecar lives under —
-/// `app_data_dir()/sidecars`, the same place presets/settings/library/ONNX
-/// models already live (see `ai_processing.rs`'s `get_models_dir` for the
-/// identical pattern). Not `app_cache_dir()` — unlike thumbnails, this data
-/// isn't regenerable, so it belongs with the app's other persistent data.
+/// Root directory every relocated `.rrdata`/`.rrexif` sidecar lives under.
+/// Deliberately *not* `app_data_dir()/sidecars` (which would nest under the
+/// full Tauri bundle identifier, e.g. `io.github.CyberTimon.RapidRAW`) —
+/// sidecars live in a plain `RapidRAW/sidecars` sibling folder instead, so
+/// the folder a user finds browsing AppData actually reads "RapidRAW", not
+/// the bundle id. `tauri.conf.json`'s `identifier` itself is untouched —
+/// presets/settings/library/ONNX models (`ai_processing.rs`'s
+/// `get_models_dir`) keep living under the identifier-named folder as
+/// before; only this one relocation feature's own root moves. Not
+/// `app_cache_dir()` either — unlike thumbnails, this data isn't
+/// regenerable, so it belongs with the app's other persistent data.
 pub fn sidecar_root_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
-    let root = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| e.to_string())?
-        .join("sidecars");
+    let app_data = app_handle.path().app_data_dir().map_err(|e| e.to_string())?;
+    let old_root = app_data.join("sidecars");
+    let base = app_data.parent().map(|p| p.to_path_buf()).unwrap_or(app_data);
+    let root = base.join("RapidRAW").join("sidecars");
     if !root.exists() {
+        // One-time migration for anyone who already had sidecars under the
+        // pre-rename, bundle-identifier-nested location: move the whole
+        // tree in one `rename` rather than recreating it empty and
+        // orphaning everything already relocated there (there's no
+        // adjacent-to-photo fallback once a sidecar has already left the
+        // photo's own folder, so silently starting fresh here would look
+        // like every edit made since the relocation feature shipped had
+        // been lost).
+        if old_root.is_dir() {
+            if let Some(parent) = root.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if std::fs::rename(&old_root, &root).is_ok() {
+                return Ok(root);
+            }
+        }
         std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
     }
     Ok(root)
+}
+
+/// Root of the cosmetic "browse by month" secondary view — a sibling of
+/// [`sidecar_root_dir`], so both live under the same `RapidRAW/` folder.
+fn sidecar_by_month_root(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    let root = sidecar_root_dir(app_handle)?;
+    Ok(root
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| root.clone())
+        .join("sidecars_by_month"))
+}
+
+/// Best-effort: hard-links `sidecar_path` (which must already live under
+/// [`sidecar_root_dir`]) into `sidecars_by_month/<month>/<same-mirrored-
+/// relative-path>`, purely for the user's own convenience browsing Explorer
+/// — grouped by the month a sidecar was *first* created (i.e. first edited),
+/// never the photo's own capture date (not worth an EXIF read on every
+/// write just for this). This is a second pointer at the same file, not a
+/// copy and not the authoritative location — the app's own logic never
+/// reads through this tree, so any failure here (unsupported filesystem,
+/// cross-volume link, permissions) is safe to swallow silently rather than
+/// surfacing an error for a cosmetic feature. A hard link (not a symlink)
+/// is used specifically because Windows symlinks need admin/Developer Mode
+/// privileges and hard links don't — and the same-volume constraint hard
+/// links carry is always satisfied here since both paths live under the
+/// same `RapidRAW/` tree.
+fn link_into_month_view(app_handle: &AppHandle, sidecar_path: &Path, month: &str) {
+    let Ok(root) = sidecar_root_dir(app_handle) else {
+        return;
+    };
+    let Ok(relative) = sidecar_path.strip_prefix(&root) else {
+        return;
+    };
+    let Ok(by_month_root) = sidecar_by_month_root(app_handle) else {
+        return;
+    };
+    let link_path = by_month_root.join(month).join(relative);
+    if link_path.exists() {
+        return;
+    }
+    if let Some(parent) = link_path.parent() {
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+    }
+    let _ = std::fs::hard_link(sidecar_path, &link_path);
+}
+
+/// The month (`YYYY-MM`, local time) a sidecar was first created — `now` for
+/// a fresh write ([`write_sidecar`]), or the file's own modified time for a
+/// pre-existing file being migrated ([`migrate_legacy_rrdata`]), falling
+/// back to `now` if that metadata can't be read.
+fn month_of(path: &Path) -> String {
+    std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .map(|t| {
+            let datetime: chrono::DateTime<chrono::Local> = t.into();
+            datetime.format("%Y-%m").to_string()
+        })
+        .unwrap_or_else(|| chrono::Local::now().format("%Y-%m").to_string())
+}
+
+/// Writes a sidecar's contents and, only the first time this exact file is
+/// created, adds it to the cosmetic by-month view above — every write site
+/// funnels through this (instead of a bare `fs::write`) so that view can't
+/// silently miss a sidecar. Safe/cheap to call on every save: the `exists()`
+/// check means re-saving an already-edited photo just overwrites the real
+/// file and skips the link step entirely.
+pub fn write_sidecar(app_handle: &AppHandle, sidecar_path: &Path, contents: &str) -> std::io::Result<()> {
+    let is_new = !sidecar_path.exists();
+    std::fs::write(sidecar_path, contents)?;
+    if is_new {
+        link_into_month_view(app_handle, sidecar_path, &chrono::Local::now().format("%Y-%m").to_string());
+    }
+    Ok(())
 }
 
 /// Sanitizes one path component into something valid as a plain directory
@@ -147,6 +245,7 @@ pub fn migrate_legacy_rrdata(
     let parent = new_path.parent()?;
     std::fs::create_dir_all(parent).ok()?;
     std::fs::rename(legacy_path, &new_path).ok()?;
+    link_into_month_view(app_handle, &new_path, &month_of(&new_path));
     Some(new_path)
 }
 

--- a/src-tauri/src/sidecar_paths.rs
+++ b/src-tauri/src/sidecar_paths.rs
@@ -1,0 +1,159 @@
+use std::path::{Component, Path, PathBuf};
+
+use tauri::{AppHandle, Manager};
+
+/// Root directory every relocated `.rrdata`/`.rrexif` sidecar lives under —
+/// `app_data_dir()/sidecars`, the same place presets/settings/library/ONNX
+/// models already live (see `ai_processing.rs`'s `get_models_dir` for the
+/// identical pattern). Not `app_cache_dir()` — unlike thumbnails, this data
+/// isn't regenerable, so it belongs with the app's other persistent data.
+pub fn sidecar_root_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    let root = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("sidecars");
+    if !root.exists() {
+        std::fs::create_dir_all(&root).map_err(|e| e.to_string())?;
+    }
+    Ok(root)
+}
+
+/// Sanitizes one path component into something valid as a plain directory
+/// name on every platform — in particular a Windows drive prefix (`C:`, or
+/// the `\\?\C:` verbatim form `Path::canonicalize()` returns) collapses to
+/// just `C` here, since filtering to alphanumeric characters strips the
+/// `\`/`?`/`:` either way regardless of which prefix form was given.
+fn sanitize_component(component: Component) -> Option<String> {
+    match component {
+        Component::Prefix(prefix) => {
+            let raw = prefix.as_os_str().to_string_lossy();
+            let cleaned: String = raw.chars().filter(|c| c.is_alphanumeric()).collect();
+            if cleaned.is_empty() { None } else { Some(cleaned) }
+        }
+        Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+        Component::RootDir | Component::CurDir | Component::ParentDir => None,
+    }
+}
+
+/// Maps a photo's own directory to the mirrored directory under the
+/// centralized sidecar root its sidecar(s) now live in — e.g.
+/// `C:\Users\vini\Photos\trip` -> `<sidecar_root>\C\Users\vini\Photos\trip`.
+/// Only the *directory* a sidecar is considered to live in moves; the
+/// sidecar's own filename-construction rules (below) are unchanged, so this
+/// is a pure relocation, not a renaming — and because the mirrored tree's
+/// structure exactly parallels the source tree's, folder-level sidecar
+/// *discovery* (`list_images_in_dir`/`list_images_recursive`) keeps working
+/// by scanning the mirrored directory instead of the photo's own — same
+/// bucket-and-match logic, just pointed at a different root.
+pub fn mirrored_sidecar_dir(sidecar_root: &Path, photo_dir: &Path) -> PathBuf {
+    let mut result = sidecar_root.to_path_buf();
+    for component in photo_dir.components() {
+        if let Some(part) = sanitize_component(component) {
+            result.push(part);
+        }
+    }
+    result
+}
+
+/// The centralized sidecar directory for the folder containing `photo_path`
+/// — canonicalizes first so the same photo always mirrors to the same
+/// location regardless of how it was navigated to (symlink, differing case
+/// on Windows, `.`/`..` in the input path); falls back to the raw,
+/// non-canonicalized parent if canonicalization fails (e.g. the photo was
+/// deleted between being listed and being looked up here — rare, but this
+/// should degrade gracefully rather than error).
+pub fn sidecar_dir_for_photo(app_handle: &AppHandle, photo_path: &Path) -> Result<PathBuf, String> {
+    let root = sidecar_root_dir(app_handle)?;
+    let photo_dir = photo_path.parent().unwrap_or_else(|| Path::new(""));
+    let canonical_dir = photo_dir.canonicalize().unwrap_or_else(|_| photo_dir.to_path_buf());
+    Ok(mirrored_sidecar_dir(&root, &canonical_dir))
+}
+
+/// Builds the sidecar filename for `photo_path` (and, for a virtual copy,
+/// its `copy_id`) — identical construction rules to what
+/// `file_management.rs`'s `parse_virtual_path` and `exif_processing.rs`'s
+/// `get_primary_sidecar_path`/`get_rrexif_path` always used, kept exactly
+/// the same here so relocating sidecars doesn't also rename them.
+pub fn sidecar_filename(photo_path: &Path, copy_id: Option<&str>, extension: &str) -> String {
+    let base = photo_path.file_name().unwrap_or_default().to_string_lossy();
+    match copy_id {
+        Some(id) => format!("{}.{}.{}", base, id, extension),
+        None => format!("{}.{}", base, extension),
+    }
+}
+
+/// Full centralized path for `photo_path`'s primary (`copy_id: None`) or
+/// virtual-copy sidecar, of the given `extension` (`"rrdata"` or, during the
+/// legacy-migration window, `"rrexif"`).
+pub fn sidecar_path_for(
+    app_handle: &AppHandle,
+    photo_path: &Path,
+    copy_id: Option<&str>,
+    extension: &str,
+) -> Result<PathBuf, String> {
+    let dir = sidecar_dir_for_photo(app_handle, photo_path)?;
+    Ok(dir.join(sidecar_filename(photo_path, copy_id, extension)))
+}
+
+/// The mirrored sidecar directory for an entire source directory (not a
+/// specific photo) — same mirroring as [`sidecar_dir_for_photo`], just
+/// applied to a folder the caller already has (e.g. a library root a bulk
+/// operation was asked to walk) instead of deriving it from a photo's
+/// parent. Also returns the canonicalized source directory the mapping was
+/// computed from, since callers that need to walk the mirrored tree and
+/// map results back to source paths (see `tagging.rs`'s
+/// `clear_ai_tags`/`clear_all_tags`) need both ends of the mapping to agree
+/// on the exact same canonical form.
+pub fn mirrored_root_for_source_dir(
+    app_handle: &AppHandle,
+    source_dir: &Path,
+) -> Result<(PathBuf, PathBuf), String> {
+    let root = sidecar_root_dir(app_handle)?;
+    let canonical_dir = source_dir
+        .canonicalize()
+        .unwrap_or_else(|_| source_dir.to_path_buf());
+    let mirrored = mirrored_sidecar_dir(&root, &canonical_dir);
+    Ok((mirrored, canonical_dir))
+}
+
+/// Moves one legacy (pre-relocation) `.rrdata` file found directly next to
+/// a photo into its new centralized, mirrored location — called from
+/// `list_images_in_dir`/`list_images_recursive` for every `.rrdata` they
+/// encounter while scanning a photo's own folder, so migration happens
+/// automatically and incrementally on ordinary folder browsing (no
+/// separate "have I migrated this folder yet" flag needed: a folder with
+/// nothing left to migrate is just a fast, do-nothing scan). Returns the
+/// new path on success, so the caller can fold the migrated sidecar
+/// straight into whatever it's already doing without a second lookup.
+/// `.rrexif` is *not* migrated here — it already has its own
+/// merge-into-`.rrdata`-then-delete migration path
+/// (`exif_processing.rs`'s `read_rrexif_sidecar`) and stays adjacent to
+/// the photo by design (see `legacy_sidecar_path`'s doc comment).
+pub fn migrate_legacy_rrdata(
+    app_handle: &AppHandle,
+    legacy_path: &Path,
+    photo_path: &Path,
+    copy_id: Option<&str>,
+) -> Option<PathBuf> {
+    let new_path = sidecar_path_for(app_handle, photo_path, copy_id, "rrdata").ok()?;
+    if new_path.exists() {
+        // Something's already at the new location (e.g. re-migrated on a
+        // previous run that failed to remove the legacy file) — don't
+        // clobber it, just leave the legacy copy for the user/a future
+        // pass to reconcile manually rather than silently losing data.
+        return None;
+    }
+    let parent = new_path.parent()?;
+    std::fs::create_dir_all(parent).ok()?;
+    std::fs::rename(legacy_path, &new_path).ok()?;
+    Some(new_path)
+}
+
+/// The pre-relocation sidecar path (next to the photo) — used only by the
+/// one-time bulk migration (`migrate_sidecars_in_dir`) and the lazy
+/// fallback lookup, both of which need to find sidecars a pre-update
+/// install of the app already wrote in the old location.
+pub fn legacy_sidecar_path(photo_path: &Path, copy_id: Option<&str>, extension: &str) -> PathBuf {
+    photo_path.with_file_name(sidecar_filename(photo_path, copy_id, extension))
+}

--- a/src-tauri/src/tagging.rs
+++ b/src-tauri/src/tagging.rs
@@ -382,7 +382,11 @@ pub async fn start_background_indexing(
                                         if let Some(parent) = sidecar_path.parent() {
                                             let _ = fs::create_dir_all(parent);
                                         }
-                                        let _ = fs::write(sidecar_path, json_string);
+                                        let _ = crate::sidecar_paths::write_sidecar(
+                                            &app_handle_inner,
+                                            &sidecar_path,
+                                            &json_string,
+                                        );
                                     }
                                 }
                             }
@@ -449,7 +453,7 @@ fn modify_tags_for_path(
     if let Some(parent) = sidecar_path.parent() {
         fs::create_dir_all(parent).map_err(|e| e.to_string())?;
     }
-    fs::write(&sidecar_path, json_string).map_err(|e| e.to_string())?;
+    crate::sidecar_paths::write_sidecar(app_handle, &sidecar_path, &json_string).map_err(|e| e.to_string())?;
 
     if let Ok(settings) = crate::load_settings(app_handle.clone())
         && settings.enable_xmp_sync.unwrap_or(false)

--- a/src-tauri/src/tagging.rs
+++ b/src-tauri/src/tagging.rs
@@ -14,7 +14,7 @@ use tokenizers::Tokenizer;
 use tokio::task::JoinHandle;
 use walkdir::WalkDir;
 
-use crate::file_management::{self, parse_virtual_path};
+use crate::file_management;
 use crate::formats::is_supported_image_file;
 use crate::hierarchy::TAG_HIERARCHY;
 use crate::image_processing::ImageMetadata;
@@ -330,7 +330,14 @@ pub async fn start_background_indexing(
 
                 async move {
                     let path_str = path.to_string_lossy().to_string();
-                    let (_, sidecar_path) = parse_virtual_path(&path_str);
+                    let Ok((_, sidecar_path)) =
+                        crate::file_management::sidecar_path_for_virtual(
+                            &app_handle_inner,
+                            &path_str,
+                        )
+                    else {
+                        return;
+                    };
 
                     let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
@@ -372,6 +379,9 @@ pub async fn start_background_indexing(
 
                                     if let Ok(json_string) = serde_json::to_string_pretty(&metadata)
                                     {
+                                        if let Some(parent) = sidecar_path.parent() {
+                                            let _ = fs::create_dir_all(parent);
+                                        }
                                         let _ = fs::write(sidecar_path, json_string);
                                     }
                                 }
@@ -418,7 +428,8 @@ fn modify_tags_for_path(
     app_handle: &AppHandle,
     modify_fn: impl Fn(&mut Vec<String>),
 ) -> Result<(), String> {
-    let (source_path, sidecar_path) = parse_virtual_path(path_str);
+    let (source_path, sidecar_path) =
+        crate::file_management::sidecar_path_for_virtual(app_handle, path_str)?;
 
     let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
@@ -435,6 +446,9 @@ fn modify_tags_for_path(
     }
 
     let json_string = serde_json::to_string_pretty(&metadata).map_err(|e| e.to_string())?;
+    if let Some(parent) = sidecar_path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
     fs::write(&sidecar_path, json_string).map_err(|e| e.to_string())?;
 
     if let Ok(settings) = crate::load_settings(app_handle.clone())
@@ -483,7 +497,17 @@ pub fn remove_tag_for_paths(
     Ok(())
 }
 
-fn rrdata_source_path(rrdata: &Path) -> Option<PathBuf> {
+/// Recovers a discovered sidecar's original photo path — `rrdata` is
+/// somewhere under `mirrored_root` (the centralized, relocated sidecar
+/// tree for `source_root`), so this strips `mirrored_root`'s prefix off,
+/// re-joins the remaining relative path onto `source_root`, and finally
+/// strips the sidecar's own `.rrdata` (and, for a virtual copy, its 6-hex
+/// `.<id>` suffix) off the filename — the exact inverse of
+/// `sidecar_paths::sidecar_path_for`.
+fn rrdata_source_path(rrdata: &Path, mirrored_root: &Path, source_root: &Path) -> Option<PathBuf> {
+    let relative_dir = rrdata.parent()?.strip_prefix(mirrored_root).ok()?;
+    let source_dir = source_root.join(relative_dir);
+
     let name = rrdata.file_name()?.to_str()?;
     let base = name.strip_suffix(".rrdata")?;
 
@@ -498,11 +522,13 @@ fn rrdata_source_path(rrdata: &Path) -> Option<PathBuf> {
         base
     };
 
-    Some(rrdata.with_file_name(source_filename))
+    Some(source_dir.join(source_filename))
 }
 
 fn sync_xmp_for_rrdata(
     rrdata_path: &Path,
+    mirrored_root: &Path,
+    source_root: &Path,
     metadata: &ImageMetadata,
     enable_xmp_sync: bool,
     create_xmp_if_missing: bool,
@@ -510,14 +536,15 @@ fn sync_xmp_for_rrdata(
     if !enable_xmp_sync {
         return;
     }
-    if let Some(source_path) = rrdata_source_path(rrdata_path) {
+    if let Some(source_path) = rrdata_source_path(rrdata_path, mirrored_root, source_root) {
         file_management::sync_metadata_to_xmp(&source_path, metadata, create_xmp_if_missing);
     }
 }
 
 #[tauri::command]
 pub fn clear_ai_tags(root_path: String, app_handle: AppHandle) -> Result<usize, String> {
-    if !Path::new(&root_path).exists() {
+    let root = Path::new(&root_path);
+    if !root.exists() {
         return Err(format!("Root path does not exist: {}", root_path));
     }
 
@@ -525,8 +552,15 @@ pub fn clear_ai_tags(root_path: String, app_handle: AppHandle) -> Result<usize, 
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
     let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
+    // Sidecars are centralized (sidecar_paths.rs) but mirror the source
+    // tree's own structure, so a bulk walk over root_path's *mirrored*
+    // sidecar directory finds exactly the same .rrdata files a walk of
+    // root_path itself used to find pre-relocation.
+    let (mirrored_root, canonical_root) =
+        crate::sidecar_paths::mirrored_root_for_source_dir(&app_handle, root)?;
+
     let mut updated_count = 0;
-    let walker = WalkDir::new(root_path).into_iter();
+    let walker = WalkDir::new(&mirrored_root).into_iter();
 
     for entry in walker.filter_map(|e| e.ok()) {
         let path = entry.path();
@@ -550,7 +584,14 @@ pub fn clear_ai_tags(root_path: String, app_handle: AppHandle) -> Result<usize, 
                     && fs::write(path, json_string).is_ok()
                 {
                     updated_count += 1;
-                    sync_xmp_for_rrdata(path, &metadata, enable_xmp_sync, create_xmp_if_missing);
+                    sync_xmp_for_rrdata(
+                        path,
+                        &mirrored_root,
+                        &canonical_root,
+                        &metadata,
+                        enable_xmp_sync,
+                        create_xmp_if_missing,
+                    );
                 }
             }
         }
@@ -560,7 +601,8 @@ pub fn clear_ai_tags(root_path: String, app_handle: AppHandle) -> Result<usize, 
 
 #[tauri::command]
 pub fn clear_all_tags(root_path: String, app_handle: AppHandle) -> Result<usize, String> {
-    if !Path::new(&root_path).exists() {
+    let root = Path::new(&root_path);
+    if !root.exists() {
         return Err(format!("Root path does not exist: {}", root_path));
     }
 
@@ -568,8 +610,11 @@ pub fn clear_all_tags(root_path: String, app_handle: AppHandle) -> Result<usize,
     let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
     let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
 
+    let (mirrored_root, canonical_root) =
+        crate::sidecar_paths::mirrored_root_for_source_dir(&app_handle, root)?;
+
     let mut updated_count = 0;
-    let walker = WalkDir::new(root_path).into_iter();
+    let walker = WalkDir::new(&mirrored_root).into_iter();
 
     for entry in walker.filter_map(|e| e.ok()) {
         let path = entry.path();
@@ -591,7 +636,14 @@ pub fn clear_all_tags(root_path: String, app_handle: AppHandle) -> Result<usize,
                     && fs::write(path, json_string).is_ok()
                 {
                     updated_count += 1;
-                    sync_xmp_for_rrdata(path, &metadata, enable_xmp_sync, create_xmp_if_missing);
+                    sync_xmp_for_rrdata(
+                        path,
+                        &mirrored_root,
+                        &canonical_root,
+                        &metadata,
+                        enable_xmp_sync,
+                        create_xmp_if_missing,
+                    );
                 }
             }
         }

--- a/src/components/adjustments/Details.tsx
+++ b/src/components/adjustments/Details.tsx
@@ -1,9 +1,13 @@
 import { useTranslation } from 'react-i18next';
+import { Grip } from 'lucide-react';
+import Button from '../ui/Button';
 import Slider from '../ui/Slider';
 import { Adjustments, DetailsAdjustment } from '../../utils/adjustments';
 import { AppSettings } from '../ui/AppProperties';
 import Text from '../ui/Text';
 import { TextVariants } from '../../types/typography';
+import { useEditorStore } from '../../store/useEditorStore';
+import { useUIStore } from '../../store/useUIStore';
 
 interface DetailsPanelProps {
   adjustments: Adjustments;
@@ -25,6 +29,26 @@ export default function DetailsPanel({
   const handleAdjustmentChange = (key: string, value: string) => {
     const numericValue = parseInt(value, 10);
     setAdjustments((prev: Partial<Adjustments>) => ({ ...prev, [key]: numericValue }));
+  };
+
+  // Opens the same modal the right-click "Denoise" context-menu entry opens
+  // (useAppContextMenus.ts) — a second, more discoverable entry point into
+  // the exact same flow, not a reimplementation of it.
+  const handleOpenAiDenoise = () => {
+    const { selectedImage } = useEditorStore.getState();
+    if (!selectedImage) return;
+    const { setUI } = useUIStore.getState();
+    setUI({
+      denoiseModalState: {
+        isOpen: true,
+        isProcessing: false,
+        previewBase64: null,
+        error: null,
+        targetPaths: [selectedImage.path],
+        progressMessage: null,
+        isRaw: selectedImage?.isRaw || false,
+      },
+    });
   };
 
   const adjustmentVisibility = appSettings?.adjustmentVisibility || {};
@@ -128,6 +152,12 @@ export default function DetailsPanel({
             value={adjustments.colorNoiseReduction}
             onDragStateChange={onDragStateChange}
           />
+          {!isForMask && (
+            <Button onClick={handleOpenAiDenoise} className="w-full mt-3">
+              <Grip size={16} />
+              {t('adjustments.details.aiDenoiseButton')}
+            </Button>
+          )}
         </div>
       )}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -95,6 +95,7 @@
       "resetPoint": "Reset {{channel}} Point Curve"
     },
     "details": {
+      "aiDenoiseButton": "AI Denoise…",
       "blueYellow": "Blue/Yellow",
       "centre": "Centré",
       "chromaticAberration": "Chromatic Aberration",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -107,7 +107,7 @@
       "redCyan": "Red/Cyan",
       "sharpening": "Sharpening",
       "sharpness": "Sharpness",
-      "structure": "Structure",
+      "structure": "Texture",
       "threshold": "Threshold"
     },
     "effects": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -107,7 +107,7 @@
       "redCyan": "Vermelho/Ciano",
       "sharpening": "Nitidez",
       "sharpness": "Nitidez",
-      "structure": "Estrutura",
+      "structure": "Textura",
       "threshold": "Limiar"
     },
     "effects": {

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -95,6 +95,7 @@
       "resetPoint": "Redefinir Curva de Pontos {{channel}}"
     },
     "details": {
+      "aiDenoiseButton": "Denoise por IA…",
       "blueYellow": "Azul/Amarelo",
       "centre": "Centro",
       "chromaticAberration": "Aberração Cromática",


### PR DESCRIPTION
## Summary

Five independent changes from day-to-day use of the app:

- **Fix Texture**: the "Structure" slider is already mapped to Lightroom's `Texture` on preset import (`preset_converter.rs`), but its blur radius (40px) was larger than Clarity's (8px) — backwards from real Texture semantics, where Texture is the fine-detail slider and Clarity is the broad one. Lowered to 2.5px so it actually behaves like Texture, and relabeled the slider (en/pt locales) to match. Internal field/JSON key name (`structure`) is unchanged for compatibility with existing sidecars and the XMP mapping.
- **Smooth AI Denoise tile blending**: `apply_seamless()` blended overlapping denoise tiles with a flat 0.5 multiplier across the whole overlap band instead of a smooth window — a visible seam-artifact risk on tile boundaries. Replaced with a raised-cosine ramp (`seam_weight`, with a unit test) that still sums to 1.0 across neighboring tiles but fades smoothly.
- **Faster thumbnails**: lowered the default thumbnail resolution (720→360, closer to actual grid tile size) and scaled the default worker-thread count with `available_parallelism()` instead of a flat 4 — both are default-value changes only, still overridable in Settings.
- **Dedicated AI Denoise panel entry**: AI Denoise was only reachable via a right-click context-menu entry. Added a button in the Details panel's Noise Reduction section that opens the exact same modal/flow.
- **Centralize `.rrdata`/`.rrexif` sidecars**: instead of littering every photo folder with a `<photo>.rrdata` file next to it, sidecars now live under a mirrored folder structure in the app's own data directory (`RapidRAW/sidecars/...`), with automatic incremental migration on folder browsing. Also adds a purely cosmetic `sidecars_by_month/<YYYY-MM>/...` view (hard links, not copies) for browsing "what did I edit this month" in Explorer/Finder. `.xmp` sidecars are untouched (still written next to the photo, unchanged interop behavior).

This last change is the most opinionated one and a real behavior change for existing users (sidecars move out of the photo folder automatically, no opt-out toggle exists yet) — happy to adjust scope, add a setting to keep the old adjacent-to-photo behavior, or split it into its own PR if preferred.

## Test plan

- [x] `cargo check` / `cargo test` clean (`seam_weight` unit test passes)
- [x] `npm run typecheck` — no new errors introduced (pre-existing unrelated errors on `main` confirmed via the same check on `main` itself)
- [x] Manually verified on Windows: sidecar migration from the old adjacent-to-photo location, from a prior centralized-but-differently-named location, thumbnail generation speed, Texture vs Clarity behavior on a real photo, Denoise panel button opens the same modal as the context-menu entry
- [ ] Not tested on macOS/Linux — the sidecar relocation's directory resolution should be portable (`app_data_dir()`-based) but hasn't been run there

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>