### PR TITLE
fix: apply geometry transforms after orientation rotation

### DIFF
--- a/src-tauri/src/adjustment_utils.rs
+++ b/src-tauri/src/adjustment_utils.rs
@@ -102,10 +102,10 @@ pub fn apply_all_transformations<'a, I: IntoCowImage<'a>>(
     let flip_vertical = adjustments["flipVertical"].as_bool().unwrap_or(false);
 
     let coarse_rotated_image = apply_coarse_rotation(image, orientation_steps);
-    let warped_image = apply_geometry_warp(coarse_rotated_image, adjustments);
+    let oriented_image = apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical);
+    let warped_image = apply_geometry_warp(oriented_image, adjustments);
     let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, adjustments);
-    let flipped_image = apply_flip(blurred_image, flip_horizontal, flip_vertical);
-    let rotated_image = apply_rotation(flipped_image, rotation_degrees);
+    let rotated_image = apply_rotation(blurred_image, rotation_degrees);
 
     let crop_data: Option<Crop> = serde_json::from_value(adjustments["crop"].clone()).ok();
     let crop_json = serde_json::to_value(crop_data).unwrap_or(serde_json::Value::Null);

--- a/src-tauri/src/adjustment_utils.rs
+++ b/src-tauri/src/adjustment_utils.rs
@@ -96,16 +96,15 @@ pub fn apply_all_transformations<'a, I: IntoCowImage<'a>>(
 ) -> (Cow<'a, DynamicImage>, (f32, f32)) {
     let start_time = std::time::Instant::now();
     let image = image.into_cow();
-    let warped_image = apply_geometry_warp(image, adjustments);
-    let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, adjustments);
-
     let orientation_steps = adjustments["orientationSteps"].as_u64().unwrap_or(0) as u8;
     let rotation_degrees = adjustments["rotation"].as_f64().unwrap_or(0.0) as f32;
     let flip_horizontal = adjustments["flipHorizontal"].as_bool().unwrap_or(false);
     let flip_vertical = adjustments["flipVertical"].as_bool().unwrap_or(false);
 
-    let coarse_rotated_image = apply_coarse_rotation(blurred_image, orientation_steps);
-    let flipped_image = apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical);
+    let coarse_rotated_image = apply_coarse_rotation(image, orientation_steps);
+    let warped_image = apply_geometry_warp(coarse_rotated_image, adjustments);
+    let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, adjustments);
+    let flipped_image = apply_flip(blurred_image, flip_horizontal, flip_vertical);
     let rotated_image = apply_rotation(flipped_image, rotation_degrees);
 
     let crop_data: Option<Crop> = serde_json::from_value(adjustments["crop"].clone()).ok();

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -1572,16 +1572,14 @@ pub fn generate_thumbnail_data(
                 img
             };
 
-            let warped_image =
-                apply_geometry_warp(Cow::Borrowed(&composite_image), &meta.adjustments);
-
-            let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &meta.adjustments);
-
             let orientation_steps =
                 meta.adjustments["orientationSteps"].as_u64().unwrap_or(0) as u8;
-            let coarse_rotated_image = apply_coarse_rotation(blurred_image, orientation_steps);
+            let coarse_rotated_image =
+                apply_coarse_rotation(Cow::Borrowed(&composite_image), orientation_steps);
+            let warped_image = apply_geometry_warp(coarse_rotated_image, &meta.adjustments);
+            let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &meta.adjustments);
 
-            let (full_w, full_h) = coarse_rotated_image.dimensions();
+            let (full_w, full_h) = blurred_image.dimensions();
 
             let mut processing_dim = target_res;
             if let Some(c) = &crop_data
