### PR TITLE
Hide zero-byte images until locally available

### DIFF
--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -31,7 +31,7 @@ use crate::PendingMetadata;
 use crate::android_integration::*;
 use crate::app_settings::*;
 use crate::exif_processing;
-use crate::formats::{is_raw_file, is_supported_image_file};
+use crate::formats::{is_nonempty_supported_image_file, is_raw_file, is_supported_image_file};
 use crate::gpu_processing;
 use crate::image_loader;
 use crate::image_processing::GpuContext;
@@ -598,7 +598,7 @@ pub fn list_images_in_dir(path: String, app_handle: AppHandle) -> Result<Vec<Ima
                 .entry(source_filename.to_string())
                 .or_default()
                 .push(copy_id);
-        } else if is_supported_image_file(&file_name) {
+        } else if is_nonempty_supported_image_file(&entry_path) {
             images.push((file_name, entry_path));
         }
     }
@@ -726,7 +726,7 @@ pub fn list_images_recursive(
                     .or_default()
                     .push(copy_id);
             }
-        } else if is_supported_image_file(entry_path.to_string_lossy().as_ref()) {
+        } else if is_nonempty_supported_image_file(entry_path) {
             images.push(entry_path.to_path_buf());
         }
     }
@@ -1030,7 +1030,7 @@ pub fn get_album_images(
         .into_par_iter()
         .filter_map(|virtual_path| {
             let (source_path, sidecar_path) = parse_virtual_path(&virtual_path);
-            if !source_path.exists() {
+            if !is_nonempty_supported_image_file(&source_path) {
                 return None;
             }
 
@@ -1183,7 +1183,7 @@ fn scan_dir_lazy(
                         .filter_map(Result::ok)
                         .filter(|e| {
                             e.file_type().is_file()
-                                && crate::formats::is_supported_image_file(e.path())
+                                && crate::formats::is_nonempty_supported_image_file(e.path())
                         })
                         .count()
                 } else {
@@ -1213,7 +1213,7 @@ fn scan_dir_lazy(
             });
         } else if show_image_counts
             && file_type.is_file()
-            && crate::formats::is_supported_image_file(&current_path)
+            && crate::formats::is_nonempty_supported_image_file(&current_path)
         {
             current_dir_image_count += 1;
         }

--- a/src-tauri/src/formats.rs
+++ b/src-tauri/src/formats.rs
@@ -116,3 +116,45 @@ pub fn is_supported_image_file<P: AsRef<Path>>(path: P) -> bool {
         .iter()
         .any(|non_raw_ext| non_raw_ext.eq_ignore_ascii_case(ext))
 }
+
+/// Returns whether a path points to a supported image with locally readable content.
+///
+/// Zero-byte image entries cannot be decoded and commonly represent cloud-sync
+/// placeholders whose contents have not been downloaded yet. Metadata is read on
+/// every call so the image becomes discoverable on the next scan after hydration.
+pub fn is_nonempty_supported_image_file<P: AsRef<Path>>(path: P) -> bool {
+    let path = path.as_ref();
+
+    is_supported_image_file(path)
+        && std::fs::metadata(path).is_ok_and(|metadata| metadata.is_file() && metadata.len() > 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_nonempty_supported_image_file, is_supported_image_file};
+
+    #[test]
+    fn empty_supported_images_are_hidden_until_they_have_content() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let image_path = temp_dir.path().join("cloud-placeholder.jpg");
+
+        std::fs::File::create(&image_path).expect("create empty image placeholder");
+        assert!(is_supported_image_file(&image_path));
+        assert!(!is_nonempty_supported_image_file(&image_path));
+
+        std::fs::write(&image_path, b"hydrated").expect("hydrate image placeholder");
+        assert!(is_nonempty_supported_image_file(&image_path));
+    }
+
+    #[test]
+    fn missing_and_unsupported_files_are_not_discoverable() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let missing_image = temp_dir.path().join("missing.jpg");
+        let unsupported_file = temp_dir.path().join("notes.txt");
+
+        std::fs::write(&unsupported_file, b"content").expect("create unsupported file");
+
+        assert!(!is_nonempty_supported_image_file(missing_image));
+        assert!(!is_nonempty_supported_image_file(unsupported_file));
+    }
+}

--- a/src-tauri/src/tagging.rs
+++ b/src-tauri/src/tagging.rs
@@ -15,7 +15,7 @@ use tokio::task::JoinHandle;
 use walkdir::WalkDir;
 
 use crate::file_management::{self, parse_virtual_path};
-use crate::formats::is_supported_image_file;
+use crate::formats::is_nonempty_supported_image_file;
 use crate::hierarchy::TAG_HIERARCHY;
 use crate::image_processing::ImageMetadata;
 use crate::{AppState, candidates::TAG_CANDIDATES};
@@ -294,9 +294,7 @@ pub async fn start_background_indexing(
             Ok(entries) => entries
                 .filter_map(Result::ok)
                 .map(|entry| entry.path())
-                .filter(|path| {
-                    path.is_file() && is_supported_image_file(path.to_string_lossy().as_ref())
-                })
+                .filter(|path| path.is_file() && is_nonempty_supported_image_file(path))
                 .collect(),
             Err(e) => {
                 eprintln!("Failed to read directory '{}': {}", folder_path, e);


### PR DESCRIPTION
## Description

Hide zero-byte supported images from RapidRAW's library until their contents are locally available.

Zero-byte image files cannot be decoded and commonly represent cloud-sync placeholders that have been listed locally before their provider downloads the actual bytes. Showing them produces broken thumbnails and load errors even though the remote original may be fine.

The check is provider-agnostic and cross-platform. RapidRAW reads fresh metadata on each scan, so an image automatically becomes discoverable on the next refresh after Dropbox, iCloud, or another provider hydrates it.

This is intentionally separate from #1643, but complements it: zero-byte placeholders are filtered consistently for every supported image format.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- Add a shared `is_nonempty_supported_image_file` discovery predicate while preserving extension-only checks for pickers and file operations.
- Exclude zero-byte images from normal and recursive folder views, album views, folder image counts, and background indexing.
- Re-evaluate file size on every scan so hydrated images reappear without provider-specific state or persistent exclusion.
- Add tests proving that an empty supported image is hidden, becomes discoverable after content is written, and that missing or unsupported paths remain excluded.

## Screenshots/Videos

Not applicable; the intended result is that unavailable zero-byte tiles no longer render.

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [x] Automated tests cover the new discovery behavior.

**Test Configuration:**
- **OS:** macOS
- **Hardware:** Apple Silicon

Checks:

- `cargo test --manifest-path src-tauri/Cargo.toml --lib` — 2 passed
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `git diff --check`
- `cargo clippy --all-targets --all-features -- -D warnings -A clippy::collapsible_if`

The repository's unmodified `src-tauri/src/exif_processing.rs` currently triggers the pre-existing `collapsible_if` warning under the exact strict Clippy command. With that unrelated baseline lint allowed, all targets and features pass Clippy with `-D warnings`.

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

This deliberately checks for zero length rather than Dropbox- or iCloud-specific attributes. A zero-byte file cannot be a decodable image regardless of provider, while non-empty cloud entries keep RapidRAW's existing placeholder behavior.

## AI Disclaimer

- [x] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
