### PR TITLE
Add selection-aware Auto Adjust shortcut

### DIFF
--- a/src/hooks/useAppContextMenus.ts
+++ b/src/hooks/useAppContextMenus.ts
@@ -52,11 +52,10 @@ import { useProcessStore } from '../store/useProcessStore';
 import { useUIStore } from '../store/useUIStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { Invokes, Option, OPTION_SEPARATOR, Panel, AlbumItem, Album, AlbumGroup } from '../components/ui/AppProperties';
-import { Color, COLOR_LABELS, INITIAL_ADJUSTMENTS, normalizeLoadedAdjustments } from '../utils/adjustments';
+import { Color, COLOR_LABELS, INITIAL_ADJUSTMENTS } from '../utils/adjustments';
 import TaggingSubMenu from '../context/TaggingSubMenu';
 import { useEditorActions } from './useEditorActions';
 import { useLibraryActions } from './useLibraryActions';
-import { globalImageCache } from '../utils/ImageLRUCache';
 
 export interface UseAppContextMenusProps {
   handleImageSelect: (path: string) => void;
@@ -332,9 +331,8 @@ export function useAppContextMenus(props: UseAppContextMenusProps) {
       event.preventDefault();
       event.stopPropagation();
 
-      const { selectedImage, copiedAdjustments, setEditor } = useEditorStore.getState();
-      const { multiSelectedPaths, imageList, libraryActivePath, albumTree, activeAlbumId, setLibrary } =
-        useLibraryStore.getState();
+      const { selectedImage, copiedAdjustments } = useEditorStore.getState();
+      const { multiSelectedPaths, imageList, albumTree, activeAlbumId, setLibrary } = useLibraryStore.getState();
       const { appSettings } = useSettingsStore.getState();
       const { activeView, setUI, setPanel } = useUIStore.getState();
       const { setProcess } = useProcessStore.getState();
@@ -450,34 +448,6 @@ export function useAppContextMenus(props: UseAppContextMenusProps) {
         }
       };
 
-      const handleApplyAutoAdjustmentsToSelection = () => {
-        if (finalSelection.length === 0) return;
-        finalSelection.forEach((p) => globalImageCache.delete(p));
-
-        invoke(Invokes.ApplyAutoAdjustmentsToPaths, { paths: finalSelection })
-          .then(async () => {
-            if (selectedImage && finalSelection.includes(selectedImage.path)) {
-              const metadata: any = await invoke(Invokes.LoadMetadata, { path: selectedImage.path });
-              if (metadata.adjustments && !metadata.adjustments.is_null) {
-                const normalized = normalizeLoadedAdjustments(metadata.adjustments);
-                setEditor({ adjustments: normalized });
-                useEditorStore.getState().resetHistory(normalized);
-              }
-            }
-            if (libraryActivePath && finalSelection.includes(libraryActivePath)) {
-              const metadata: any = await invoke(Invokes.LoadMetadata, { path: libraryActivePath });
-              if (metadata.adjustments && !metadata.adjustments.is_null) {
-                const normalized = normalizeLoadedAdjustments(metadata.adjustments);
-                setLibrary({ libraryActiveAdjustments: normalized });
-              }
-            }
-          })
-          .catch((err) => {
-            console.error('Failed to apply auto adjustments to paths:', err);
-            toast.error(t('contextMenus.toasts.failedApplyAuto', { err }));
-          });
-      };
-
       const onExportClick = () => {
         setLibrary({ multiSelectedPaths: finalSelection });
         if (activeView === 'editor' && selectedImage && selectedImage.path !== path) {
@@ -556,7 +526,7 @@ export function useAppContextMenus(props: UseAppContextMenusProps) {
           label: t('contextMenus.editor.productivity'),
           icon: Gauge,
           submenu: [
-            { label: autoAdjustLabel, icon: Aperture, onClick: handleApplyAutoAdjustmentsToSelection },
+            { label: autoAdjustLabel, icon: Aperture, onClick: () => handleAutoAdjustments(finalSelection) },
             {
               label: denoiseLabel,
               icon: Grip,

--- a/src/hooks/useEditorActions.ts
+++ b/src/hooks/useEditorActions.ts
@@ -2,10 +2,12 @@ import { useCallback } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import debounce from 'lodash.debounce';
 import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
 import { useEditorStore } from '../store/useEditorStore';
 import { useLibraryStore } from '../store/useLibraryStore';
 import { useSettingsStore } from '../store/useSettingsStore';
 import { useProcessStore } from '../store/useProcessStore';
+import { useUIStore } from '../store/useUIStore';
 import {
   Adjustments,
   INITIAL_ADJUSTMENTS,
@@ -17,6 +19,11 @@ import {
 import { calculateCenteredCrop } from '../utils/cropUtils';
 import { Invokes } from '../components/ui/AppProperties';
 import { globalImageCache } from '../utils/ImageLRUCache';
+import {
+  countEditedAutoAdjustTargets,
+  resolveAutoAdjustTargets,
+  shouldConfirmAutoAdjust,
+} from '../utils/autoAdjustments';
 
 export const debouncedSetHistory = debounce((newAdj: Adjustments) => {
   useEditorStore.getState().pushHistory(newAdj);
@@ -30,6 +37,7 @@ export const debouncedSave = debounce((path: string, adjustmentsToSave: Adjustme
 }, 300);
 
 export function useEditorActions() {
+  const { t } = useTranslation();
   const setEditor = useEditorStore((s) => s.setEditor);
 
   const setAdjustments = useCallback(
@@ -67,20 +75,86 @@ export function useEditorActions() {
     [setAdjustments],
   );
 
-  const handleAutoAdjustments = useCallback(async () => {
-    const selectedImage = useEditorStore.getState().selectedImage;
-    if (!selectedImage?.isReady) return;
-    try {
-      const autoAdjustments: Adjustments = await invoke(Invokes.CalculateAutoAdjustments);
-      setAdjustments((prev: Adjustments) => ({
-        ...prev,
-        ...autoAdjustments,
-        sectionVisibility: { ...prev.sectionVisibility, ...autoAdjustments.sectionVisibility },
-      }));
-    } catch (err) {
-      toast.error(`Failed to apply auto adjustments: ${err}`);
-    }
-  }, [setAdjustments]);
+  const applyAutoAdjustments = useCallback(
+    async (paths: string[]) => {
+      if (paths.length === 0) return;
+
+      const { selectedImage } = useEditorStore.getState();
+      const currentEditorPath = selectedImage?.isReady ? selectedImage.path : null;
+      const batchPaths = currentEditorPath ? paths.filter((path) => path !== currentEditorPath) : paths;
+
+      paths.forEach((path) => globalImageCache.delete(path));
+
+      try {
+        const tasks: Promise<unknown>[] = [];
+
+        if (currentEditorPath && paths.includes(currentEditorPath)) {
+          tasks.push(
+            invoke<Adjustments>(Invokes.CalculateAutoAdjustments).then((autoAdjustments) => {
+              setAdjustments((prev: Adjustments) => ({
+                ...prev,
+                ...autoAdjustments,
+                sectionVisibility: { ...prev.sectionVisibility, ...autoAdjustments.sectionVisibility },
+              }));
+            }),
+          );
+        }
+
+        if (batchPaths.length > 0) {
+          tasks.push(invoke(Invokes.ApplyAutoAdjustmentsToPaths, { paths: batchPaths }));
+        }
+
+        await Promise.all(tasks);
+      } catch (err) {
+        toast.error(t('contextMenus.toasts.failedApplyAuto', { err }));
+      }
+    },
+    [setAdjustments, t],
+  );
+
+  const handleAutoAdjustments = useCallback(
+    (pathsOrEvent?: string[] | unknown) => {
+      const { selectedImage } = useEditorStore.getState();
+      const { imageList, libraryActivePath, multiSelectedPaths } = useLibraryStore.getState();
+      const { activeView, setUI } = useUIStore.getState();
+      const explicitPaths = Array.isArray(pathsOrEvent) ? pathsOrEvent : undefined;
+      const paths = resolveAutoAdjustTargets({
+        activeView,
+        explicitPaths,
+        libraryActivePath,
+        multiSelectedPaths,
+        selectedImagePath: selectedImage?.path ?? null,
+      });
+
+      if (paths.length === 0) return;
+
+      const editedTargetCount = countEditedAutoAdjustTargets(paths, imageList, selectedImage);
+
+      if (shouldConfirmAutoAdjust(paths.length, editedTargetCount)) {
+        setUI({
+          confirmModalState: {
+            confirmText: t('contextMenus.thumbnail.confirmAutoAdjustButton', { photoCount: paths.length }),
+            isOpen: true,
+            message:
+              editedTargetCount > 0
+                ? t('contextMenus.thumbnail.confirmAutoAdjustEditedMessage', {
+                    photoCount: paths.length,
+                    editedCount: editedTargetCount,
+                  })
+                : t('contextMenus.thumbnail.confirmAutoAdjustMessage', { photoCount: paths.length }),
+            onConfirm: () => {
+              void applyAutoAdjustments(paths);
+            },
+            title: t('contextMenus.thumbnail.confirmAutoAdjustTitle'),
+          },
+        });
+        return;
+      }
+
+      void applyAutoAdjustments(paths);
+    },
+    [applyAutoAdjustments, t],
+  );
 
   const handleLutSelect = useCallback(
     async (path: string, isBuiltIn: boolean = false) => {

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -31,7 +31,7 @@ export const useKeyboardShortcuts = ({
   handleToggleFullScreen,
   handleZoomChange,
 }: KeyboardShortcutsProps) => {
-  const { handleRotate, handleCopyAdjustments, handlePasteAdjustments } = useEditorActions();
+  const { handleRotate, handleAutoAdjustments, handleCopyAdjustments, handlePasteAdjustments } = useEditorActions();
   const { handleRate, handleSetColorLabel } = useLibraryActions();
 
   const sortedListRef = useRef(sortedImageList);
@@ -291,6 +291,14 @@ export const useKeyboardShortcuts = ({
         execute: (e: any, s: any) => {
           e.preventDefault();
           s.editor.redo();
+        },
+      },
+      apply_auto_adjustments: {
+        shouldFire: (s: any) =>
+          !!s.editor.selectedImage || s.library.multiSelectedPaths.length > 0 || s.library.libraryActivePath !== null,
+        execute: (e: any) => {
+          e.preventDefault();
+          handleAutoAdjustments();
         },
       },
       toggle_fullscreen: {
@@ -679,6 +687,7 @@ export const useKeyboardShortcuts = ({
     handleToggleFullScreen,
     handleZoomChange,
     handleRotate,
+    handleAutoAdjustments,
     handleCopyAdjustments,
     handleCopyImagePaths,
     handlePasteAdjustments,

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -237,6 +237,10 @@
       "shortcutsHeading": "DRECERES"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Ajusta automàticament {{photoCount}} fotos",
+      "confirmAutoAdjustEditedMessage": "Voleu aplicar ajustaments automàtics a {{photoCount}} fotos seleccionades? {{editedCount}} ja contenen edicions. Se'n substituiran els ajustaments tonals globals; les màscares i els retalls es conservaran.",
+      "confirmAutoAdjustMessage": "Voleu aplicar ajustaments automàtics a {{photoCount}} fotos seleccionades?",
+      "confirmAutoAdjustTitle": "Ajusta automàticament la selecció",
       "addToAlbum": "Afegir a l'àlbum",
       "autoAdjust_one": "Ajustament automàtic de la imatge",
       "autoAdjust_other": "Ajustament automàtic de les imatges",
@@ -1521,6 +1525,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Aplica ajustaments automàtics",
         "brush_size_down": "Reduir mida del pinzell",
         "brush_size_up": "Augmentar mida del pinzell",
         "color_label_blue": "Etiqueta de color: Blau",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -237,6 +237,10 @@
       "shortcutsHeading": "TASTENKÜRZEL"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "{{photoCount}} Fotos automatisch anpassen",
+      "confirmAutoAdjustEditedMessage": "Automatische Anpassungen auf {{photoCount}} ausgewählte Fotos anwenden? {{editedCount}} davon enthalten bereits Bearbeitungen. Ihre globalen Tonwertanpassungen werden ersetzt; Masken und Zuschnitte bleiben erhalten.",
+      "confirmAutoAdjustMessage": "Automatische Anpassungen auf {{photoCount}} ausgewählte Fotos anwenden?",
+      "confirmAutoAdjustTitle": "Auswahl automatisch anpassen",
       "addToAlbum": "Zu Album hinzufügen",
       "autoAdjust_one": "Bild autom. anpassen",
       "autoAdjust_other": "Bilder autom. anpassen",
@@ -1521,6 +1525,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Automatische Anpassungen anwenden",
         "brush_size_down": "Pinselgröße verringern",
         "brush_size_up": "Pinselgröße erhöhen",
         "color_label_blue": "Farbmarkierung: Blau",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -242,6 +242,10 @@
       "autoAdjust_other": "Auto Adjust Images",
       "collage_one": "Frame Image",
       "collage_other": "Create Collage",
+      "confirmAutoAdjustButton": "Auto Adjust {{photoCount}} Photos",
+      "confirmAutoAdjustEditedMessage": "Apply Auto Adjust to {{photoCount}} selected photos? {{editedCount}} already contain edits. Their global tone adjustments will be replaced; masks and crops will be preserved.",
+      "confirmAutoAdjustMessage": "Apply Auto Adjust to {{photoCount}} selected photos?",
+      "confirmAutoAdjustTitle": "Auto Adjust Selection",
       "confirmDelete": "Confirm Delete",
       "confirmDeleteVc": "Confirm Delete + Virtual Copies",
       "convertNegative_one": "Convert Negative",
@@ -1521,6 +1525,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Apply auto adjustments",
         "brush_size_down": "Decrease brush size",
         "brush_size_up": "Increase brush size",
         "color_label_blue": "Color label: Blue",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -241,6 +241,10 @@
       "shortcutsHeading": "ATAJOS"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Ajustar automáticamente {{photoCount}} fotos",
+      "confirmAutoAdjustEditedMessage": "¿Aplicar ajustes automáticos a {{photoCount}} fotos seleccionadas? {{editedCount}} ya contienen ediciones. Sus ajustes tonales globales se reemplazarán; las máscaras y los recortes se conservarán.",
+      "confirmAutoAdjustMessage": "¿Aplicar ajustes automáticos a {{photoCount}} fotos seleccionadas?",
+      "confirmAutoAdjustTitle": "Ajustar selección automáticamente",
       "addToAlbum": "Agregar al álbum",
       "autoAdjust_many": "Ajuste automático de imágenes",
       "autoAdjust_one": "Ajuste automático de imagen",
@@ -1554,6 +1558,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Aplicar ajustes automáticos",
         "brush_size_down": "Reducir tamaño del pincel",
         "brush_size_up": "Aumentar tamaño del pincel",
         "color_label_blue": "Etiqueta de color: Azul",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -241,6 +241,10 @@
       "shortcutsHeading": "RACCOURCIS"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Ajuster automatiquement {{photoCount}} photos",
+      "confirmAutoAdjustEditedMessage": "Appliquer les réglages automatiques aux {{photoCount}} photos sélectionnées ? {{editedCount}} contiennent déjà des modifications. Leurs réglages tonaux globaux seront remplacés ; les masques et recadrages seront conservés.",
+      "confirmAutoAdjustMessage": "Appliquer les réglages automatiques aux {{photoCount}} photos sélectionnées ?",
+      "confirmAutoAdjustTitle": "Ajuster automatiquement la sélection",
       "addToAlbum": "Ajouter à l'album",
       "autoAdjust_many": "Ajustement auto des images",
       "autoAdjust_one": "Ajustement auto de l'image",
@@ -1554,6 +1558,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Appliquer les réglages automatiques",
         "brush_size_down": "Diminuer la taille du pinceau",
         "brush_size_up": "Augmenter la taille du pinceau",
         "color_label_blue": "Étiquette de couleur : Bleu",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -241,6 +241,10 @@
       "shortcutsHeading": "SCORCIATOIE"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Regola automaticamente {{photoCount}} foto",
+      "confirmAutoAdjustEditedMessage": "Applicare le regolazioni automatiche a {{photoCount}} foto selezionate? {{editedCount}} contengono già modifiche. Le regolazioni tonali globali verranno sostituite; maschere e ritagli verranno mantenuti.",
+      "confirmAutoAdjustMessage": "Applicare le regolazioni automatiche a {{photoCount}} foto selezionate?",
+      "confirmAutoAdjustTitle": "Regola automaticamente la selezione",
       "addToAlbum": "Aggiungi all'Album",
       "autoAdjust_many": "Regolazione Automatica Immagini",
       "autoAdjust_one": "Regolazione Automatica Immagine",
@@ -1554,6 +1558,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Applica regolazioni automatiche",
         "brush_size_down": "Riduci dimensione pennello",
         "brush_size_up": "Aumenta dimensione pennello",
         "color_label_blue": "Etichetta colore: Blu",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -237,6 +237,10 @@
       "shortcutsHeading": "ショートカット"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "{{photoCount}}枚の写真を自動補正",
+      "confirmAutoAdjustEditedMessage": "選択した{{photoCount}}枚の写真に自動補正を適用しますか？そのうち{{editedCount}}枚には既に編集があります。全体の階調補正は置き換えられますが、マスクと切り抜きは保持されます。",
+      "confirmAutoAdjustMessage": "選択した{{photoCount}}枚の写真に自動補正を適用しますか？",
+      "confirmAutoAdjustTitle": "選択範囲を自動補正",
       "addToAlbum": "アルバムに追加",
       "autoAdjust_one": "画像を自動補正",
       "autoAdjust_other": "画像を自動補正",
@@ -1519,6 +1523,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "自動補正を適用",
         "brush_size_down": "ブラシサイズを縮小",
         "brush_size_up": "ブラシサイズを拡大",
         "color_label_blue": "カラーラベル: ブルー",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -237,6 +237,10 @@
       "shortcutsHeading": "단축키"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "사진 {{photoCount}}장 자동 조정",
+      "confirmAutoAdjustEditedMessage": "선택한 사진 {{photoCount}}장에 자동 조정을 적용할까요? 이 중 {{editedCount}}장은 이미 편집되어 있습니다. 전역 톤 조정은 대체되며 마스크와 자르기는 유지됩니다.",
+      "confirmAutoAdjustMessage": "선택한 사진 {{photoCount}}장에 자동 조정을 적용할까요?",
+      "confirmAutoAdjustTitle": "선택 항목 자동 조정",
       "addToAlbum": "앨범에 추가",
       "autoAdjust_one": "이미지 자동 조정",
       "autoAdjust_other": "이미지 자동 조정",
@@ -1519,6 +1523,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "자동 조정 적용",
         "brush_size_down": "브러시 크기 줄이기",
         "brush_size_up": "브러시 크기 늘리기",
         "color_label_blue": "색상 레이블: 파랑",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -245,6 +245,10 @@
       "shortcutsHeading": "SKRÓTY"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Dostosuj automatycznie {{photoCount}} zdjęć",
+      "confirmAutoAdjustEditedMessage": "Zastosować automatyczne korekty do {{photoCount}} wybranych zdjęć? {{editedCount}} z nich zawiera już edycje. Globalne korekty tonalne zostaną zastąpione; maski i kadrowanie zostaną zachowane.",
+      "confirmAutoAdjustMessage": "Zastosować automatyczne korekty do {{photoCount}} wybranych zdjęć?",
+      "confirmAutoAdjustTitle": "Automatycznie dostosuj zaznaczenie",
       "addToAlbum": "Dodaj do albumu",
       "autoAdjust_few": "Auto-korekta obrazów",
       "autoAdjust_many": "Auto-korekta obrazów",
@@ -1589,6 +1593,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Zastosuj automatyczne korekty",
         "brush_size_down": "Zmniejsz rozmiar pędzla",
         "brush_size_up": "Zwiększ rozmiar pędzla",
         "color_label_blue": "Etykieta koloru: Niebieski",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -241,6 +241,10 @@
       "shortcutsHeading": "ATALHOS"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Ajustar automaticamente {{photoCount}} fotos",
+      "confirmAutoAdjustEditedMessage": "Aplicar ajustes automáticos a {{photoCount}} fotos selecionadas? {{editedCount}} já contêm edições. Os ajustes tonais globais serão substituídos; máscaras e cortes serão preservados.",
+      "confirmAutoAdjustMessage": "Aplicar ajustes automáticos a {{photoCount}} fotos selecionadas?",
+      "confirmAutoAdjustTitle": "Ajustar seleção automaticamente",
       "addToAlbum": "Adicionar ao Álbum",
       "autoAdjust_many": "Ajustar Imagens Automaticamente",
       "autoAdjust_one": "Ajustar Imagem Automaticamente",
@@ -1555,6 +1559,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Aplicar ajustes automáticos",
         "brush_size_down": "Diminuir tamanho do pincel",
         "brush_size_up": "Aumentar tamanho do pincel",
         "color_label_blue": "Rótulo de cor: Azul",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -245,6 +245,10 @@
       "shortcutsHeading": "БЫСТРЫЕ КЛАВИШИ"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "Автоматически скорректировать {{photoCount}} фото",
+      "confirmAutoAdjustEditedMessage": "Применить автоматические корректировки к {{photoCount}} выбранным фотографиям? {{editedCount}} из них уже содержат правки. Их глобальные тоновые корректировки будут заменены; маски и кадрирование сохранятся.",
+      "confirmAutoAdjustMessage": "Применить автоматические корректировки к {{photoCount}} выбранным фотографиям?",
+      "confirmAutoAdjustTitle": "Автоматически скорректировать выбранное",
       "addToAlbum": "Добавить в альбом",
       "autoAdjust_few": "Автонастройка изображений",
       "autoAdjust_many": "Автонастройка изображений",
@@ -1589,6 +1593,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "Применить автоматические корректировки",
         "brush_size_down": "Уменьшить размер кисти",
         "brush_size_up": "Увеличить размер кисти",
         "color_label_blue": "Цветовая метка: Синий",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -237,6 +237,10 @@
       "shortcutsHeading": "快捷方式"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "自动调整 {{photoCount}} 张照片",
+      "confirmAutoAdjustEditedMessage": "要对选中的 {{photoCount}} 张照片应用自动调整吗？其中 {{editedCount}} 张已有编辑。它们的全局色调调整将被替换；蒙版和裁剪会保留。",
+      "confirmAutoAdjustMessage": "要对选中的 {{photoCount}} 张照片应用自动调整吗？",
+      "confirmAutoAdjustTitle": "自动调整所选照片",
       "addToAlbum": "添加到相册",
       "autoAdjust_one": "自动调整图像",
       "autoAdjust_other": "自动调整图像",
@@ -1519,6 +1523,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "应用自动调整",
         "brush_size_down": "减小画笔大小",
         "brush_size_up": "增大画笔大小",
         "color_label_blue": "颜色标签：蓝色",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -237,6 +237,10 @@
       "shortcutsHeading": "快捷方式"
     },
     "thumbnail": {
+      "confirmAutoAdjustButton": "自動調整 {{photoCount}} 張照片",
+      "confirmAutoAdjustEditedMessage": "要對選取的 {{photoCount}} 張照片套用自動調整嗎？其中 {{editedCount}} 張已有編輯。它們的全域色調調整將被取代；遮色片和裁切會保留。",
+      "confirmAutoAdjustMessage": "要對選取的 {{photoCount}} 張照片套用自動調整嗎？",
+      "confirmAutoAdjustTitle": "自動調整所選照片",
       "addToAlbum": "新增到相簿",
       "autoAdjust_one": "自動調整影像",
       "autoAdjust_other": "自動調整影像",
@@ -1519,6 +1523,7 @@
     },
     "keybinds": {
       "actions": {
+        "apply_auto_adjustments": "套用自動調整",
         "brush_size_down": "減小畫筆大小",
         "brush_size_up": "增大畫筆大小",
         "color_label_blue": "顏色標籤：藍色",

--- a/src/utils/autoAdjustments.ts
+++ b/src/utils/autoAdjustments.ts
@@ -1,0 +1,50 @@
+export const AUTO_ADJUST_CONFIRMATION_THRESHOLD = 10;
+
+interface EditedImageReference {
+  is_edited?: boolean;
+  path: string;
+}
+
+interface AutoAdjustTargetContext {
+  activeView: string;
+  explicitPaths?: string[];
+  libraryActivePath: string | null;
+  multiSelectedPaths: string[];
+  selectedImagePath: string | null;
+}
+
+export const resolveAutoAdjustTargets = ({
+  activeView,
+  explicitPaths,
+  libraryActivePath,
+  multiSelectedPaths,
+  selectedImagePath,
+}: AutoAdjustTargetContext): string[] => {
+  const unique = (paths: string[]) => [...new Set(paths.filter(Boolean))];
+
+  if (explicitPaths?.length) return unique(explicitPaths);
+
+  if (activeView === 'editor') {
+    if (!selectedImagePath) return [];
+    if (multiSelectedPaths.length > 1 && multiSelectedPaths.includes(selectedImagePath)) {
+      return unique(multiSelectedPaths);
+    }
+    return [selectedImagePath];
+  }
+
+  if (multiSelectedPaths.length > 0) return unique(multiSelectedPaths);
+  return libraryActivePath ? [libraryActivePath] : [];
+};
+
+export const countEditedAutoAdjustTargets = (
+  paths: string[],
+  imageList: EditedImageReference[],
+  selectedImage?: EditedImageReference | null,
+): number => {
+  const editedPaths = new Set(imageList.filter((image) => image.is_edited).map((image) => image.path));
+  if (selectedImage?.is_edited) editedPaths.add(selectedImage.path);
+  return paths.filter((path) => editedPaths.has(path)).length;
+};
+
+export const shouldConfirmAutoAdjust = (targetCount: number, editedTargetCount: number): boolean =>
+  targetCount >= AUTO_ADJUST_CONFIRMATION_THRESHOLD || (targetCount > 1 && editedTargetCount > 0);

--- a/src/utils/keyboardUtils.ts
+++ b/src/utils/keyboardUtils.ts
@@ -256,6 +256,12 @@ export const KEYBIND_DEFINITIONS: KeybindDefinition[] = [
   { action: 'undo', description: 'settings.keybinds.actions.undo', defaultCombo: ['ctrl', 'KeyZ'], section: 'editing' },
   { action: 'redo', description: 'settings.keybinds.actions.redo', defaultCombo: ['ctrl', 'KeyY'], section: 'editing' },
   {
+    action: 'apply_auto_adjustments',
+    description: 'settings.keybinds.actions.apply_auto_adjustments',
+    defaultCombo: ['ctrl', 'KeyU'],
+    section: 'editing',
+  },
+  {
     action: 'copy_adjustments',
     description: 'settings.keybinds.actions.copy_adjustments',
     defaultCombo: ['ctrl', 'KeyC'],


### PR DESCRIPTION
## Description

Adds a canonical, selection-aware Auto Adjust action with a configurable Cmd/Ctrl+U shortcut. The toolbar button, thumbnail context menu, and keyboard shortcut now share the same action path.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Adds the `apply_auto_adjustments` keybind, defaulting to Cmd/Ctrl+U.
- Applies Auto Adjust to the current photo or the active multi-selection.
- Uses the loaded editor command for the ready current photo and the batch backend for remaining targets.
- Requests confirmation for selections of 10 or more photos, or multi-selections containing existing edits.
- Reuses the canonical action from the toolbar, context menu, and keyboard shortcut.
- Adds localized labels and confirmation copy for all 13 supported locales.
- Adds pure helpers for target resolution and confirmation decisions.

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS
- **Checks:** `npm run build`, focused helper assertions, locale-key coverage, Prettier, and `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The repository-wide TypeScript and i18n validation commands still report pre-existing baseline failures unrelated to this change. This branch is independent from the Settings search PR.

## AI Disclaimer

- [x] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
