### PR TITLE
Bound decoded-image cache memory and deprioritize ingest threads

### DIFF
--- a/src-tauri/src/cache_utils.rs
+++ b/src-tauri/src/cache_utils.rs
@@ -1,5 +1,7 @@
 use crate::AppState;
-use image::DynamicImage;
+use half::f16;
+use image::{DynamicImage, GenericImageView, Rgb32FImage, Rgba32FImage};
+use rayon::prelude::*;
 use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -228,39 +230,142 @@ pub fn calculate_full_job_hash(path: &str, adjustments: &serde_json::Value) -> u
     hasher.finish()
 }
 
+/// Upper bound in bytes for the decoded-image cache, derived from physical RAM.
+///
+/// Eviction previously ran on item count alone, so a handful of large RAWs
+/// (a 60-megapixel image is ~700 MB once decoded to f32) could pin several
+/// gigabytes and push lower-RAM machines into swap. An eighth of physical RAM,
+/// clamped to [256 MB, 4 GB], bounds that without shrinking the cache on
+/// machines that have memory to spare.
+fn default_byte_budget() -> usize {
+    let mut sys = sysinfo::System::new();
+    sys.refresh_memory();
+    let budget = (sys.total_memory() / 8).clamp(256 * 1024 * 1024, 4 * 1024 * 1024 * 1024);
+    usize::try_from(budget).unwrap_or(usize::MAX)
+}
+
+/// Cached pixels are stored at half precision: a cached original is only read
+/// back when the user returns to a recently viewed photo, and the GPU pipeline
+/// already samples it through Rgba16Float textures, so keeping the cache at
+/// f32 doubles its footprint without changing what gets rendered. Images that
+/// are not f32 (already compact) are kept as-is.
+enum CachedPixels {
+    RgbF16(Vec<f16>),
+    RgbaF16(Vec<f16>),
+    Original(Arc<DynamicImage>),
+}
+
+struct CachedImage {
+    width: u32,
+    height: u32,
+    pixels: CachedPixels,
+    byte_size: usize,
+}
+
+impl CachedImage {
+    fn new(image: &Arc<DynamicImage>) -> Self {
+        let (width, height) = image.dimensions();
+        match image.as_ref() {
+            DynamicImage::ImageRgb32F(buffer) => {
+                let data: Vec<f16> = buffer
+                    .as_raw()
+                    .par_iter()
+                    .map(|v| f16::from_f32(*v))
+                    .collect();
+                let byte_size = data.len() * size_of::<f16>();
+                Self {
+                    width,
+                    height,
+                    pixels: CachedPixels::RgbF16(data),
+                    byte_size,
+                }
+            }
+            DynamicImage::ImageRgba32F(buffer) => {
+                let data: Vec<f16> = buffer
+                    .as_raw()
+                    .par_iter()
+                    .map(|v| f16::from_f32(*v))
+                    .collect();
+                let byte_size = data.len() * size_of::<f16>();
+                Self {
+                    width,
+                    height,
+                    pixels: CachedPixels::RgbaF16(data),
+                    byte_size,
+                }
+            }
+            _ => {
+                let byte_size = image.as_bytes().len();
+                Self {
+                    width,
+                    height,
+                    pixels: CachedPixels::Original(image.clone()),
+                    byte_size,
+                }
+            }
+        }
+    }
+
+    fn to_image(&self) -> Arc<DynamicImage> {
+        match &self.pixels {
+            CachedPixels::RgbF16(data) => {
+                let raw: Vec<f32> = data.par_iter().map(|v| v.to_f32()).collect();
+                let buffer = Rgb32FImage::from_raw(self.width, self.height, raw)
+                    .expect("cached pixel count matches cached dimensions");
+                Arc::new(DynamicImage::ImageRgb32F(buffer))
+            }
+            CachedPixels::RgbaF16(data) => {
+                let raw: Vec<f32> = data.par_iter().map(|v| v.to_f32()).collect();
+                let buffer = Rgba32FImage::from_raw(self.width, self.height, raw)
+                    .expect("cached pixel count matches cached dimensions");
+                Arc::new(DynamicImage::ImageRgba32F(buffer))
+            }
+            CachedPixels::Original(image) => image.clone(),
+        }
+    }
+}
+
 pub struct DecodedImageCache {
     capacity: usize,
-    items: Vec<(String, Arc<DynamicImage>, HashMap<String, String>)>,
+    byte_budget: usize,
+    total_bytes: usize,
+    items: Vec<(String, CachedImage, HashMap<String, String>)>,
 }
 
 impl DecodedImageCache {
     pub fn new(capacity: usize) -> Self {
+        Self::with_byte_budget(capacity, default_byte_budget())
+    }
+
+    fn with_byte_budget(capacity: usize, byte_budget: usize) -> Self {
         Self {
             capacity,
+            byte_budget,
+            total_bytes: 0,
             items: Vec::with_capacity(capacity),
         }
     }
 
     pub fn set_capacity(&mut self, capacity: usize) {
         self.capacity = capacity;
-        while self.items.len() > self.capacity {
-            self.items.remove(0);
-        }
+        self.evict_to_limits();
+    }
+
+    pub fn contains(&self, path: &str) -> bool {
+        self.items.iter().any(|(p, _, _)| p == path)
     }
 
     pub fn get(&mut self, path: &str) -> Option<(Arc<DynamicImage>, HashMap<String, String>)> {
-        if let Some(pos) = self.items.iter().position(|(p, _, _)| p == path) {
-            let item = self.items.remove(pos);
-            let result = (item.1.clone(), item.2.clone());
-            self.items.push(item);
-            Some(result)
-        } else {
-            None
-        }
+        let pos = self.items.iter().position(|(p, _, _)| p == path)?;
+        let item = self.items.remove(pos);
+        let result = (item.1.to_image(), item.2.clone());
+        self.items.push(item);
+        Some(result)
     }
 
     pub fn clear(&mut self) {
         self.items.clear();
+        self.total_bytes = 0;
     }
 
     pub fn insert(
@@ -270,11 +375,36 @@ impl DecodedImageCache {
         exif: HashMap<String, String>,
     ) {
         if let Some(pos) = self.items.iter().position(|(p, _, _)| *p == path) {
-            self.items.remove(pos);
-        } else if self.items.len() >= self.capacity {
-            self.items.remove(0);
+            let (_, removed, _) = self.items.remove(pos);
+            self.total_bytes -= removed.byte_size;
         }
-        self.items.push((path, image, exif));
+        if self.capacity == 0 {
+            return;
+        }
+
+        let cached = CachedImage::new(&image);
+        if cached.byte_size > self.byte_budget {
+            log::debug!(
+                "Not caching '{}': {} MB exceeds the {} MB decoded-image cache budget",
+                path,
+                cached.byte_size / (1024 * 1024),
+                self.byte_budget / (1024 * 1024)
+            );
+            return;
+        }
+
+        self.total_bytes += cached.byte_size;
+        self.items.push((path, cached, exif));
+        self.evict_to_limits();
+    }
+
+    fn evict_to_limits(&mut self) {
+        while self.items.len() > self.capacity
+            || (self.total_bytes > self.byte_budget && !self.items.is_empty())
+        {
+            let (_, removed, _) = self.items.remove(0);
+            self.total_bytes -= removed.byte_size;
+        }
     }
 }
 
@@ -307,5 +437,81 @@ pub fn clear_session_caches(state: tauri::State<AppState>) {
     }
     if let Ok(mut geometry_cache) = state.geometry_cache.lock() {
         geometry_cache.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::Rgb;
+
+    fn rgb_f32_image(width: u32, height: u32) -> Arc<DynamicImage> {
+        let buffer = Rgb32FImage::from_fn(width, height, |x, y| {
+            let base = (x + y * width) as f32;
+            Rgb([base * 0.001, base * 0.0005 + 0.25, 4.0 + base * 0.01])
+        });
+        Arc::new(DynamicImage::ImageRgb32F(buffer))
+    }
+
+    fn f16_bytes(width: u32, height: u32) -> usize {
+        (width * height * 3) as usize * size_of::<f16>()
+    }
+
+    #[test]
+    fn count_eviction_is_least_recently_used() {
+        let mut cache = DecodedImageCache::with_byte_budget(2, usize::MAX);
+        cache.insert("a".into(), rgb_f32_image(8, 8), HashMap::new());
+        cache.insert("b".into(), rgb_f32_image(8, 8), HashMap::new());
+        assert!(cache.get("a").is_some());
+        cache.insert("c".into(), rgb_f32_image(8, 8), HashMap::new());
+        assert!(cache.contains("a"));
+        assert!(!cache.contains("b"));
+        assert!(cache.contains("c"));
+    }
+
+    #[test]
+    fn byte_budget_evicts_oldest_entries() {
+        let budget = f16_bytes(64, 64) * 2 + 16;
+        let mut cache = DecodedImageCache::with_byte_budget(10, budget);
+        cache.insert("a".into(), rgb_f32_image(64, 64), HashMap::new());
+        cache.insert("b".into(), rgb_f32_image(64, 64), HashMap::new());
+        cache.insert("c".into(), rgb_f32_image(64, 64), HashMap::new());
+        assert!(!cache.contains("a"));
+        assert!(cache.contains("b"));
+        assert!(cache.contains("c"));
+        assert!(cache.total_bytes <= budget);
+    }
+
+    #[test]
+    fn oversized_image_is_not_cached() {
+        let budget = f16_bytes(64, 64) - 1;
+        let mut cache = DecodedImageCache::with_byte_budget(10, budget);
+        cache.insert("big".into(), rgb_f32_image(64, 64), HashMap::new());
+        assert!(!cache.contains("big"));
+        assert_eq!(cache.total_bytes, 0);
+    }
+
+    #[test]
+    fn f16_roundtrip_stays_within_half_precision() {
+        let mut cache = DecodedImageCache::with_byte_budget(2, usize::MAX);
+        let original = rgb_f32_image(32, 32);
+        cache.insert("img".into(), original.clone(), HashMap::new());
+        let (restored, _) = cache.get("img").unwrap();
+
+        let original_buffer = original.to_rgb32f();
+        let restored_buffer = restored.to_rgb32f();
+        for (a, b) in original_buffer.iter().zip(restored_buffer.iter()) {
+            let tolerance = a.abs() * 1e-3 + 1e-6;
+            assert!((a - b).abs() <= tolerance, "{a} vs {b}");
+        }
+    }
+
+    #[test]
+    fn non_f32_images_are_stored_unconverted() {
+        let mut cache = DecodedImageCache::with_byte_budget(2, usize::MAX);
+        let rgb8 = Arc::new(DynamicImage::new_rgb8(16, 16));
+        cache.insert("u8".into(), rgb8.clone(), HashMap::new());
+        let (restored, _) = cache.get("u8").unwrap();
+        assert!(Arc::ptr_eq(&rgb8, &restored));
     }
 }

--- a/src-tauri/src/cache_utils.rs
+++ b/src-tauri/src/cache_utils.rs
@@ -493,14 +493,40 @@ mod tests {
 
     #[test]
     fn f16_roundtrip_stays_within_half_precision() {
-        let mut cache = DecodedImageCache::with_byte_budget(2, usize::MAX);
-        let original = rgb_f32_image(32, 32);
-        cache.insert("img".into(), original.clone(), HashMap::new());
-        let (restored, _) = cache.get("img").unwrap();
+        let mut cache = DecodedImageCache::with_byte_budget(4, usize::MAX);
+        // Deliberately non-square and portrait so a transposed width/height
+        // would change the restored geometry instead of silently passing.
+        for (width, height) in [(37u32, 91u32), (91, 37)] {
+            let original = rgb_f32_image(width, height);
+            let key = format!("{width}x{height}");
+            cache.insert(key.clone(), original.clone(), HashMap::new());
+            let (restored, _) = cache.get(&key).unwrap();
 
-        let original_buffer = original.to_rgb32f();
-        let restored_buffer = restored.to_rgb32f();
-        for (a, b) in original_buffer.iter().zip(restored_buffer.iter()) {
+            assert_eq!(restored.dimensions(), (width, height));
+
+            let original_buffer = original.to_rgb32f();
+            let restored_buffer = restored.to_rgb32f();
+            for (a, b) in original_buffer.iter().zip(restored_buffer.iter()) {
+                let tolerance = a.abs() * 1e-3 + 1e-6;
+                assert!((a - b).abs() <= tolerance, "{a} vs {b}");
+            }
+        }
+    }
+
+    #[test]
+    fn rgba_roundtrip_preserves_geometry_and_alpha() {
+        let mut cache = DecodedImageCache::with_byte_budget(2, usize::MAX);
+        let buffer = Rgba32FImage::from_fn(23, 61, |x, y| {
+            let base = (x + y * 23) as f32;
+            image::Rgba([base * 0.01, base * 0.02, base * 0.03, 0.5])
+        });
+        let original = Arc::new(DynamicImage::ImageRgba32F(buffer));
+        cache.insert("rgba".into(), original.clone(), HashMap::new());
+        let (restored, _) = cache.get("rgba").unwrap();
+
+        assert_eq!(restored.dimensions(), (23, 61));
+        let restored_buffer = restored.to_rgba32f();
+        for (a, b) in original.to_rgba32f().iter().zip(restored_buffer.iter()) {
             let tolerance = a.abs() * 1e-3 + 1e-6;
             assert!((a - b).abs() <= tolerance, "{a} vs {b}");
         }

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -151,6 +151,24 @@ fn enqueue_metadata(
     manager.cvar.notify_one();
 }
 
+/// Drops the calling thread to Utility quality-of-service on macOS.
+///
+/// Ingest work (thumbnail and metadata workers) can occupy every core at
+/// default QoS, competing with the UI and the preview pipeline for
+/// performance cores and, on unified memory, starving the GPU. Utility QoS
+/// marks the work as throughput-oriented so the scheduler steers it to
+/// efficiency cores and deprioritizes it under load. Other platforms have no
+/// direct equivalent, so this is a no-op there.
+#[cfg(target_os = "macos")]
+pub(crate) fn set_utility_thread_qos() {
+    unsafe {
+        libc::pthread_set_qos_class_self_np(libc::qos_class_t::QOS_CLASS_UTILITY, 0);
+    }
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn set_utility_thread_qos() {}
+
 // Not compute-heavy — these threads mostly block waiting on iCloud to
 // materialize a file, not burning CPU — so a small fixed pool is enough and
 // doesn't need a user-facing setting the way thumbnail_worker_threads does.
@@ -165,6 +183,7 @@ pub fn start_metadata_workers(app_handle: tauri::AppHandle) {
         let manager_clone = manager.clone();
 
         std::thread::spawn(move || {
+            set_utility_thread_qos();
             loop {
                 let item = {
                     let mut queue = manager_clone.queue.lock().unwrap();
@@ -1871,6 +1890,7 @@ pub fn start_thumbnail_workers(app_handle: tauri::AppHandle) {
         let manager_clone = manager.clone();
 
         std::thread::spawn(move || {
+            set_utility_thread_qos();
             loop {
                 let path_to_process: String = {
                     let mut queue = manager_clone.queue.lock().unwrap();
@@ -4217,5 +4237,30 @@ pub fn sync_metadata_to_xmp(source_path: &Path, metadata: &ImageMetadata, create
         }
 
         let _ = fs::write(&xmp_file, content);
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod qos_tests {
+    use super::set_utility_thread_qos;
+
+    #[test]
+    fn helper_sets_utility_qos_on_calling_thread() {
+        std::thread::spawn(|| {
+            set_utility_thread_qos();
+            let mut qos = libc::qos_class_t::QOS_CLASS_UNSPECIFIED;
+            let mut relative_priority = 0;
+            let result = unsafe {
+                libc::pthread_get_qos_class_np(
+                    libc::pthread_self(),
+                    &mut qos,
+                    &mut relative_priority,
+                )
+            };
+            assert_eq!(result, 0);
+            assert!(matches!(qos, libc::qos_class_t::QOS_CLASS_UTILITY));
+        })
+        .join()
+        .unwrap();
     }
 }

--- a/src-tauri/src/image_loader.rs
+++ b/src-tauri/src/image_loader.rs
@@ -828,8 +828,7 @@ pub fn is_image_cached(path: String, state: tauri::State<'_, AppState>) -> bool 
         .decoded_image_cache
         .lock()
         .unwrap()
-        .get(&source_path_str)
-        .is_some()
+        .contains(&source_path_str)
 }
 
 #[tauri::command]


### PR DESCRIPTION
## Description

The decoded-image cache evicted by item count alone and stored every entry as f32, so a handful of large RAWs could pin several gigabytes. A 48.8 MP image costs 559 MB once decoded to `Rgb32F`, and the default cache holds 5, so the cache alone can reach 2.9 GB before anything else is accounted for. On unified-memory Macs that also starves the GPU, which matches the reports in #515 and #521.

Three changes:

1. **Cache entries are stored at half precision.** Pixels convert to f16 on insert and back on read. The GPU pipeline already samples through `Rgba16Float` textures, so rendered output is unchanged. Images that are not f32 are stored untouched.
2. **Eviction enforces a byte budget as well as a count.** The budget is physical RAM divided by 8, clamped to [256 MB, 4 GB]. That is 3 GB on a 24 GB machine and 1 GB on an 8 GB machine, so low-RAM machines stop caching before they swap instead of always holding 5 entries regardless of size. An image larger than the whole budget is not cached.
3. **Thumbnail and metadata workers run at Utility QoS on macOS.** Folder ingest was saturating performance cores at default QoS. `set_utility_thread_qos` is a no-op on other platforms.

`is_image_cached` now calls a non-mutating `contains()`. It previously called `get()`, so a boolean probe reordered LRU position and, under this change, would have rebuilt pixels for a question that only needed a yes or no.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Build/CI or Dependency update

## Changes Made

- `cache_utils.rs`: `DecodedImageCache` stores `CachedImage` (f16 pixels plus dimensions and byte size), tracks total bytes, and evicts on both limits. Adds `contains()` and unit tests.
- `image_loader.rs`: `is_image_cached` uses `contains()`.
- `file_management.rs`: adds `set_utility_thread_qos`, called by the thumbnail and metadata workers.

## Testing

Measured on the hardware below, comparing this branch against `main` at 7ac8d50d.

**Cache footprint**, inserting seven 48.8 MP images into a 5-entry cache and reading `ri_phys_footprint`:

| | per image | process footprint |
| --- | --- | --- |
| `main` | 559 MB | 3356 MB |
| this branch | 280 MB | 2240 MB |

**Application run**, same 7-image folder opened, walked through, and revisited in both builds:

| | peak footprint | final footprint |
| --- | --- | --- |
| `main` | 6065 MB | 3026 MB |
| this branch | 5217 MB | 2570 MB |

**The cost.** A cache hit is no longer free, because pixels are rebuilt from f16:

| | time |
| --- | --- |
| cache hit before | 42 ns |
| cache hit now | 8 ms |
| full decode (cache miss) | 184-243 ms |

So a hit still avoids roughly 95% of the work a miss costs, and the 8 ms lands when switching to a previously viewed image, not during editing. The image being edited is held separately in `original_image` and never round-trips through the cache.

Seven unit tests cover LRU order, byte-budget eviction, the oversized-image case, f16 round-trip accuracy, non-f32 passthrough, and QoS assignment. The round-trip tests use non-square images in both orientations and assert restored dimensions, so a transposed width and height cannot pass.

Cross-platform: the only platform-specific code is `set_utility_thread_qos`. I verified the non-macOS branch compiles by forcing it active on macOS. Everything else uses existing unconditional dependencies (`half`, `rayon`, `sysinfo`, `image`). I could not build Windows or Linux locally, so CI is the real check there.

- [x] These changes were tested locally by a human and confirmed to work.
- [ ] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

**Test Configuration:**

- **OS:** macOS 26.6.2
- **Hardware:** Apple M5 Pro, 24 GB

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

`cargo fmt --check` and `cargo clippy` are clean on the changed files. The two `clippy` warnings in `exif_processing.rs` are pre-existing on `main`.

## Additional Notes

The byte budget is deliberately a fraction of RAM rather than a user setting, so the existing `imageCacheSize` preference keeps its meaning as a maximum. If you would rather expose the budget in settings, or pick a different fraction, I am happy to change it.

I left the two f16 conversions on rayon. They are ~22 ms on insert and ~8 ms on read for a 48.8 MP image, and both already run off the UI thread.

## AI Disclaimer:

Please state the involvement of AI in this PR:

- [x] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)

Written by Claude Code, directed and reviewed by the repository owner of the fork.
