### PR TITLE
fix: guard against epoch-zero file timestamps on export

### DIFF
--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -463,8 +463,27 @@ fn process_image_for_export_pipeline(
     )
 }
 
-fn set_timestamps_from_exif(src: &Path, dst: &Path) {
+fn set_timestamps_from_exif(src: &Path, dst: &Path) -> bool {
     let capture_dt = exif_processing::get_creation_date_from_path(src);
+
+    // A non-positive Unix timestamp means the EXIF date was missing, zero,
+    // or pre-epoch (e.g. camera clock unset, sentinel "1970:01:01 00:00:00",
+    // or a parse that silently produced year 0). Fall back to the current
+    // time and signal the caller so it can notify the user once per batch.
+    if capture_dt.timestamp() <= 0 {
+        log::warn!(
+            "EXIF capture date for '{}' is missing or invalid ({}); \
+             using export time as file timestamp",
+            src.display(),
+            capture_dt
+        );
+        let now = filetime::FileTime::now();
+        if let Err(e) = filetime::set_file_times(dst, now, now) {
+            log::warn!("Could not set timestamps on '{}': {}", dst.display(), e);
+        }
+        return true;
+    }
+
     let ft = filetime::FileTime::from_unix_time(
         capture_dt.timestamp(),
         capture_dt.timestamp_subsec_nanos(),
@@ -472,6 +491,7 @@ fn set_timestamps_from_exif(src: &Path, dst: &Path) {
     if let Err(e) = filetime::set_file_times(dst, ft, ft) {
         log::warn!("Could not set timestamps on '{}': {}", dst.display(), e);
     }
+    false
 }
 
 fn save_image_with_metadata(
@@ -881,6 +901,7 @@ pub(crate) async fn export_images_impl(
 
     let context = Arc::new(context);
     let progress_counter = Arc::new(AtomicUsize::new(0));
+    let timestamp_fallback_used = Arc::new(AtomicBool::new(false));
 
     let available_cores = std::thread::available_parallelism()
         .map(|n| n.get())
@@ -958,6 +979,7 @@ pub(crate) async fn export_images_impl(
             let app_handle_clone = app_handle.clone();
             let context_clone = Arc::clone(&context);
             let progress_counter_clone = Arc::clone(&progress_counter);
+            let timestamp_fallback_clone = Arc::clone(&timestamp_fallback_used);
             let output_folder_path = output_folder_path.to_path_buf();
             let base_origin_folders = base_origin_folders.clone();
             let export_settings = export_settings.clone();
@@ -1147,7 +1169,9 @@ pub(crate) async fn export_images_impl(
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
 
                     if export_settings.preserve_timestamps {
-                        set_timestamps_from_exif(Path::new(&source_path_str), &output_path);
+                        if set_timestamps_from_exif(Path::new(&source_path_str), &output_path) {
+                            timestamp_fallback_clone.store(true, Ordering::SeqCst);
+                        }
                     }
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
 
@@ -1232,6 +1256,14 @@ pub(crate) async fn export_images_impl(
                         serde_json::json!({ "current": total_paths, "total": total_paths, "path": "" }),
                     );
                     let _ = app_handle.emit("export-complete", ());
+                    if timestamp_fallback_used.load(Ordering::SeqCst) {
+                        let _ = app_handle.emit(
+                            "export-warning",
+                            "Some files were exported with the current time as the file \
+                             timestamp because their EXIF capture date was missing or \
+                             invalid. Check that your source files have a valid capture date.",
+                        );
+                    }
                 }
             },
         );

--- a/src/components/panel/right/ExportPanel.tsx
+++ b/src/components/panel/right/ExportPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { save, open } from '@tauri-apps/plugin-dialog';
 import { invoke } from '@tauri-apps/api/core';
-import { FileInput, CheckCircle, XCircle, Loader, Ban, ChevronDown, ChevronRight, Settings, X } from 'lucide-react';
+import { FileInput, CheckCircle, XCircle, Loader, Ban, ChevronDown, ChevronRight, Settings, X, AlertTriangle } from 'lucide-react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 import debounce from 'lodash.debounce';
@@ -279,7 +279,7 @@ export default function ExportPanel({
   const activePanels = useUIStore((state) => state.activePanels);
   const isPanelReallyActive = Object.values(activePanels).includes(Panel.Export);
 
-  const { status, progress, errorMessage } = exportState;
+  const { status, progress, errorMessage, warningMessage } = exportState;
   const isExporting = [Status.Exporting, Status.Cancelling].includes(status);
   const isCancelling = status === Status.Cancelling;
   const isLibraryContext = !!onClose;
@@ -898,6 +898,8 @@ export default function ExportPanel({
                     ? 'bg-red-500/20 text-red-400 shadow-none'
                     : status === Status.Cancelled
                       ? 'bg-yellow-500/20 text-yellow-400 shadow-none'
+                      : status === Status.Warning
+                        ? 'bg-amber-500/20 text-amber-400 shadow-none'                      
                       : ''
           }`}
           disabled={isCancelling || (status !== Status.Exporting && !canExport)}
@@ -932,6 +934,10 @@ export default function ExportPanel({
           ) : status === Status.Cancelled ? (
             <>
               <Ban size={18} className="mr-2" /> {t('export.status.cancelled')}
+            </>
+          ) : status === Status.Warning ? (
+            <>
+              <AlertTriangle size={18} className="mr-2" /> {warningMessage || t('export.status.warning')}
             </>
           ) : (
             <>

--- a/src/components/ui/ExportImportProperties.tsx
+++ b/src/components/ui/ExportImportProperties.tsx
@@ -70,6 +70,7 @@ export interface ExportState {
   errorMessage: string;
   progress: Progress;
   status: Status;
+  warningMessage: string;
 }
 
 export interface FileFormat {
@@ -93,6 +94,7 @@ export enum Status {
   Idle = 'idle',
   Importing = 'importing',
   Success = 'success',
+  Warning = 'warning',
 }
 
 export interface ExportPreset {

--- a/src/hooks/useTauriListeners.ts
+++ b/src/hooks/useTauriListeners.ts
@@ -173,6 +173,13 @@ export function useTauriListeners({
       listen('export-cancelling', () => {
         if (isEffectActive) useProcessStore.getState().setExportState({ status: Status.Cancelling });
       }),
+      listen('export-warning', (event: any) => {
+        if (isEffectActive)
+          useProcessStore.getState().setExportState({
+            status: Status.Warning,
+            warningMessage: typeof event.payload === 'string' ? event.payload : 'Export completed with warnings.',
+          });
+      }),
       listen('export-cancelled', () => {
         if (isEffectActive) useProcessStore.getState().setExportState({ status: Status.Cancelled });
       }),

--- a/src/store/useProcessStore.ts
+++ b/src/store/useProcessStore.ts
@@ -40,7 +40,7 @@ let pasteTimeout: ReturnType<typeof setTimeout>;
 const MAX_PREVIEW_CACHE_SIZE = 10;
 
 export const useProcessStore = create<ProcessState>((set, get) => ({
-  exportState: { errorMessage: '', progress: { current: 0, total: 0 }, status: Status.Idle },
+  exportState: { errorMessage: '', warningMessage: '', progress: { current: 0, total: 0 }, status: Status.Idle },
   importState: { errorMessage: '', path: '', progress: { current: 0, total: 0 }, status: Status.Idle },
   isIndexing: false,
   indexingProgress: { current: 0, total: 0 },
@@ -81,13 +81,14 @@ export const useProcessStore = create<ProcessState>((set, get) => ({
 
     clearTimeout(exportTimeout);
 
-    if ([Status.Success, Status.Error, Status.Cancelled].includes(status)) {
+    if ([Status.Success, Status.Error, Status.Cancelled, Status.Warning].includes(status)) {
       exportTimeout = setTimeout(() => {
         set((prev) => ({
           exportState: {
             ...prev.exportState,
             status: Status.Idle,
             errorMessage: '',
+            warningMessage: '',
             progress: { current: 0, total: 0 },
           },
         }));


### PR DESCRIPTION
## Description

When "Set File Timestamps from EXIF Capture Date" is enabled, exported files were receiving a 1970-01-01 timestamp if the source file's EXIF capture date was missing, unset, or contained a sentinel value (e.g. `1970:01:01 00:00:00` from a camera with an unconfigured clock). The root cause is in the EXIF date parse chain — `set_timestamps_from_exif` was passing a non-positive Unix timestamp directly to `filetime::set_file_times` without validating it. This is cross-platform; it affects Linux, macOS, and Windows equally. Relates to #1618.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- `set_timestamps_from_exif` now returns `bool` and guards against non-positive Unix timestamps before calling `filetime::set_file_times`. When the guard fires, the exported file is stamped with the current time (export time) instead of 1970-01-01
- When any file in a successful batch export triggers the fallback, a single `export-warning` event is emitted — one message regardless of how many files were affected
- Frontend: added `Status.Warning` and `warningMessage` to `ExportState`; wired the `export-warning` Tauri event in `useTauriListeners`; added a Warning display branch to the export button in `ExportPanel`

## Screenshots/Videos

N/A — no UI changes under normal conditions. The Warning state on the export button only appears when the timestamp fallback fires.

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

This fix was developed via static analysis of the export pipeline. Runtime testing against the reporter's specific camera and file combination was not possible. The guard is conservative — it only intercepts non-positive Unix timestamps, which are unambiguously invalid for any real capture date. Maintainer and reporter testing against affected files would be appreciated.

**Test Configuration:**

- **OS:** Ubuntu 26.04 x86_64
- **Hardware:** Intel Core i7, 16 threads

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The keywords/tags portion of #1618 is being tracked separately and will be addressed in a follow-up PR.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [ ] This PR is created by an AI agent
- [x] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)