@@ -1599,7 +1597,7 @@ pub fn generate_thumbnail_data(
 
             let (base, gpu_scale) = if full_w > processing_dim || full_h > processing_dim {
                 let base = crate::image_processing::downscale_f32_image(
-                    &coarse_rotated_image,
+                    &blurred_image,
                     processing_dim,
                     processing_dim,
                 );
@@ -1610,7 +1608,7 @@ pub fn generate_thumbnail_data(
                 };
                 (base, scale)
             } else {
-                (coarse_rotated_image.into_owned(), 1.0)
+                (blurred_image.into_owned(), 1.0)
             };
 
             let total_scale = gpu_scale * raw_scale_factor;

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -1574,9 +1574,14 @@ pub fn generate_thumbnail_data(
 
             let orientation_steps =
                 meta.adjustments["orientationSteps"].as_u64().unwrap_or(0) as u8;
+            let flip_horizontal = meta.adjustments["flipHorizontal"]
+                .as_bool()
+                .unwrap_or(false);
+            let flip_vertical = meta.adjustments["flipVertical"].as_bool().unwrap_or(false);
             let coarse_rotated_image =
                 apply_coarse_rotation(Cow::Borrowed(&composite_image), orientation_steps);
-            let warped_image = apply_geometry_warp(coarse_rotated_image, &meta.adjustments);
+            let oriented_image = apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical);
+            let warped_image = apply_geometry_warp(oriented_image, &meta.adjustments);
             let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &meta.adjustments);
 
             let (full_w, full_h) = blurred_image.dimensions();

--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -962,7 +962,8 @@ pub fn inverse_transform_mask(
         .get("flipVertical")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-    let flipped = apply_flip(unrotated_fine, flip_h, flip_v).into_owned();
+    let unwarped = apply_unwarp_geometry(unrotated_fine, adjustments).into_owned();
+    let flipped = apply_flip(unwarped, flip_h, flip_v).into_owned();
 
     let steps = adjustments
         .get("orientationSteps")
@@ -971,9 +972,7 @@ pub fn inverse_transform_mask(
     let inverse_steps = (4 - (steps % 4)) % 4;
     let unrotated_coarse = apply_coarse_rotation(flipped, inverse_steps).into_owned();
 
-    let unwarped = apply_unwarp_geometry(unrotated_coarse, adjustments).into_owned();
-
-    unwarped.into_luma8()
+    unrotated_coarse.into_luma8()
 }
 
 pub fn inverse_transform_point(
@@ -999,6 +998,8 @@ pub fn inverse_transform_point(
         x = cx + dx * cos_t - dy * sin_t;
         y = cy + dx * sin_t + dy * cos_t;
     }
+
+    (x, y) = inverse_geometry_point(x, y, curr_w, curr_h, adjustments);
 
     let flip_h = adjustments
         .get("flipHorizontal")
@@ -1028,6 +1029,16 @@ pub fn inverse_transform_point(
         std::mem::swap(&mut curr_w, &mut curr_h);
     }
 
+    (x, y)
+}
+
+fn inverse_geometry_point(
+    x: f64,
+    y: f64,
+    curr_w: f64,
+    curr_h: f64,
+    adjustments: &serde_json::Value,
+) -> (f64, f64) {
     let params = get_geometry_params_from_json(adjustments);
     let width = curr_w as f32;
     let height = curr_h as f32;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -761,18 +761,17 @@ fn generate_uncropped_preview(
             Cow::Borrowed(loaded_image.image.as_ref())
         };
 
-        let warped_image = apply_geometry_warp(patched_image, &adjustments_clone);
-        let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &adjustments_clone);
         let orientation_steps = adjustments_clone["orientationSteps"].as_u64().unwrap_or(0) as u8;
-        let coarse_rotated_image = apply_coarse_rotation(blurred_image, orientation_steps);
+        let coarse_rotated_image = apply_coarse_rotation(patched_image, orientation_steps);
+        let warped_image = apply_geometry_warp(coarse_rotated_image, &adjustments_clone);
+        let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &adjustments_clone);
 
         let flip_horizontal = adjustments_clone["flipHorizontal"]
             .as_bool()
             .unwrap_or(false);
         let flip_vertical = adjustments_clone["flipVertical"].as_bool().unwrap_or(false);
 
-        let flipped_image =
-            apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical).into_owned();
+        let flipped_image = apply_flip(blurred_image, flip_horizontal, flip_vertical).into_owned();
 
         let settings = load_settings(app_handle.clone()).unwrap_or_default();
         let preview_dim = settings.editor_preview_resolution.unwrap_or(1920);
@@ -972,15 +971,15 @@ async fn preview_geometry_transform(
             adjusted_params.lens_vignette_amount *= 0.8;
         }
 
-        let warped_image = warp_image_geometry(&base_image_to_warp, adjusted_params);
         let orientation_steps = js_adjustments["orientationSteps"].as_u64().unwrap_or(0) as u8;
         let flip_horizontal = js_adjustments["flipHorizontal"].as_bool().unwrap_or(false);
         let flip_vertical = js_adjustments["flipVertical"].as_bool().unwrap_or(false);
 
         let coarse_rotated_image =
