### PR TITLE
Prioritize editor rendering over thumbnail refreshes

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Condvar, Mutex};
+use std::time::{Duration, Instant};
 
 use image::{DynamicImage, GrayImage};
 use serde::{Deserialize, Serialize};
@@ -71,6 +72,7 @@ pub struct PreviewJob {
     pub compute_waveform: bool,
     pub active_waveform_channel: Option<String>,
     pub responder: tokio::sync::oneshot::Sender<Vec<u8>>,
+    pub gpu_work_ticket: GpuWorkTicket,
 }
 
 pub struct AnalyticsJob {
@@ -134,6 +136,340 @@ impl MetadataManager {
     }
 }
 
+pub const ADJUSTED_THUMBNAIL_IDLE_DELAY: Duration = Duration::from_millis(1_500);
+
+#[derive(Clone, Copy)]
+struct PendingAdjustedThumbnail {
+    ready_at: Instant,
+    token: ThumbnailRevision,
+    sequence: u64,
+}
+
+struct AdjustedThumbnailQueueState {
+    pending: HashMap<String, PendingAdjustedThumbnail>,
+    latest_revision: HashMap<String, u64>,
+    epoch: u64,
+    last_editor_activity: Instant,
+    next_sequence: u64,
+}
+
+impl AdjustedThumbnailQueueState {
+    fn new(now: Instant) -> Self {
+        Self {
+            pending: HashMap::new(),
+            latest_revision: HashMap::new(),
+            epoch: 0,
+            last_editor_activity: now,
+            next_sequence: 0,
+        }
+    }
+
+    fn invalidate(&mut self, path: &str) -> ThumbnailRevision {
+        let revision = self
+            .latest_revision
+            .get(path)
+            .copied()
+            .unwrap_or(0)
+            .wrapping_add(1);
+        self.latest_revision.insert(path.to_string(), revision);
+        self.pending.remove(path);
+        ThumbnailRevision {
+            epoch: self.epoch,
+            revision,
+        }
+    }
+
+    fn arm_deferred(&mut self, path: String, token: ThumbnailRevision, now: Instant) {
+        if self.snapshot(&path) != token {
+            return;
+        }
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+        self.pending.insert(
+            path,
+            PendingAdjustedThumbnail {
+                ready_at: now + ADJUSTED_THUMBNAIL_IDLE_DELAY,
+                token,
+                sequence: self.next_sequence,
+            },
+        );
+    }
+
+    fn schedule(&mut self, path: String, now: Instant) -> ThumbnailRevision {
+        let token = self.invalidate(&path);
+        self.arm_deferred(path, token, now);
+        token
+    }
+
+    fn note_editor_activity(&mut self, now: Instant) {
+        self.last_editor_activity = now;
+    }
+
+    fn take_ready(&mut self, now: Instant) -> Option<AdjustedThumbnailJob> {
+        if now < self.last_editor_activity + ADJUSTED_THUMBNAIL_IDLE_DELAY {
+            return None;
+        }
+
+        let (path, pending) = self
+            .pending
+            .iter()
+            .filter(|(_, job)| job.ready_at <= now)
+            .max_by_key(|(_, job)| job.sequence)
+            .map(|(path, job)| (path.clone(), *job))?;
+        self.pending.remove(&path);
+        Some(AdjustedThumbnailJob {
+            path,
+            token: pending.token,
+            sequence: pending.sequence,
+        })
+    }
+
+    fn wait_duration(&self, now: Instant) -> Option<Duration> {
+        let earliest_job = self.pending.values().map(|job| job.ready_at).min()?;
+        let editor_idle_at = self.last_editor_activity + ADJUSTED_THUMBNAIL_IDLE_DELAY;
+        let wake_at = earliest_job.max(editor_idle_at);
+        Some(wake_at.saturating_duration_since(now))
+    }
+
+    fn is_current(&self, job: &AdjustedThumbnailJob) -> bool {
+        self.snapshot(&job.path) == job.token
+    }
+
+    fn snapshot(&self, path: &str) -> ThumbnailRevision {
+        ThumbnailRevision {
+            epoch: self.epoch,
+            revision: self.latest_revision.get(path).copied().unwrap_or(0),
+        }
+    }
+
+    fn requeue(&mut self, job: &AdjustedThumbnailJob, now: Instant, delay: Duration) {
+        if self.is_current(job) {
+            self.pending.insert(
+                job.path.clone(),
+                PendingAdjustedThumbnail {
+                    ready_at: now + delay,
+                    token: job.token,
+                    sequence: job.sequence,
+                },
+            );
+        }
+    }
+
+    fn cancel_all(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
+        self.pending.clear();
+        self.latest_revision.clear();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ThumbnailRevision {
+    epoch: u64,
+    revision: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdjustedThumbnailJob {
+    path: String,
+    token: ThumbnailRevision,
+    sequence: u64,
+}
+
+impl AdjustedThumbnailJob {
+    pub fn path(&self) -> &str {
+        &self.path
+    }
+}
+
+pub struct AdjustedThumbnailManager {
+    state: Mutex<AdjustedThumbnailQueueState>,
+    cvar: Condvar,
+}
+
+impl AdjustedThumbnailManager {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(AdjustedThumbnailQueueState::new(Instant::now())),
+            cvar: Condvar::new(),
+        })
+    }
+
+    pub fn schedule(&self, path: String) {
+        self.state.lock().unwrap().schedule(path, Instant::now());
+        self.cvar.notify_one();
+    }
+
+    pub fn invalidate(&self, path: &str) -> ThumbnailRevision {
+        let token = self.state.lock().unwrap().invalidate(path);
+        self.cvar.notify_all();
+        token
+    }
+
+    pub fn arm_deferred(&self, path: String, token: ThumbnailRevision) {
+        self.state
+            .lock()
+            .unwrap()
+            .arm_deferred(path, token, Instant::now());
+        self.cvar.notify_one();
+    }
+
+    pub fn note_editor_activity(&self) {
+        self.state
+            .lock()
+            .unwrap()
+            .note_editor_activity(Instant::now());
+        self.cvar.notify_all();
+    }
+
+    pub fn wait_for_ready(&self) -> AdjustedThumbnailJob {
+        let mut state = self.state.lock().unwrap();
+        loop {
+            let now = Instant::now();
+            if let Some(path) = state.take_ready(now) {
+                return path;
+            }
+
+            state = if let Some(wait_duration) = state.wait_duration(now) {
+                self.cvar.wait_timeout(state, wait_duration).unwrap().0
+            } else {
+                self.cvar.wait(state).unwrap()
+            };
+        }
+    }
+
+    pub fn is_current(&self, job: &AdjustedThumbnailJob) -> bool {
+        self.state.lock().unwrap().is_current(job)
+    }
+
+    pub fn snapshot_revision(&self, path: &str) -> ThumbnailRevision {
+        self.state.lock().unwrap().snapshot(path)
+    }
+
+    pub fn revision_is_current(&self, path: &str, revision: ThumbnailRevision) -> bool {
+        self.snapshot_revision(path) == revision
+    }
+
+    pub fn requeue(&self, job: &AdjustedThumbnailJob, delay: Duration) {
+        self.state
+            .lock()
+            .unwrap()
+            .requeue(job, Instant::now(), delay);
+        self.cvar.notify_one();
+    }
+
+    pub fn cancel_all(&self) {
+        self.state.lock().unwrap().cancel_all();
+        self.cvar.notify_all();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum GpuWorkPriority {
+    Export,
+    Background,
+    VisibleThumbnail,
+    SelectedThumbnail,
+    Interactive,
+}
+
+impl GpuWorkPriority {
+    const COUNT: usize = 5;
+
+    fn index(self) -> usize {
+        self as usize
+    }
+}
+
+struct GpuWorkQueueState {
+    active: bool,
+    waiting: [usize; GpuWorkPriority::COUNT],
+}
+
+impl GpuWorkQueueState {
+    fn can_acquire(&self, priority: GpuWorkPriority) -> bool {
+        !self.active
+            && self.waiting[(priority.index() + 1)..]
+                .iter()
+                .all(|count| *count == 0)
+    }
+}
+
+pub struct GpuWorkScheduler {
+    state: Mutex<GpuWorkQueueState>,
+    cvar: Condvar,
+}
+
+impl GpuWorkScheduler {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(GpuWorkQueueState {
+                active: false,
+                waiting: [0; GpuWorkPriority::COUNT],
+            }),
+            cvar: Condvar::new(),
+        })
+    }
+
+    pub fn ticket(self: &Arc<Self>, priority: GpuWorkPriority) -> GpuWorkTicket {
+        let priority_index = priority.index();
+        self.state.lock().unwrap().waiting[priority_index] += 1;
+        self.cvar.notify_all();
+        GpuWorkTicket {
+            scheduler: Some(Arc::clone(self)),
+            priority,
+        }
+    }
+
+    pub fn acquire(self: &Arc<Self>, priority: GpuWorkPriority) -> GpuWorkPermit {
+        self.ticket(priority).acquire()
+    }
+}
+
+pub struct GpuWorkTicket {
+    scheduler: Option<Arc<GpuWorkScheduler>>,
+    priority: GpuWorkPriority,
+}
+
+impl GpuWorkTicket {
+    pub fn acquire(mut self) -> GpuWorkPermit {
+        let scheduler = self.scheduler.take().unwrap();
+        let priority_index = self.priority.index();
+        let mut state = scheduler.state.lock().unwrap();
+
+        while !state.can_acquire(self.priority) {
+            state = scheduler.cvar.wait(state).unwrap();
+        }
+
+        state.waiting[priority_index] -= 1;
+        state.active = true;
+        drop(state);
+        GpuWorkPermit { scheduler }
+    }
+}
+
+impl Drop for GpuWorkTicket {
+    fn drop(&mut self) {
+        if let Some(scheduler) = self.scheduler.take() {
+            let mut state = scheduler.state.lock().unwrap();
+            state.waiting[self.priority.index()] -= 1;
+            drop(state);
+            scheduler.cvar.notify_all();
+        }
+    }
+}
+
+pub struct GpuWorkPermit {
+    scheduler: Arc<GpuWorkScheduler>,
+}
+
+impl Drop for GpuWorkPermit {
+    fn drop(&mut self) {
+        let mut state = self.scheduler.state.lock().unwrap();
+        state.active = false;
+        drop(state);
+        self.scheduler.cvar.notify_all();
+    }
+}
+
 pub type ThumbnailGeometryEntry = (u64, Arc<DynamicImage>, f32);
 pub type TransformedImageCache = (u64, Arc<DynamicImage>, (f32, f32));
 
