### PR TITLE
fix: preserve local EXIF timestamps

### DIFF
--- a/src-tauri/src/exif_processing.rs
+++ b/src-tauri/src/exif_processing.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use crate::formats::is_raw_file;
 use crate::image_processing::ImageMetadata;
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{DateTime, Local, LocalResult, NaiveDateTime, TimeZone, Utc};
 use exif::{Exif, In, Value};
 use little_exif::exif_tag::ExifTag;
 use little_exif::filetype::FileExtension;
@@ -124,13 +124,21 @@ fn parse_creation_datetime(s: &str) -> Option<NaiveDateTime> {
     None
 }
 
+fn creation_datetime_to_utc(dt: NaiveDateTime) -> DateTime<Utc> {
+    match Local.from_local_datetime(&dt) {
+        LocalResult::Single(local_dt) | LocalResult::Ambiguous(local_dt, _) => {
+            local_dt.with_timezone(&Utc)
+        }
+        LocalResult::None => DateTime::from_naive_utc_and_offset(dt, Utc),
+    }
+}
+
 fn parse_creation_field(field: &exif::Field) -> Option<DateTime<Utc>> {
-    parse_creation_datetime(&field.display_value().to_string())
-        .map(|dt| DateTime::from_naive_utc_and_offset(dt, Utc))
+    parse_creation_datetime(&field.display_value().to_string()).map(creation_datetime_to_utc)
 }
 
 fn parse_raw_creation_date(date_str: Option<&str>) -> Option<DateTime<Utc>> {
-    parse_creation_datetime(date_str?).map(|dt| DateTime::from_naive_utc_and_offset(dt, Utc))
+    parse_creation_datetime(date_str?).map(creation_datetime_to_utc)
 }
 
 fn clean_ascii_value(value: &exif::Value) -> Option<String> {
@@ -741,7 +749,7 @@ pub fn try_get_exif_creation_date(path: &Path) -> Option<DateTime<Utc>> {
         && let Some(dt_str) = map.get("DateTimeOriginal").or(map.get("CreateDate"))
         && let Some(dt) = parse_creation_datetime(dt_str)
     {
-        return Some(DateTime::from_naive_utc_and_offset(dt, Utc));
+        return Some(creation_datetime_to_utc(dt));
     }
 
     if let Ok(file) = std::fs::File::open(path) {


### PR DESCRIPTION
## Description

Fixes timezone handling for EXIF-derived filesystem timestamps during export.

EXIF capture dates are local wall-clock values, not UTC values. They were previously interpreted as UTC when the “Preserve timestamps” option was enabled, causing exported file timestamps to shift according to the system’s timezone and daylight-saving offset.

The JPEG’s embedded capture time remains unchanged regardless of the “Preserve timestamps” setting, provided metadata is retained. When the setting is disabled, the filesystem timestamp remains the export time by design. When enabled, it is set to the correct capture time.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Resolve timezone-less EXIF capture dates using the system’s local timezone.
- Apply the correction consistently to standard EXIF, RAW metadata, and RapidRAW sidecar metadata.
- Prevent timezone-dependent offsets when setting exported file timestamps from EXIF capture dates.
- No automated tests were included because the repository currently has no test suite. A temporary regression test was used during development and removed before submission.

## Screenshots/Videos

Not applicable.

## Testing

- [x] These changes were tested locally by a human and confirmed to work.
- [x] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.3.1
- **Hardware:** Apple Silicon (arm64)

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The observed one-hour offset was caused by the system’s local UTC offset in Lisbon during daylight saving time. The actual offset may differ depending on the system timezone and the capture date.

The “Preserve timestamps” option continues to control only the exported file’s filesystem timestamp. The embedded JPEG capture metadata is not modified by this change.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [ ] This PR is created by an AI agent
- [x] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)