-            apply_coarse_rotation(Cow::Owned(warped_image), orientation_steps);
+            apply_coarse_rotation(Cow::Borrowed(&base_image_to_warp), orientation_steps);
+        let warped_image = warp_image_geometry(coarse_rotated_image.as_ref(), adjusted_params);
         let flipped_image =
-            apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical).into_owned();
+            apply_flip(Cow::Owned(warped_image), flip_horizontal, flip_vertical).into_owned();
 
         if show_lines {
             let gray_image = flipped_image.to_luma8();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -763,24 +763,23 @@ fn generate_uncropped_preview(
 
         let orientation_steps = adjustments_clone["orientationSteps"].as_u64().unwrap_or(0) as u8;
         let coarse_rotated_image = apply_coarse_rotation(patched_image, orientation_steps);
-        let warped_image = apply_geometry_warp(coarse_rotated_image, &adjustments_clone);
-        let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &adjustments_clone);
-
         let flip_horizontal = adjustments_clone["flipHorizontal"]
             .as_bool()
             .unwrap_or(false);
         let flip_vertical = adjustments_clone["flipVertical"].as_bool().unwrap_or(false);
-
-        let flipped_image = apply_flip(blurred_image, flip_horizontal, flip_vertical).into_owned();
+        let oriented_image = apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical);
+        let warped_image = apply_geometry_warp(oriented_image, &adjustments_clone);
+        let blurred_image = crate::lens_blur::apply_lens_blur(warped_image, &adjustments_clone);
+        let oriented_image = blurred_image.into_owned();
 
         let settings = load_settings(app_handle.clone()).unwrap_or_default();
         let preview_dim = settings.editor_preview_resolution.unwrap_or(1920);
 
-        let (rotated_w, rotated_h) = flipped_image.dimensions();
+        let (rotated_w, rotated_h) = oriented_image.dimensions();
 
         let (processing_base, scale_for_gpu) = if rotated_w > preview_dim || rotated_h > preview_dim
         {
-            let base = downscale_f32_image(&flipped_image, preview_dim, preview_dim);
+            let base = downscale_f32_image(&oriented_image, preview_dim, preview_dim);
             let scale = if rotated_w > 0 {
                 base.width() as f32 / rotated_w as f32
             } else {
@@ -788,7 +787,7 @@ fn generate_uncropped_preview(
             };
             (base, scale)
         } else {
-            (flipped_image.clone(), 1.0)
+            (oriented_image, 1.0)
         };
 
         let (preview_width, preview_height) = processing_base.dimensions();
@@ -977,13 +976,12 @@ async fn preview_geometry_transform(
 
         let coarse_rotated_image =
             apply_coarse_rotation(Cow::Borrowed(&base_image_to_warp), orientation_steps);
-        let warped_image = warp_image_geometry(coarse_rotated_image.as_ref(), adjusted_params);
-        let flipped_image =
-            apply_flip(Cow::Owned(warped_image), flip_horizontal, flip_vertical).into_owned();
+        let oriented_image = apply_flip(coarse_rotated_image, flip_horizontal, flip_vertical);
+        let warped_image = warp_image_geometry(oriented_image.as_ref(), adjusted_params);
 
         if show_lines {
-            let gray_image = flipped_image.to_luma8();
-            let mut visualization = flipped_image.to_rgba8();
+            let gray_image = warped_image.to_luma8();
+            let mut visualization = warped_image.to_rgba8();
             let edges = canny(&gray_image, 50.0, 100.0);
 
             let min_dim = gray_image.width().min(gray_image.height());
@@ -1034,7 +1032,7 @@ async fn preview_geometry_transform(
 
             DynamicImage::ImageRgba8(visualization)
         } else {
-            flipped_image
+            warped_image
         }
     })
     .await


### PR DESCRIPTION
## Description

Fixes #1603. Geometry transforms now respect the image’s current orientation, so Vertical and Horizontal adjustments consistently operate on the displayed image axes and move in the expected direction.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Apply image orientation and flips before geometry transforms.
- Keep Vertical and Horizontal adjustments screen-relative across all image orientations.
- Align the main render pipeline, transform preview, uncropped preview, and thumbnail generation.
- Update inverse mask and point transformations to match the new processing order.

## Screenshots/Videos

Not applicable.

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The repository’s TypeScript typecheck reports unrelated pre-existing errors in unchanged files.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [ ] This PR is created by an AI agent
- [x] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)