@@ -170,8 +506,180 @@ pub struct AppState {
     pub full_transformed_cache: Mutex<Option<TransformedImageCache>>,
     pub decoded_image_cache: Mutex<DecodedImageCache>,
     pub thumbnail_manager: Arc<ThumbnailManager>,
+    pub adjusted_thumbnail_manager: Arc<AdjustedThumbnailManager>,
     pub metadata_manager: Arc<MetadataManager>,
+    pub gpu_work_scheduler: Arc<GpuWorkScheduler>,
     pub disks_cache: Mutex<Option<Disks>>,
     pub disks_cache_refreshing: AtomicBool,
     pub camera_session: Mutex<CameraSession>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc;
+
+    #[test]
+    fn adjusted_thumbnail_saves_coalesce_by_path() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+
+        state.schedule("one.raw".to_string(), now);
+        state.schedule("one.raw".to_string(), now + Duration::from_millis(250));
+
+        assert_eq!(state.pending.len(), 1);
+        assert!(
+            state
+                .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY)
+                .is_none()
+        );
+        let job = state
+            .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY + Duration::from_millis(250))
+            .unwrap();
+        assert_eq!(job.path(), "one.raw");
+    }
+
+    #[test]
+    fn editor_activity_postpones_adjusted_thumbnail_work() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        state.schedule("one.raw".to_string(), now);
+        state.note_editor_activity(now + Duration::from_millis(1_000));
+
+        assert!(
+            state
+                .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY)
+                .is_none()
+        );
+        let job = state
+            .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY + Duration::from_millis(1_000))
+            .unwrap();
+        assert_eq!(job.path(), "one.raw");
+    }
+
+    #[test]
+    fn newest_ready_adjusted_thumbnail_runs_first() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        state.schedule("older.raw".to_string(), now);
+        state.schedule("selected.raw".to_string(), now + Duration::from_millis(10));
+
+        let job = state
+            .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY + Duration::from_millis(10))
+            .unwrap();
+        assert_eq!(job.path(), "selected.raw");
+    }
+
+    #[test]
+    fn virtual_copy_thumbnail_revisions_are_independent() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        let base_revision = state.schedule("one.raw".to_string(), now);
+        let copy_revision = state.schedule("one.raw?vc=copy".to_string(), now);
+
+        state.schedule("one.raw".to_string(), now + Duration::from_millis(1));
+
+        assert_ne!(state.snapshot("one.raw"), base_revision);
+        assert_eq!(state.snapshot("one.raw?vc=copy"), copy_revision);
+    }
+
+    #[test]
+    fn newer_save_invalidates_an_inflight_adjusted_thumbnail() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        state.schedule("one.raw".to_string(), now);
+        let inflight = state
+            .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY)
+            .unwrap();
+
+        state.schedule(
+            "one.raw".to_string(),
+            now + ADJUSTED_THUMBNAIL_IDLE_DELAY + Duration::from_millis(1),
+        );
+
+        assert!(!state.is_current(&inflight));
+        assert_eq!(state.pending.len(), 1);
+    }
+
+    #[test]
+    fn cancellation_invalidates_pending_and_inflight_jobs() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        state.schedule("one.raw".to_string(), now);
+        let inflight = state
+            .take_ready(now + ADJUSTED_THUMBNAIL_IDLE_DELAY)
+            .unwrap();
+        state.schedule("two.raw".to_string(), now);
+
+        state.cancel_all();
+
+        assert!(!state.is_current(&inflight));
+        assert!(state.pending.is_empty());
+    }
+
+    #[test]
+    fn cancellation_invalidates_unedited_visible_thumbnail_tokens() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        let visible_worker_token = state.snapshot("never-edited.raw");
+
+        state.cancel_all();
+
+        assert_ne!(state.snapshot("never-edited.raw"), visible_worker_token);
+    }
+
+    #[test]
+    fn invalidation_precedes_persistence_and_arming() {
+        let now = Instant::now();
+        let mut state = AdjustedThumbnailQueueState::new(now);
+        let old_visible_worker_token = state.snapshot("one.raw");
+        let save_token = state.invalidate("one.raw");
+
+        assert_ne!(state.snapshot("one.raw"), old_visible_worker_token);
+        assert!(state.pending.is_empty());
+
+        state.arm_deferred("one.raw".to_string(), save_token, now);
+        assert_eq!(state.pending.len(), 1);
+    }
+
+    #[test]
+    fn gpu_scheduler_prefers_higher_waiting_priorities() {
+        let mut state = GpuWorkQueueState {
+            active: false,
+            waiting: [0; GpuWorkPriority::COUNT],
+        };
+        state.waiting[GpuWorkPriority::VisibleThumbnail.index()] = 1;
+        state.waiting[GpuWorkPriority::Interactive.index()] = 1;
+
+        assert!(!state.can_acquire(GpuWorkPriority::VisibleThumbnail));
+        assert!(state.can_acquire(GpuWorkPriority::Interactive));
+    }
+
+    #[test]
+    fn queued_interactive_ticket_acquires_before_background() {
+        let scheduler = GpuWorkScheduler::new();
+        let initial_permit = scheduler.acquire(GpuWorkPriority::Background);
+        let background_ticket = scheduler.ticket(GpuWorkPriority::Background);
+        let interactive_ticket = scheduler.ticket(GpuWorkPriority::Interactive);
+        let (acquired_tx, acquired_rx) = mpsc::channel();
+
+        let background_tx = acquired_tx.clone();
+        let background_thread = std::thread::spawn(move || {
+            let _permit = background_ticket.acquire();
+            background_tx.send("background").unwrap();
+        });
+        let interactive_thread = std::thread::spawn(move || {
+            let _permit = interactive_ticket.acquire();
+            acquired_tx.send("interactive").unwrap();
+        });
+
+        drop(initial_permit);
+
+        assert_eq!(
+            acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            "interactive"
+        );
+        interactive_thread.join().unwrap();
+        background_thread.join().unwrap();
+    }
 }

