### PR TITLE
Add searchable settings panel

### DIFF
--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ArrowLeft,
   Cloud,
@@ -17,6 +17,7 @@ import {
   Scaling,
   Image as ImageIcon,
   Mouse,
+  Search,
   Touchpad,
 } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
@@ -47,6 +48,9 @@ import { useOsPlatform } from '../../hooks/useOsPlatform';
 import { open } from '@tauri-apps/plugin-shell';
 import { RotateCcw } from 'lucide-react';
 import { useUIStore } from '../../store/useUIStore';
+import { filterSettingsSearchItems, SettingsSearchItem } from '../../utils/settingsSearch';
+
+type SettingsCategoryId = 'general' | 'processing' | 'shortcuts';
 
 interface ConfirmModalState {
   confirmText: string;
@@ -137,6 +141,250 @@ const zoomMultiplierOptions: OptionItem<number>[] = [
   { value: 0.25, label: '0.25x' },
 ];
 
+interface SettingsSearchDefinition {
+  category: SettingsCategoryId;
+  descriptionKey?: string;
+  keywords?: string[];
+  labelKey: string;
+  targetLabelKey?: string;
+}
+
+const SETTINGS_SEARCH_DEFINITIONS: SettingsSearchDefinition[] = [
+  { category: 'general', labelKey: 'settings.general.theme', descriptionKey: 'settings.general.themeDesc' },
+  { category: 'general', labelKey: 'settings.language', descriptionKey: 'settings.languageDesc' },
+  { category: 'general', labelKey: 'settings.general.xmpSync', descriptionKey: 'settings.general.xmpSyncDesc' },
+  {
+    category: 'general',
+    labelKey: 'settings.general.createXmp',
+    descriptionKey: 'settings.general.createXmpDesc',
+    targetLabelKey: 'settings.general.xmpSync',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.general.folderImageCounts',
+    descriptionKey: 'settings.general.folderImageCountsDesc',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.general.displayEditIcon',
+    descriptionKey: 'settings.general.displayEditIconDesc',
+  },
+  { category: 'general', labelKey: 'settings.general.focusMode', descriptionKey: 'settings.general.focusModeDesc' },
+  { category: 'general', labelKey: 'settings.general.font', descriptionKey: 'settings.general.fontDesc' },
+  {
+    category: 'general',
+    labelKey: 'settings.general.nativeTitlebar',
+    descriptionKey: 'settings.general.nativeTitlebarDesc',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.adjustments.title',
+    descriptionKey: 'settings.adjustments.description',
+    keywords: ['panels', 'visibility'],
+  },
+  ...[
+    'settings.adjustments.chromaticAberration',
+    'settings.adjustments.colorCalibration',
+    'settings.adjustments.grain',
+    'settings.adjustments.noiseReduction',
+  ].map((labelKey) => ({
+    category: 'general' as const,
+    labelKey,
+    targetLabelKey: 'settings.adjustments.title',
+  })),
+  {
+    category: 'general',
+    labelKey: 'settings.lenses.title',
+    descriptionKey: 'settings.lenses.description',
+    keywords: ['manufacturer', 'model'],
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.tagging.aiTagging',
+    descriptionKey: 'settings.tagging.aiTaggingDesc',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.tagging.maxAiTags',
+    descriptionKey: 'settings.tagging.maxAiTagsDesc',
+    targetLabelKey: 'settings.tagging.aiTagging',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.tagging.customList',
+    descriptionKey: 'settings.tagging.customListDesc',
+    targetLabelKey: 'settings.tagging.aiTagging',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.tagging.shortcuts',
+    descriptionKey: 'settings.tagging.shortcutsDesc',
+  },
+  { category: 'general', labelKey: 'settings.data.clearSidecars', descriptionKey: 'settings.data.clearSidecarsDesc' },
+  {
+    category: 'general',
+    labelKey: 'settings.data.resetLayoutTitle',
+    descriptionKey: 'settings.data.resetLayoutDesc',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.data.clearThumbnail',
+    descriptionKey: 'settings.data.clearThumbnailDesc',
+  },
+  { category: 'general', labelKey: 'settings.data.logs', descriptionKey: 'settings.data.logsDesc' },
+  {
+    category: 'general',
+    labelKey: 'settings.tagging.clearAiTagsTitle',
+    descriptionKey: 'settings.tagging.clearAiTagsDesc',
+  },
+  {
+    category: 'general',
+    labelKey: 'settings.tagging.clearAllTagsTitle',
+    descriptionKey: 'settings.tagging.clearAllTagsDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.previewStrategy',
+    descriptionKey: 'settings.processing.dynamicDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.previewRes',
+    descriptionKey: 'settings.processing.previewResDesc',
+    targetLabelKey: 'settings.processing.previewStrategy',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.staticPreviewRes',
+    descriptionKey: 'settings.processing.staticPreviewResDesc',
+    targetLabelKey: 'settings.processing.previewStrategy',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.renderScale',
+    descriptionKey: 'settings.processing.renderScaleDesc',
+    targetLabelKey: 'settings.processing.previewStrategy',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.highDpi',
+    descriptionKey: 'settings.processing.highDpiDesc',
+    targetLabelKey: 'settings.processing.previewStrategy',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.livePreviews',
+    descriptionKey: 'settings.processing.livePreviewsDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.livePreviewQuality',
+    descriptionKey: 'settings.processing.livePreviewQualityDesc',
+    targetLabelKey: 'settings.processing.livePreviews',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.thumbnailRes',
+    descriptionKey: 'settings.processing.thumbnailResDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.alwaysDecodeRaw',
+    descriptionKey: 'settings.processing.alwaysDecodeRawDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.workerThreads',
+    descriptionKey: 'settings.processing.workerThreadsDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.imageCache',
+    descriptionKey: 'settings.processing.imageCacheDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.wgpu',
+    descriptionKey: 'settings.processing.wgpuDescRecommended',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.backend',
+    descriptionKey: 'settings.processing.backendDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.linuxCompat',
+    descriptionKey: 'settings.processing.linuxCompatDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.highlightRecovery',
+    descriptionKey: 'settings.processing.preprocessing.highlightRecoveryDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.colorNr',
+    descriptionKey: 'settings.processing.preprocessing.colorNrDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.sharpening',
+    descriptionKey: 'settings.processing.preprocessing.sharpeningDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.applyPreprocessing',
+    descriptionKey: 'settings.processing.preprocessing.applyPreprocessingDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.linearRaw',
+    descriptionKey: 'settings.processing.preprocessing.linearRawDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.tonemapperOverride',
+    descriptionKey: 'settings.processing.preprocessing.tonemapperOverrideDesc',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.defaultRawTonemapper',
+    descriptionKey: 'settings.processing.preprocessing.defaultRawTonemapperDesc',
+    targetLabelKey: 'settings.processing.preprocessing.tonemapperOverride',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.preprocessing.defaultNonRawTonemapper',
+    descriptionKey: 'settings.processing.preprocessing.defaultNonRawTonemapperDesc',
+    targetLabelKey: 'settings.processing.preprocessing.tonemapperOverride',
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.ai.title',
+    descriptionKey: 'settings.processing.ai.description',
+    keywords: ['artificial intelligence', 'provider'],
+  },
+  {
+    category: 'processing',
+    labelKey: 'settings.processing.ai.connector.address',
+    descriptionKey: 'settings.processing.ai.connector.addressDesc',
+    targetLabelKey: 'settings.processing.ai.title',
+  },
+  {
+    category: 'shortcuts',
+    labelKey: 'settings.controls.optimization',
+    descriptionKey: 'settings.controls.optimizationDesc',
+    keywords: ['mouse', 'trackpad'],
+  },
+  { category: 'shortcuts', labelKey: 'settings.controls.zoom', descriptionKey: 'settings.controls.zoomDesc' },
+  {
+    category: 'shortcuts',
+    labelKey: 'settings.controls.keyboardTitle',
+    targetLabelKey: 'settings.controls.keyboardTitle',
+  },
+];
+
 const KeybindRow = ({
   def,
   currentCombo,
@@ -171,7 +419,7 @@ const KeybindRow = ({
   const displayCombo = currentCombo !== undefined ? (currentCombo.length ? currentCombo : null) : def.defaultCombo;
 
   return (
-    <div className="flex justify-between items-center py-2">
+    <div className="flex justify-between items-center py-2" data-settings-search-text={t(def.description as any)}>
       <Text variant={TextVariants.label}>{t(def.description as any)}</Text>
       <div className="flex items-center gap-1">
         {isConflicting && <span className="text-yellow-400 text-xs">⚠</span>}
@@ -208,7 +456,7 @@ const KeybindRow = ({
 };
 
 const SettingItem = ({ children, description, label }: SettingItemProps) => (
-  <div>
+  <div data-settings-search-text={`${label} ${description || ''}`}>
     <Text variant={TextVariants.heading} className="block mb-2">
       {label}
     </Text>
@@ -234,7 +482,10 @@ const DataActionItem = ({
   const { t } = useTranslation();
 
   return (
-    <div className="pb-8 border-b border-border-color last:border-b-0 last:pb-0">
+    <div
+      className="pb-8 border-b border-border-color last:border-b-0 last:pb-0"
+      data-settings-search-text={`${title} ${typeof description === 'string' ? description : ''}`}
+    >
       <Text variant={TextVariants.heading} className="mb-2">
         {title}
       </Text>
@@ -551,13 +802,17 @@ export default function SettingsPanel({
     applyPreprocessingToNonRaws: appSettings?.applyPreprocessingToNonRaws ?? false,
   });
   const [restartRequired, setRestartRequired] = useState(false);
-  const [activeCategory, setActiveCategory] = useState('general');
+  const [activeCategory, setActiveCategory] = useState<SettingsCategoryId>('general');
+  const [settingsSearchQuery, setSettingsSearchQuery] = useState('');
+  const [pendingSearchTarget, setPendingSearchTarget] = useState<string | null>(null);
   const [logPath, setLogPath] = useState<string | null>(null);
   const [logPathLoading, setLogPathLoading] = useState(true);
   const [logPathError, setLogPathError] = useState(false);
   const [dpr, setDpr] = useState(() => (typeof window !== 'undefined' ? window.devicePixelRatio : 1));
+  const settingsSearchInputRef = useRef<HTMLInputElement>(null);
+  const settingsContentRef = useRef<HTMLDivElement>(null);
 
-  const settingCategories = useMemo(
+  const settingCategories = useMemo<{ id: SettingsCategoryId; label: string; icon: typeof Cpu }[]>(
     () => [
       { id: 'general', label: t('settings.categories.general'), icon: SlidersHorizontal },
       { id: 'processing', label: t('settings.categories.processing'), icon: Cpu },
@@ -565,6 +820,78 @@ export default function SettingsPanel({
     ],
     [t],
   );
+
+  const settingsSearchItems = useMemo<(SettingsSearchItem<SettingsCategoryId> & { targetText: string })[]>(() => {
+    const categoryLabels: Record<SettingsCategoryId, string> = {
+      general: t('settings.categories.general'),
+      processing: t('settings.categories.processing'),
+      shortcuts: t('settings.categories.shortcuts'),
+    };
+
+    const settingItems = SETTINGS_SEARCH_DEFINITIONS.map((definition) => ({
+      category: definition.category,
+      categoryLabel: categoryLabels[definition.category],
+      description: definition.descriptionKey ? t(definition.descriptionKey as never) : undefined,
+      keywords: definition.keywords,
+      label: t(definition.labelKey as never),
+      targetText: t((definition.targetLabelKey || definition.labelKey) as never),
+    }));
+
+    const keybindItems = KEYBIND_DEFINITIONS.map((definition) => {
+      const section = KEYBIND_SECTIONS.find((item) => item.id === definition.section);
+      return {
+        category: 'shortcuts' as const,
+        categoryLabel: categoryLabels.shortcuts,
+        description: section ? t(section.label as never) : t('settings.controls.keyboardTitle'),
+        keywords: [definition.action.replaceAll('_', ' ')],
+        label: t(definition.description as never),
+        targetText: t(definition.description as never),
+      };
+    });
+
+    return [...settingItems, ...keybindItems];
+  }, [t]);
+
+  const filteredSettingsSearchItems = useMemo(
+    () => filterSettingsSearchItems(settingsSearchItems, settingsSearchQuery),
+    [settingsSearchItems, settingsSearchQuery],
+  );
+
+  useEffect(() => {
+    const handleSettingsSearchShortcut = (event: KeyboardEvent) => {
+      if (recordingAction) return;
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === 'f') {
+        event.preventDefault();
+        settingsSearchInputRef.current?.focus();
+        settingsSearchInputRef.current?.select();
+      }
+    };
+
+    window.addEventListener('keydown', handleSettingsSearchShortcut);
+    return () => window.removeEventListener('keydown', handleSettingsSearchShortcut);
+  }, [recordingAction]);
+
+  useEffect(() => {
+    if (!pendingSearchTarget) return;
+
+    const timer = window.setTimeout(() => {
+      const target = Array.from(
+        settingsContentRef.current?.querySelectorAll<HTMLElement>('[data-settings-search-text]') || [],
+      ).find((element) => element.dataset.settingsSearchText?.includes(pendingSearchTarget));
+
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        target.dataset.settingsSearchHighlight = 'true';
+        window.setTimeout(() => {
+          delete target.dataset.settingsSearchHighlight;
+        }, 1800);
+      }
+
+      setPendingSearchTarget(null);
+    }, 250);
+
+    return () => window.clearTimeout(timer);
+  }, [activeCategory, pendingSearchTarget]);
 
   const livePreviewQualityOptions = useMemo<OptionItem<string>[]>(
     () => [
@@ -1029,7 +1356,7 @@ export default function SettingsPanel({
       <ConfirmModal {...confirmModalState} onClose={closeConfirmModal} />
       <LayoutGroup id="settings-panel">
         <div className="flex flex-col h-full w-full text-text-primary">
-          <header className="shrink-0 flex flex-wrap items-center justify-between gap-y-4 mb-8 pt-4">
+          <header className="shrink-0 flex flex-wrap items-center justify-between gap-4 mb-8 pt-4">
             <div className="flex items-center shrink-0">
               <Button
                 className="mr-4 hover:bg-surface text-text-primary rounded-full"
@@ -1045,11 +1372,53 @@ export default function SettingsPanel({
               </Text>
             </div>
 
+            <div className="relative w-full min-[1200px]:w-72">
+              <Search
+                aria-hidden="true"
+                className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary pointer-events-none"
+                size={17}
+              />
+              <input
+                ref={settingsSearchInputRef}
+                aria-label={t('settings.search.placeholder')}
+                className="w-full h-11 pl-10 pr-10 bg-surface border border-border-color rounded-md text-sm text-text-primary placeholder:text-text-secondary focus:border-accent transition-colors"
+                onChange={(event) => setSettingsSearchQuery(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Escape' && settingsSearchQuery) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setSettingsSearchQuery('');
+                  }
+                }}
+                placeholder={t('settings.search.placeholder')}
+                role="searchbox"
+                spellCheck={false}
+                type="text"
+                value={settingsSearchQuery}
+              />
+              {settingsSearchQuery && (
+                <button
+                  aria-label={t('settings.search.clear')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-text-secondary hover:text-text-primary rounded"
+                  onClick={() => {
+                    setSettingsSearchQuery('');
+                    settingsSearchInputRef.current?.focus();
+                  }}
+                >
+                  <X aria-hidden="true" size={16} />
+                </button>
+              )}
+            </div>
+
             <div className="relative flex w-full min-[1200px]:w-112.5 p-2 bg-surface rounded-md">
               {settingCategories.map((category) => (
                 <button
                   key={category.id}
-                  onClick={() => setActiveCategory(category.id)}
+                  onClick={() => {
+                    setActiveCategory(category.id);
+                    setPendingSearchTarget(null);
+                    setSettingsSearchQuery('');
+                  }}
                   className={clsx(
                     'relative flex-1 flex items-center justify-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md transition-colors',
                     {
@@ -1076,9 +1445,58 @@ export default function SettingsPanel({
             </div>
           </header>
 
-          <div className="flex-1 overflow-y-auto overflow-x-hidden pr-2 -mr-2 custom-scrollbar">
+          <div
+            ref={settingsContentRef}
+            className="flex-1 overflow-y-auto overflow-x-hidden pr-2 -mr-2 custom-scrollbar"
+          >
             <AnimatePresence mode="wait">
-              {activeCategory === 'general' && (
+              {settingsSearchQuery.trim() && (
+                <motion.div
+                  key="settings-search-results"
+                  initial={{ opacity: 0, y: 8 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  exit={{ opacity: 0, y: -8 }}
+                  transition={{ duration: 0.16 }}
+                  className="p-6 bg-surface rounded-xl shadow-md"
+                >
+                  <Text variant={TextVariants.title} color={TextColors.accent} className="mb-6">
+                    {t('settings.search.results')}
+                  </Text>
+                  {filteredSettingsSearchItems.length > 0 ? (
+                    <div className="divide-y divide-border-color">
+                      {filteredSettingsSearchItems.map((item) => (
+                        <button
+                          key={`${item.category}-${item.label}`}
+                          className="w-full text-left py-4 px-3 first:pt-2 last:pb-2 rounded-md hover:bg-bg-primary transition-colors"
+                          onClick={() => {
+                            setActiveCategory(item.category);
+                            setPendingSearchTarget(item.targetText);
+                            setSettingsSearchQuery('');
+                          }}
+                        >
+                          <span className="flex items-center justify-between gap-4">
+                            <Text variant={TextVariants.heading} color={TextColors.primary}>
+                              {item.label}
+                            </Text>
+                            <Text variant={TextVariants.small} color={TextColors.accent} className="shrink-0">
+                              {item.categoryLabel}
+                            </Text>
+                          </span>
+                          {item.description && (
+                            <Text variant={TextVariants.small} className="mt-1">
+                              {item.description}
+                            </Text>
+                          )}
+                        </button>
+                      ))}
+                    </div>
+                  ) : (
+                    <Text className="py-8 text-center">{t('settings.search.noResults')}</Text>
+                  )}
+                </motion.div>
+              )}
+
+              {!settingsSearchQuery.trim() && activeCategory === 'general' && (
                 <motion.div
                   key="general"
                   initial={{ opacity: 0, x: 10 }}
@@ -1239,7 +1657,10 @@ export default function SettingsPanel({
                     </div>
                   </div>
 
-                  <div className="p-6 bg-surface rounded-xl shadow-md">
+                  <div
+                    className="p-6 bg-surface rounded-xl shadow-md"
+                    data-settings-search-text={`${t('settings.adjustments.title')} ${t('settings.adjustments.description')}`}
+                  >
                     <Text variant={TextVariants.title} color={TextColors.accent} className="mb-8">
                       {t('settings.adjustments.title')}
                     </Text>
@@ -1300,7 +1721,10 @@ export default function SettingsPanel({
                     </div>
                   </div>
 
-                  <div className="p-6 bg-surface rounded-xl shadow-md">
+                  <div
+                    className="p-6 bg-surface rounded-xl shadow-md"
+                    data-settings-search-text={`${t('settings.lenses.title')} ${t('settings.lenses.description')}`}
+                  >
                     <Text variant={TextVariants.title} color={TextColors.accent} className="mb-8">
                       {t('settings.lenses.title')}
                     </Text>
@@ -1733,7 +2157,7 @@ export default function SettingsPanel({
                   </div>
                 </motion.div>
               )}
-              {activeCategory === 'processing' && (
+              {!settingsSearchQuery.trim() && activeCategory === 'processing' && (
                 <motion.div
                   key="processing"
                   initial={{ opacity: 0, x: 10 }}
@@ -1747,7 +2171,7 @@ export default function SettingsPanel({
                       {t('settings.processing.title')}
                     </Text>
                     <div className="space-y-8">
-                      <div>
+                      <div data-settings-search-text={t('settings.processing.previewStrategy')}>
                         <Text variant={TextVariants.heading} className="mb-2">
                           {t('settings.processing.previewStrategy')}
                         </Text>
@@ -2167,7 +2591,10 @@ export default function SettingsPanel({
                     </div>
                   </div>
 
-                  <div className="p-6 bg-surface rounded-xl shadow-md">
+                  <div
+                    className="p-6 bg-surface rounded-xl shadow-md"
+                    data-settings-search-text={`${t('settings.processing.ai.title')} ${t('settings.processing.ai.description')}`}
+                  >
                     <Text variant={TextVariants.title} color={TextColors.accent} className="mb-8">
                       {t('settings.processing.ai.title')}
                     </Text>
@@ -2426,7 +2853,7 @@ export default function SettingsPanel({
                 </motion.div>
               )}
 
-              {activeCategory === 'shortcuts' && (
+              {!settingsSearchQuery.trim() && activeCategory === 'shortcuts' && (
                 <motion.div
                   key="shortcuts"
                   initial={{ opacity: 0, x: 10 }}
@@ -2440,7 +2867,9 @@ export default function SettingsPanel({
                       {t('settings.controls.title')}
                     </Text>
                     <div className="space-y-8">
-                      <div>
+                      <div
+                        data-settings-search-text={`${t('settings.controls.optimization')} ${t('settings.controls.optimizationDesc')}`}
+                      >
                         <Text variant={TextVariants.heading} className="mb-2">
                           {t('settings.controls.optimization')}
                         </Text>
@@ -2470,7 +2899,10 @@ export default function SettingsPanel({
                     </div>
                   </div>
 
-                  <div className="p-6 bg-surface rounded-xl shadow-md">
+                  <div
+                    className="p-6 bg-surface rounded-xl shadow-md"
+                    data-settings-search-text={t('settings.controls.keyboardTitle')}
+                  >
                     <Text variant={TextVariants.title} color={TextColors.accent} className="mb-8">
                       {t('settings.controls.keyboardTitle')}
                     </Text>

--- a/src/i18n/locales/ca.json
+++ b/src/i18n/locales/ca.json
@@ -1409,6 +1409,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Esborra la cerca",
+      "noResults": "No s'ha trobat cap configuració.",
+      "placeholder": "Cerca a la configuració…",
+      "results": "Resultats de la cerca"
+    },
     "adjustments": {
       "chromaticAberration": "Aberració cromàtica",
       "colorCalibration": "Calibratge de color",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -1409,6 +1409,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Suche löschen",
+      "noResults": "Keine Einstellungen gefunden.",
+      "placeholder": "Einstellungen durchsuchen…",
+      "results": "Suchergebnisse"
+    },
     "adjustments": {
       "chromaticAberration": "Chromatische Aberration",
       "colorCalibration": "Farbkalibrierung",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1409,6 +1409,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Clear search",
+      "noResults": "No settings found.",
+      "placeholder": "Search settings…",
+      "results": "Search Results"
+    },
     "adjustments": {
       "chromaticAberration": "Chromatic Aberration",
       "colorCalibration": "Color Calibration",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -1439,6 +1439,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Borrar búsqueda",
+      "noResults": "No se encontraron ajustes.",
+      "placeholder": "Buscar en Ajustes…",
+      "results": "Resultados de búsqueda"
+    },
     "adjustments": {
       "chromaticAberration": "Aberración cromática",
       "colorCalibration": "Calibración de color",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -1439,6 +1439,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Effacer la recherche",
+      "noResults": "Aucun réglage trouvé.",
+      "placeholder": "Rechercher dans les paramètres…",
+      "results": "Résultats de recherche"
+    },
     "adjustments": {
       "chromaticAberration": "Aberration chromatique",
       "colorCalibration": "Étalonnage des couleurs",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -1439,6 +1439,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Cancella ricerca",
+      "noResults": "Nessuna impostazione trovata.",
+      "placeholder": "Cerca nelle impostazioni…",
+      "results": "Risultati della ricerca"
+    },
     "adjustments": {
       "chromaticAberration": "Aberrazione Cromatica",
       "colorCalibration": "Calibrazione Colore",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1407,6 +1407,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "検索をクリア",
+      "noResults": "設定が見つかりません。",
+      "placeholder": "設定を検索…",
+      "results": "検索結果"
+    },
     "adjustments": {
       "chromaticAberration": "色収差",
       "colorCalibration": "カラーキャリブレーション",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1407,6 +1407,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "검색 지우기",
+      "noResults": "설정을 찾을 수 없습니다.",
+      "placeholder": "설정 검색…",
+      "results": "검색 결과"
+    },
     "adjustments": {
       "chromaticAberration": "색수차",
       "colorCalibration": "색상 보정",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -1471,6 +1471,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Wyczyść wyszukiwanie",
+      "noResults": "Nie znaleziono ustawień.",
+      "placeholder": "Szukaj w ustawieniach…",
+      "results": "Wyniki wyszukiwania"
+    },
     "adjustments": {
       "chromaticAberration": "Aberracja chromatyczna",
       "colorCalibration": "Kalibracja kolorów",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -1440,6 +1440,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Limpar pesquisa",
+      "noResults": "Nenhuma configuração encontrada.",
+      "placeholder": "Pesquisar nas configurações…",
+      "results": "Resultados da pesquisa"
+    },
     "adjustments": {
       "chromaticAberration": "Aberração Cromática",
       "colorCalibration": "Calibração de Cores",

--- a/src/i18n/locales/ru.json
+++ b/src/i18n/locales/ru.json
@@ -1471,6 +1471,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "Очистить поиск",
+      "noResults": "Настройки не найдены.",
+      "placeholder": "Поиск в настройках…",
+      "results": "Результаты поиска"
+    },
     "adjustments": {
       "chromaticAberration": "Хроматическая аберрация",
       "colorCalibration": "Калибровка цвета",

--- a/src/i18n/locales/zh-CN.json
+++ b/src/i18n/locales/zh-CN.json
@@ -1407,6 +1407,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "清除搜索",
+      "noResults": "未找到设置。",
+      "placeholder": "搜索设置…",
+      "results": "搜索结果"
+    },
     "adjustments": {
       "chromaticAberration": "色差",
       "colorCalibration": "颜色校准",

--- a/src/i18n/locales/zh-TW.json
+++ b/src/i18n/locales/zh-TW.json
@@ -1407,6 +1407,12 @@
     }
   },
   "settings": {
+    "search": {
+      "clear": "清除搜尋",
+      "noResults": "找不到設定。",
+      "placeholder": "搜尋設定…",
+      "results": "搜尋結果"
+    },
     "adjustments": {
       "chromaticAberration": "色差",
       "colorCalibration": "顏色校準",

--- a/src/styles.css
+++ b/src/styles.css
@@ -152,6 +152,16 @@
 }
 
 @layer components {
+  [data-settings-search-highlight='true'] {
+    outline: 2px solid var(--color-accent) !important;
+    outline-offset: 6px;
+    border-radius: var(--radius-md);
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--color-accent) 16%, transparent);
+    transition:
+      outline-color 180ms ease,
+      box-shadow 180ms ease;
+  }
+
   .slider-input::-webkit-slider-thumb {
     @apply h-4 w-4 appearance-none rounded-full bg-accent;
     transition:

--- a/src/utils/settingsSearch.ts
+++ b/src/utils/settingsSearch.ts
@@ -1,0 +1,29 @@
+export interface SettingsSearchItem<TCategory extends string = string> {
+  category: TCategory;
+  categoryLabel: string;
+  description?: string;
+  keywords?: string[];
+  label: string;
+}
+
+export function normalizeSettingsSearchText(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .toLocaleLowerCase()
+    .trim();
+}
+
+export function filterSettingsSearchItems<TItem extends SettingsSearchItem>(items: TItem[], query: string): TItem[] {
+  const normalizedQuery = normalizeSettingsSearchText(query);
+  if (!normalizedQuery) return [];
+
+  const queryTerms = normalizedQuery.split(/\s+/);
+
+  return items.filter((item) => {
+    const searchableText = normalizeSettingsSearchText(
+      [item.label, item.description, item.categoryLabel, ...(item.keywords || [])].filter(Boolean).join(' '),
+    );
+    return queryTerms.every((term) => searchableText.includes(term));
+  });
+}


### PR DESCRIPTION
## Description

Adds a localized Settings search that can be focused with Cmd/Ctrl+F while the Settings panel is open. Results navigate to the appropriate category, scroll to the matching control, and briefly highlight it.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [x] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Adds a search field to the Settings header.
- Adds contextual Cmd/Ctrl+F handling without affecting shortcuts elsewhere in the app.
- Searches translated labels, descriptions, category names, shortcut sections, and supplemental keywords.
- Supports accent-insensitive and multi-term matching.
- Indexes every statically translated setting, data action, and all entries from `KEYBIND_DEFINITIONS`.
- Navigates to the selected result and briefly highlights the destination control.
- Routes conditionally hidden child settings to their visible parent control.
- Adds search UI translations for all 13 supported locales.


## Screenshots

| Settings overview | Cross-category search (`lens`) |
| --- | --- |
| <img width="720" alt="Settings search field in the RapidRAW Settings panel" src="https://github.com/user-attachments/assets/7e4a5125-7a90-4551-a5fd-999f1ff4447f" /> | <img width="720" alt="Settings search results across General and Processing categories" src="https://github.com/user-attachments/assets/5050c5b0-f124-4d6f-b750-697d913fa1d8" /> |
| Keyword search (`artificial intelligence`) | Result navigation and highlight |
| <img width="720" alt="Keyword search finding the Generative AI setting" src="https://github.com/user-attachments/assets/d30a3095-b105-4048-8e4a-fedddfe6e642" /> | <img width="720" alt="Navigated Processing setting highlighted after selection" src="https://github.com/user-attachments/assets/51d0d0a3-cf6a-46c9-826b-62bbc1267194" /> |

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS
- **Checks:** `npm run build`, accent/multi-term helper assertions, settings-index coverage, locale-key coverage, Prettier, and `git diff --check`

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The repository-wide TypeScript and i18n validation commands still report pre-existing baseline failures unrelated to this change. This branch is independent from the Auto Adjust PR; because shortcut results are generated from `KEYBIND_DEFINITIONS`, the new Auto Adjust command will become searchable automatically after both PRs are merged.

## AI Disclaimer

- [x] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