--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -28,8 +28,8 @@ use crate::image_loader::{
 };
 use crate::image_processing::{
     AllAdjustments, Crop, GpuContext, RenderRequest, downscale_f32_image,
-    get_all_adjustments_from_json, get_or_init_gpu_context, process_and_get_dynamic_image,
-    resolve_tonemapper_override_from_handle,
+    get_all_adjustments_from_json, get_or_init_gpu_context,
+    process_and_get_dynamic_image_for_export, resolve_tonemapper_override_from_handle,
 };
 use crate::lut_processing::{
     convert_image_to_cube_lut, generate_identity_lut_image, get_or_load_lut,
@@ -448,7 +448,7 @@ fn process_image_for_export_pipeline(
 
     let unique_hash = calculate_full_job_hash(path, js_adjustments);
 
-    process_and_get_dynamic_image(
+    process_and_get_dynamic_image_for_export(
         context,
         state,
         transformed_image.as_ref(),
@@ -733,7 +733,7 @@ fn export_masks_for_image(
             let full_white_mask = ImageBuffer::from_fn(img_w, img_h, |_, _| Luma([255u8]));
             let single_bitmaps: Vec<ImageBuffer<Luma<u8>, Vec<u8>>> = vec![full_white_mask];
 
-            let processed = process_and_get_dynamic_image(
+            let processed = process_and_get_dynamic_image_for_export(
                 context,
                 state,
                 transformed_image.as_ref(),
@@ -833,7 +833,7 @@ fn export_adjustments_as_lut(
     let lut = lut_path.and_then(|p| get_or_load_lut(state, p).ok());
     let unique_hash = calculate_full_job_hash(source_path_str, js_adjustments);
 
-    let processed_lut = process_and_get_dynamic_image(
+    let processed_lut = process_and_get_dynamic_image_for_export(
         context,
         state,
         &identity_image,
@@ -1518,7 +1518,7 @@ pub async fn estimate_export_sizes(
         let unique_hash =
             calculate_full_job_hash(&loaded_image.path, &adjustments_clone).wrapping_add(1);
 
-        let processed_preview = process_and_get_dynamic_image(
+        let processed_preview = process_and_get_dynamic_image_for_export(
             &context,
             &state,
             &preview_image,
@@ -1656,7 +1656,7 @@ pub async fn estimate_export_sizes(
         let unique_hash =
             calculate_full_job_hash(&source_path_str, &js_adjustments).wrapping_add(1);
 
-        let processed_preview = process_and_get_dynamic_image(
+        let processed_preview = process_and_get_dynamic_image_for_export(
             &context,
             &state,
             &preview_base,

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::thread;
+use std::time::Duration;
 
 use anyhow::Result;
 use chrono::{DateTime, Utc};
@@ -25,7 +26,6 @@ use tauri::{AppHandle, Emitter, Manager};
 use uuid::Uuid;
 use walkdir::WalkDir;
 
-use crate::AppState;
 use crate::PendingMetadata;
 #[cfg(target_os = "android")]
 use crate::android_integration::*;
@@ -43,6 +43,7 @@ use crate::image_processing::{
 use crate::mask_generation::MaskDefinition;
 use crate::preset_converter;
 use crate::tagging::COLOR_TAG_PREFIX;
+use crate::{AppState, GpuWorkPriority};
 
 fn resolve_thumbnail_cache_dir(app_handle: &AppHandle) -> std::result::Result<PathBuf, String> {
     let cache_dir = app_handle
@@ -1453,6 +1454,7 @@ pub fn generate_thumbnail_data(
     gpu_context: Option<&GpuContext>,
     preloaded_image: Option<&DynamicImage>,
     app_handle: &AppHandle,
+    gpu_priority: GpuWorkPriority,
 ) -> anyhow::Result<DynamicImage> {
     let (source_path, sidecar_path) = parse_virtual_path(path_str);
     let source_path_str = source_path.to_string_lossy().to_string();
@@ -1706,7 +1708,7 @@ pub fn generate_thumbnail_data(
         meta.adjustments.to_string().hash(&mut hasher);
         let unique_hash = hasher.finish();
 
-        if let Ok(processed_image) = gpu_processing::process_and_get_dynamic_image(
+        if let Ok(processed_image) = gpu_processing::process_and_get_dynamic_image_with_priority(
             context,
             &state,
             cropped_preview.as_ref(),
@@ -1718,6 +1720,7 @@ pub fn generate_thumbnail_data(
                 roi: None,
             },
             "generate_thumbnail_data",
+            gpu_priority,
         ) {
             return Ok(processed_image);
         } else {
@@ -1778,14 +1781,29 @@ fn encode_thumbnail(image: &DynamicImage, target_width: u32) -> Result<Vec<u8>> 
     Ok(buf.into_inner())
 }
 
+#[derive(Clone, Copy)]
+struct ThumbnailGenerationOptions {
+    force_regenerate: bool,
+    gpu_priority: GpuWorkPriority,
+}
+
+impl ThumbnailGenerationOptions {
+    const fn new(force_regenerate: bool, gpu_priority: GpuWorkPriority) -> Self {
+        Self {
+            force_regenerate,
+            gpu_priority,
+        }
+    }
+}
+
 fn generate_single_thumbnail_and_cache(
     path_str: &str,
     thumb_cache_dir: &Path,
     gpu_context: Option<&GpuContext>,
     preloaded_image: Option<&DynamicImage>,
-    force_regenerate: bool,
     app_handle: &AppHandle,
     settings: &AppSettings,
+    options: ThumbnailGenerationOptions,
 ) -> Option<(String, String, u8, bool)> {
     let (source_path, sidecar_path) = parse_virtual_path(path_str);
 
@@ -1818,7 +1836,7 @@ fn generate_single_thumbnail_and_cache(
     let small_path = thumb_cache_dir.join(format!("{}_small.jpg", cache_hash));
     let medium_path = thumb_cache_dir.join(format!("{}_medium.jpg", cache_hash));
 
-    if !force_regenerate && small_path.exists() && medium_path.exists() {
+    if !options.force_regenerate && small_path.exists() && medium_path.exists() {
         return Some((
             small_path.to_string_lossy().into_owned(),
             medium_path.to_string_lossy().into_owned(),
@@ -1834,13 +1852,16 @@ fn generate_single_thumbnail_and_cache(
     let target_width_small = settings.small_thumbnail_resolution.unwrap_or(480);
     let target_width_medium = settings.medium_thumbnail_resolution.unwrap_or(1280);
 
-    if let Ok(thumb_image) =
-        generate_thumbnail_data(path_str, gpu_context, preloaded_image, app_handle)
-        && let (Ok(small_data), Ok(medium_data)) = (
-            encode_thumbnail(&thumb_image, target_width_small),
-            encode_thumbnail(&thumb_image, target_width_medium),
-        )
-    {
+    if let Ok(thumb_image) = generate_thumbnail_data(
+        path_str,
+        gpu_context,
+        preloaded_image,
+        app_handle,
+        options.gpu_priority,
+    ) && let (Ok(small_data), Ok(medium_data)) = (
+        encode_thumbnail(&thumb_image, target_width_small),
+        encode_thumbnail(&thumb_image, target_width_medium),
+    ) {
         let _ = fs::write(&small_path, &small_data);
         let _ = fs::write(&medium_path, &medium_data);
         return Some((
@@ -1890,6 +1911,9 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                 };
 
                 let state = app_clone.state::<crate::AppState>();
+                let thumbnail_revision = state
+                    .adjusted_thumbnail_manager
+                    .snapshot_revision(&path_to_process);
                 let gpu_context =
                     crate::gpu_processing::get_or_init_gpu_context(&state, &app_clone).ok();
 
@@ -1906,12 +1930,16 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
                         &cache_dir,
                         gpu_context.as_ref(),
                         None,
-                        false,
                         &app_clone,
                         &current_settings,
+                        ThumbnailGenerationOptions::new(false, GpuWorkPriority::VisibleThumbnail),
                     );
 
-                    if let Some((small_path, medium_path, rating, is_edited)) = result {
+                    if state
+                        .adjusted_thumbnail_manager
+                        .revision_is_current(&path_to_process, thumbnail_revision)
+                        && let Some((small_path, medium_path, rating, is_edited)) = result
+                    {
                         emit_thumbnail_generated(
                             &app_clone,
                             &path_to_process,
@@ -1931,6 +1959,99 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
             }
         });
     }
+}
+
+pub fn start_adjusted_thumbnail_worker(app_handle: tauri::AppHandle) {
+    let state = app_handle.state::<crate::AppState>();
+    let manager = state.adjusted_thumbnail_manager.clone();
+    let thumbnail_manager = state.thumbnail_manager.clone();
+
+    thread::spawn(move || {
+        loop {
+            let job = manager.wait_for_ready();
+            if !manager.is_current(&job) {
+                continue;
+            }
+
+            let path = job.path().to_string();
+            {
+                let mut processing = thumbnail_manager.processing_now.lock().unwrap();
+                if processing.contains(&path) {
+                    drop(processing);
+                    manager.requeue(&job, Duration::from_millis(250));
+                    continue;
+                }
+                processing.insert(path.clone());
+            }
+
+            if !manager.is_current(&job) {
+                thumbnail_manager
+                    .processing_now
+                    .lock()
+                    .unwrap()
+                    .remove(&path);
+                continue;
+            }
+
+            let state = app_handle.state::<AppState>();
+            let preloaded_image = state
+                .original_image
+                .lock()
+                .unwrap()
+                .as_ref()
+                .filter(|loaded| loaded.path == path)
+                .map(|loaded| loaded.image.clone());
+            let gpu_context = gpu_processing::get_or_init_gpu_context(&state, &app_handle).ok();
+            let settings = load_settings(app_handle.clone()).unwrap_or_default();
+
+            let thumb_cache_dir = match resolve_thumbnail_cache_dir(&app_handle) {
+                Ok(dir) => dir,
+                Err(error) => {
+                    log::warn!(
+                        "Unable to initialize thumbnail cache directory for '{}': {}",
+                        path,
+                        error
+                    );
+                    emit_thumbnail_cache_setup_error(&app_handle, &path, &error);
+                    thumbnail_manager
+                        .processing_now
+                        .lock()
+                        .unwrap()
+                        .remove(&path);
+                    continue;
+                }
+            };
+
+            let result = generate_single_thumbnail_and_cache(
+                &path,
+                &thumb_cache_dir,
+                gpu_context.as_ref(),
+                preloaded_image.as_deref(),
+                &app_handle,
+                &settings,
+                ThumbnailGenerationOptions::new(false, GpuWorkPriority::SelectedThumbnail),
+            );
+
+            if manager.is_current(&job)
+                && let Some((small_path, medium_path, rating, is_edited)) = result
+            {
+                emit_thumbnail_generated(
+                    &app_handle,
+                    &path,
+                    &small_path,
+                    &medium_path,
+                    rating,
+                    is_edited,
+                );
+            }
+
+            thumbnail_manager
+                .processing_now
+                .lock()
+                .unwrap()
+                .remove(&path);
+        }
+    });
 }
 
 #[tauri::command]
@@ -2519,6 +2640,7 @@ pub fn save_metadata_and_update_thumbnail(
     app_handle: AppHandle,
     state: tauri::State<AppState>,
 ) -> Result<(), String> {
+    let thumbnail_revision = state.adjusted_thumbnail_manager.invalidate(&path);
     let (source_path, sidecar_path) = parse_virtual_path(&path);
 
     let mut metadata = crate::exif_processing::load_sidecar(&sidecar_path);
@@ -2545,65 +2667,9 @@ pub fn save_metadata_and_update_thumbnail(
         sync_metadata_to_xmp(&source_path, &metadata, create_if_missing);
     }
 
-    let loaded_image_lock = state.original_image.lock().unwrap();
-    let preloaded_image_option = if let Some(loaded_image) = loaded_image_lock.as_ref() {
-        if loaded_image.path == path {
-            Some(loaded_image.image.clone())
-        } else {
-            None
-        }
-    } else {
-        None
-    };
-    drop(loaded_image_lock);
-
-    let gpu_context = gpu_processing::get_or_init_gpu_context(&state, &app_handle).ok();
-    let app_handle_clone = app_handle.clone();
-    let path_clone = path.clone();
-
-    add_to_thumbnail_queue(&state, 1, &app_handle);
-
-    thread::spawn(move || {
-        let state = app_handle_clone.state::<AppState>();
-        let settings = load_settings(app_handle_clone.clone()).unwrap_or_default();
-
-        let thumb_cache_dir = match resolve_thumbnail_cache_dir(&app_handle_clone) {
-            Ok(dir) => dir,
-            Err(e) => {
-                log::warn!(
-                    "Unable to initialize thumbnail cache directory for '{}': {}",
-                    path_clone,
-                    e
-                );
-                emit_thumbnail_cache_setup_error(&app_handle_clone, &path_clone, &e);
-                increment_thumbnail_progress(&state, &app_handle_clone);
-                return;
-            }
-        };
-
-        let result = generate_single_thumbnail_and_cache(
-            &path_clone,
-            &thumb_cache_dir,
-            gpu_context.as_ref(),
-            preloaded_image_option.as_deref(),
-            true,
-            &app_handle_clone,
-            &settings,
-        );
-
-        if let Some((small_path, medium_path, rating, is_edited)) = result {
-            emit_thumbnail_generated(
-                &app_handle_clone,
-                &path_clone,
-                &small_path,
-                &medium_path,
-                rating,
-                is_edited,
-            );
-        }
-
-        increment_thumbnail_progress(&state, &app_handle_clone);
-    });
+    state
+        .adjusted_thumbnail_manager
+        .arm_deferred(path, thumbnail_revision);
 
     Ok(())
 }
@@ -2628,6 +2694,14 @@ pub async fn apply_adjustments_to_paths(
             .lock()
             .unwrap()
             .clone();
+        let adjusted_thumbnail_manager = app_handle
+            .state::<AppState>()
+            .adjusted_thumbnail_manager
+            .clone();
+        let thumbnail_revisions: HashMap<String, _> = paths
+            .iter()
+            .map(|path| (path.clone(), adjusted_thumbnail_manager.invalidate(path)))
+            .collect();
 
         paths.par_iter().for_each(|path| {
             let (_, sidecar_path) = parse_virtual_path(path);
@@ -2688,12 +2762,17 @@ pub async fn apply_adjustments_to_paths(
                 &thumb_cache_dir,
                 gpu_context.as_ref(),
                 None,
-                true,
                 &app_handle,
                 &settings,
+                ThumbnailGenerationOptions::new(true, GpuWorkPriority::Background),
             );
 
-            if let Some((small_path, medium_path, rating, is_edited)) = result {
+            let revision_is_current = thumbnail_revisions.get(path_str).is_some_and(|revision| {
+                adjusted_thumbnail_manager.revision_is_current(path_str, *revision)
+            });
+            if revision_is_current
+                && let Some((small_path, medium_path, rating, is_edited)) = result
+            {
                 emit_thumbnail_generated(
                     &app_handle,
                     path_str,
@@ -2723,6 +2802,14 @@ pub async fn reset_adjustments_for_paths(
         let settings = load_settings(app_handle.clone()).unwrap_or_default();
         let enable_xmp_sync = settings.enable_xmp_sync.unwrap_or(false);
         let create_xmp_if_missing = settings.create_xmp_if_missing.unwrap_or(false);
+        let adjusted_thumbnail_manager = app_handle
+            .state::<AppState>()
+            .adjusted_thumbnail_manager
+            .clone();
+        let thumbnail_revisions: HashMap<String, _> = paths
+            .iter()
+            .map(|path| (path.clone(), adjusted_thumbnail_manager.invalidate(path)))
+            .collect();
 
         paths.par_iter().for_each(|path| {
             let (_, sidecar_path) = parse_virtual_path(path);
@@ -2764,12 +2851,17 @@ pub async fn reset_adjustments_for_paths(
                 &thumb_cache_dir,
                 gpu_context.as_ref(),
                 None,
-                true,
                 &app_handle,
                 &settings,
+                ThumbnailGenerationOptions::new(true, GpuWorkPriority::Background),
             );
 
-            if let Some((small_path, medium_path, rating, is_edited)) = result {
+            let revision_is_current = thumbnail_revisions.get(path_str).is_some_and(|revision| {
+                adjusted_thumbnail_manager.revision_is_current(path_str, *revision)
+            });
+            if revision_is_current
+                && let Some((small_path, medium_path, rating, is_edited)) = result
+            {
                 emit_thumbnail_generated(
                     &app_handle,
                     path_str,
@@ -2816,8 +2908,10 @@ pub async fn apply_auto_adjustments_to_paths(
         };
 
         let gpu_context = gpu_processing::get_or_init_gpu_context(&state, &app_handle).ok();
+        let adjusted_thumbnail_manager = state.adjusted_thumbnail_manager.clone();
 
         paths.par_iter().for_each(|path| {
+            let thumbnail_revision = adjusted_thumbnail_manager.invalidate(path);
             let loaded_image: Option<DynamicImage> = (|| -> Result<DynamicImage, String> {
                 let (source_path, sidecar_path) = parse_virtual_path(path);
                 let source_path_str = source_path.to_string_lossy().to_string();
@@ -2881,12 +2975,14 @@ pub async fn apply_auto_adjustments_to_paths(
                 &thumb_cache_dir,
                 gpu_context.as_ref(),
                 loaded_image.as_ref(),
-                true,
                 &app_handle,
                 &settings,
+                ThumbnailGenerationOptions::new(true, GpuWorkPriority::Background),
             );
 
-            if let Some((small_path, medium_path, rating, is_edited)) = result {
+            if adjusted_thumbnail_manager.revision_is_current(path, thumbnail_revision)
+                && let Some((small_path, medium_path, rating, is_edited)) = result
+            {
                 emit_thumbnail_generated(
                     &app_handle,
                     path,
@@ -3601,7 +3697,13 @@ pub fn get_cached_or_generate_thumbnail_image(
             );
         }
 
-        let thumb_image = generate_thumbnail_data(path_str, gpu_context, None, app_handle)?;
+        let thumb_image = generate_thumbnail_data(
+            path_str,
+            gpu_context,
+            None,
+            app_handle,
+            GpuWorkPriority::Background,
+        )?;
         if let (Ok(small_data), Ok(medium_data)) = (
             encode_thumbnail(&thumb_image, target_width_small),
             encode_thumbnail(&thumb_image, target_width_medium),
@@ -3618,7 +3720,13 @@ pub fn get_cached_or_generate_thumbnail_image(
 
         Ok(thumb_image)
     } else {
-        generate_thumbnail_data(path_str, gpu_context, None, app_handle)
+        generate_thumbnail_data(
+            path_str,
+            gpu_context,
+            None,
+            app_handle,
+            GpuWorkPriority::Background,
+        )
     }
 }
 

--- a/src-tauri/src/gpu_processing.rs
+++ b/src-tauri/src/gpu_processing.rs
@@ -11,7 +11,7 @@ use wgpu::util::{DeviceExt, TextureDataOrder};
 
 use crate::image_processing::{AllAdjustments, GpuContext, MAX_MASKS};
 use crate::lut_processing::Lut;
-use crate::{AppState, GpuImageCache};
+use crate::{AppState, GpuImageCache, GpuWorkPriority, GpuWorkTicket};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Roi {
@@ -1593,6 +1593,27 @@ pub fn process_and_get_dynamic_image(
     request: RenderRequest,
     caller_id: &str,
 ) -> Result<DynamicImage, String> {
+    process_and_get_dynamic_image_with_priority(
+        context,
+        state,
+        base_image,
+        transform_hash,
+        request,
+        caller_id,
+        GpuWorkPriority::Background,
+    )
+}
+
+pub fn process_and_get_dynamic_image_with_priority(
+    context: &GpuContext,
+    state: &tauri::State<AppState>,
+    base_image: &DynamicImage,
+    transform_hash: u64,
+    request: RenderRequest,
+    caller_id: &str,
+    priority: GpuWorkPriority,
+) -> Result<DynamicImage, String> {
+    let _gpu_work_permit = state.gpu_work_scheduler.acquire(priority);
     process_and_get_dynamic_image_inner(
         context,
         state,
@@ -1602,6 +1623,47 @@ pub fn process_and_get_dynamic_image(
         caller_id,
         false,
         None,
+    )
+}
+
+pub fn process_and_get_dynamic_image_with_ticket(
+    context: &GpuContext,
+    state: &tauri::State<AppState>,
+    base_image: &DynamicImage,
+    transform_hash: u64,
+    request: RenderRequest,
+    caller_id: &str,
+    gpu_work_ticket: GpuWorkTicket,
+) -> Result<DynamicImage, String> {
+    let _gpu_work_permit = gpu_work_ticket.acquire();
+    process_and_get_dynamic_image_inner(
+        context,
+        state,
+        base_image,
+        transform_hash,
+        request,
+        caller_id,
+        false,
+        None,
+    )
+}
+
+pub fn process_and_get_dynamic_image_for_export(
+    context: &GpuContext,
+    state: &tauri::State<AppState>,
+    base_image: &DynamicImage,
+    transform_hash: u64,
+    request: RenderRequest,
+    caller_id: &str,
+) -> Result<DynamicImage, String> {
+    process_and_get_dynamic_image_with_priority(
+        context,
+        state,
+        base_image,
+        transform_hash,
+        request,
+        caller_id,
+        GpuWorkPriority::Export,
     )
 }
 
@@ -1615,7 +1677,9 @@ pub fn process_and_get_dynamic_image_with_analytics(
     caller_id: &str,
     output_to_display: bool,
     analytics_config: Option<crate::AnalyticsConfig>,
+    gpu_work_ticket: GpuWorkTicket,
 ) -> Result<DynamicImage, String> {
+    let _gpu_work_permit = gpu_work_ticket.acquire();
     process_and_get_dynamic_image_inner(
         context,
         state,

--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -15,7 +15,8 @@ use std::sync::Arc;
 
 pub use crate::gpu_processing::{
     RenderRequest, get_or_init_gpu_context, process_and_get_dynamic_image,
-    process_and_get_dynamic_image_with_analytics,
+    process_and_get_dynamic_image_for_export, process_and_get_dynamic_image_with_analytics,
+    process_and_get_dynamic_image_with_ticket,
 };
 use crate::{AppState, mask_generation::MaskDefinition};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,7 +90,8 @@ use crate::image_processing::{
     Crop, GeometryParams, RenderRequest, apply_coarse_rotation, apply_cpu_default_raw_processing,
     apply_flip, apply_geometry_warp, apply_linear_to_srgb, downscale_f32_image,
     get_all_adjustments_from_json, get_or_init_gpu_context, process_and_get_dynamic_image,
-    resolve_tonemapper_override, resolve_tonemapper_override_from_handle, warp_image_geometry,
+    process_and_get_dynamic_image_with_ticket, resolve_tonemapper_override,
+    resolve_tonemapper_override_from_handle, warp_image_geometry,
 };
 use crate::mask_generation::{
     MaskDefinition, generate_mask_bitmap, get_cached_or_generate_mask,
@@ -235,6 +236,7 @@ fn cancel_thumbnail_generation(
     state
         .thumbnail_cancellation_token
         .store(true, Ordering::SeqCst);
+    state.adjusted_thumbnail_manager.cancel_all();
 
     let mut tracker = state.thumbnail_progress.lock().unwrap();
     tracker.total = 0;
@@ -331,6 +333,7 @@ fn process_preview_job(
     request_analytics: bool,
     compute_waveform: bool,
     active_waveform_channel: Option<&str>,
+    gpu_work_ticket: GpuWorkTicket,
 ) -> Result<Vec<u8>, String> {
     let fn_start = std::time::Instant::now();
     let context = get_or_init_gpu_context(&state, app_handle)?;
@@ -520,6 +523,7 @@ fn process_preview_job(
             "apply_adjustments",
             use_wgpu_renderer,
             analytics_config,
+            gpu_work_ticket,
         );
 
     if let Ok(final_processed_image) = final_processed_image_result {
@@ -669,6 +673,7 @@ fn start_preview_worker(app_handle: tauri::AppHandle) {
                 job.request_analytics,
                 job.compute_waveform,
                 job.active_waveform_channel.as_deref(),
+                job.gpu_work_ticket,
             ) {
                 Ok(bytes) => {
                     let _ = responder.send(bytes);
@@ -694,6 +699,10 @@ async fn apply_adjustments(
     state: tauri::State<'_, AppState>,
 ) -> Result<Response, String> {
     let (tx, rx) = tokio::sync::oneshot::channel();
+    state.adjusted_thumbnail_manager.note_editor_activity();
+    let gpu_work_ticket = state
+        .gpu_work_scheduler
+        .ticket(GpuWorkPriority::Interactive);
 
     {
         let tx_guard = state.preview_worker_tx.lock().unwrap();
@@ -707,6 +716,7 @@ async fn apply_adjustments(
                 compute_waveform,
                 active_waveform_channel,
                 responder: tx,
+                gpu_work_ticket,
             };
             worker_tx
                 .send(job)
@@ -729,6 +739,10 @@ fn generate_uncropped_preview(
     app_handle: tauri::AppHandle,
 ) -> Result<(), String> {
     let context = get_or_init_gpu_context(&state, &app_handle)?;
+    state.adjusted_thumbnail_manager.note_editor_activity();
+    let gpu_work_ticket = state
+        .gpu_work_scheduler
+        .ticket(GpuWorkPriority::Interactive);
     let mut adjustments_clone = js_adjustments.clone();
     hydrate_adjustments(&state, &mut adjustments_clone);
 
@@ -820,7 +834,7 @@ fn generate_uncropped_preview(
         let lut_path = adjustments_clone["lutPath"].as_str();
         let lut = lut_path.and_then(|p| lut_processing::get_or_load_lut(&state, p).ok());
 
-        if let Ok(processed_image) = process_and_get_dynamic_image(
+        if let Ok(processed_image) = process_and_get_dynamic_image_with_ticket(
             &context,
             &state,
             &processing_base,
@@ -832,6 +846,7 @@ fn generate_uncropped_preview(
                 roi: None,
             },
             "generate_uncropped_preview",
+            gpu_work_ticket,
         ) {
             let (width, height) = processed_image.dimensions();
             let rgb_pixels = processed_image.to_rgb8().into_vec();
@@ -862,6 +877,7 @@ async fn preview_geometry_transform(
     state: tauri::State<'_, AppState>,
     app_handle: tauri::AppHandle,
 ) -> Result<String, String> {
+    state.adjusted_thumbnail_manager.note_editor_activity();
     let (loaded_image_path, is_raw) = {
         let guard = state.original_image.lock().unwrap();
         let loaded = guard.as_ref().ok_or("No image loaded")?;
@@ -881,6 +897,9 @@ async fn preview_geometry_transform(
         if let Some(cached_image) = maybe_cached_image {
             cached_image
         } else {
+            let gpu_work_ticket = state
+                .gpu_work_scheduler
+                .ticket(GpuWorkPriority::Interactive);
             let context = get_or_init_gpu_context(&state, &app_handle)?;
 
             let original_image = {
@@ -938,7 +957,7 @@ async fn preview_geometry_transform(
             let lut = lut_path.and_then(|p| lut_processing::get_or_load_lut(&state, p).ok());
             let mask_bitmaps = Vec::new();
 
-            let processed_base = process_and_get_dynamic_image(
+            let processed_base = process_and_get_dynamic_image_with_ticket(
                 &context,
                 &state,
                 &preview_base,
@@ -950,6 +969,7 @@ async fn preview_geometry_transform(
                     roi: None,
                 },
                 "preview_geometry_transform_base_gen",
+                gpu_work_ticket,
             )?;
 
             let mut cache = state.geometry_cache.lock().unwrap();
@@ -1486,6 +1506,13 @@ async fn generate_preview_for_path(
     js_adjustments: Value,
     app_handle: tauri::AppHandle,
 ) -> Result<Response, String> {
+    let gpu_work_ticket = {
+        let state = app_handle.state::<AppState>();
+        state.adjusted_thumbnail_manager.note_editor_activity();
+        state
+            .gpu_work_scheduler
+            .ticket(GpuWorkPriority::Interactive)
+    };
     tokio::task::spawn_blocking(move || {
         let state = app_handle.state::<AppState>();
         let context = get_or_init_gpu_context(&state, &app_handle)?;
@@ -1553,7 +1580,7 @@ async fn generate_preview_for_path(
         let lut = lut_path.and_then(|p| lut_processing::get_or_load_lut(&state, p).ok());
         let unique_hash = calculate_full_job_hash(&source_path_str, &js_adjustments);
 
-        let final_image = process_and_get_dynamic_image(
+        let final_image = process_and_get_dynamic_image_with_ticket(
             &context,
             &state,
             transformed_image.as_ref(),
@@ -1565,6 +1592,7 @@ async fn generate_preview_for_path(
                 roi: None,
             },
             "generate_preview_for_path",
+            gpu_work_ticket,
         )?;
 
         let (width, height) = final_image.dimensions();
@@ -2054,6 +2082,7 @@ pub fn run() {
             start_preview_worker(app_handle.clone());
             start_analytics_worker(app_handle.clone());
             file_management::start_thumbnail_workers(app_handle.clone());
+            file_management::start_adjusted_thumbnail_worker(app_handle.clone());
             file_management::start_metadata_workers(app_handle.clone());
             jxl_oxide::integration::register_image_decoding_hook();
 
@@ -2250,7 +2279,9 @@ pub fn run() {
             full_transformed_cache: Mutex::new(None),
             decoded_image_cache: Mutex::new(DecodedImageCache::new(5)),
             thumbnail_manager: ThumbnailManager::new(),
+            adjusted_thumbnail_manager: AdjustedThumbnailManager::new(),
             metadata_manager: MetadataManager::new(),
+            gpu_work_scheduler: GpuWorkScheduler::new(),
             disks_cache: Mutex::new(None),
             disks_cache_refreshing: AtomicBool::new(false),
             camera_session: Mutex::new(camera_tethering::CameraSession::new()),

--- a/src/hooks/useAppNavigation.ts
+++ b/src/hooks/useAppNavigation.ts
@@ -265,6 +265,7 @@ export function useAppNavigation({ clearThumbnailQueue, refs }: AppNavigationPro
       const libraryViewMode = appSettings?.libraryViewMode;
 
       if (!preserveEditor) {
+        await debouncedSave.flush();
         await invoke('cancel_thumbnail_generation');
         clearThumbnailQueue();
         setLibrary({ isViewLoading: true, activeAlbumId: null, libraryScrollTop: 0 });
@@ -312,7 +313,6 @@ export function useAppNavigation({ clearThumbnailQueue, refs }: AppNavigationPro
         });
 
         if (!preserveEditor && selectedImage) {
-          debouncedSave.flush();
           debouncedSetHistory.cancel();
           setEditor({ selectedImage: null, finalPreviewUrl: null, uncroppedAdjustedPreviewUrl: null, histogram: null });
           setEditor({ adjustments: INITIAL_ADJUSTMENTS });
@@ -415,6 +415,7 @@ export function useAppNavigation({ clearThumbnailQueue, refs }: AppNavigationPro
       const { setUI } = useUIStore.getState();
 
       if (!preserveEditor) {
+        await debouncedSave.flush();
         await invoke('cancel_thumbnail_generation');
         clearThumbnailQueue();
         setLibrary({ libraryScrollTop: 0 });

--- a/src/hooks/useEditorActions.ts
+++ b/src/hooks/useEditorActions.ts
@@ -23,7 +23,7 @@ export const debouncedSetHistory = debounce((newAdj: Adjustments) => {
 }, 500);
 
 export const debouncedSave = debounce((path: string, adjustmentsToSave: Adjustments) => {
-  invoke(Invokes.SaveMetadataAndUpdateThumbnail, { path, adjustments: adjustmentsToSave }).catch((err) => {
+  return invoke(Invokes.SaveMetadataAndUpdateThumbnail, { path, adjustments: adjustmentsToSave }).catch((err) => {
     console.error('Auto-save failed:', err);
     toast.error(`Failed to save changes: ${err}`);
   });


### PR DESCRIPTION
## Summary

- keep the existing 300 ms sidecar autosave, but coalesce adjusted-thumbnail refreshes until the editor has been idle for 1.5 seconds
- prioritize queued GPU work as interactive editor, selected thumbnail, visible thumbnail, background work, then export
- register editor priority before preview preparation so queued thumbnail work cannot jump ahead
- suppress stale thumbnail events across edits, batch operations, cancellations, and folder/album navigation
- flush the pending metadata save before cancelling old-folder thumbnail work

## Validation

- `cargo test --manifest-path src-tauri/Cargo.toml` (10 passed)
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --all-features -- -D warnings`
- `npm run build`
- `npx prettier --check src/hooks/useAppNavigation.ts src/hooks/useEditorActions.ts`

The repository-wide TypeScript and ESLint checks still surface pre-existing errors on `main`; neither reports a new error on the changed lines.
