### PR TITLE
Prewarm GPU pipelines and cancel obsolete preview frames

### DIFF
--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -62,6 +62,78 @@ pub struct GpuProcessorState {
     pub height: u32,
 }
 
+pub const PREVIEW_SUPERSEDED: &str = "Preview superseded";
+
+#[derive(Clone)]
+pub struct PreviewGeneration {
+    number: usize,
+    latest: Arc<AtomicUsize>,
+    commit: Arc<Mutex<()>>,
+}
+
+impl PreviewGeneration {
+    pub fn number(&self) -> usize {
+        self.number
+    }
+
+    pub fn is_current(&self) -> bool {
+        self.latest.load(std::sync::atomic::Ordering::Acquire) == self.number
+    }
+
+    pub fn ensure_current(&self) -> Result<(), String> {
+        if self.is_current() {
+            Ok(())
+        } else {
+            Err(PREVIEW_SUPERSEDED.to_string())
+        }
+    }
+
+    pub fn lock_commit(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.commit.lock().unwrap()
+    }
+}
+
+pub struct PreviewGenerationTracker {
+    latest: Arc<AtomicUsize>,
+    commit: Arc<Mutex<()>>,
+}
+
+impl Default for PreviewGenerationTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PreviewGenerationTracker {
+    pub fn new() -> Self {
+        Self {
+            latest: Arc::new(AtomicUsize::new(0)),
+            commit: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub fn next(&self) -> PreviewGeneration {
+        let _commit_guard = self.commit.lock().unwrap();
+        let number = self
+            .latest
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel)
+            .wrapping_add(1);
+        PreviewGeneration {
+            number,
+            latest: Arc::clone(&self.latest),
+            commit: Arc::clone(&self.commit),
+        }
+    }
+
+    pub fn snapshot(&self) -> PreviewGeneration {
+        PreviewGeneration {
+            number: self.latest.load(std::sync::atomic::Ordering::Acquire),
+            latest: Arc::clone(&self.latest),
+            commit: Arc::clone(&self.commit),
+        }
+    }
+}
+
 pub struct PreviewJob {
     pub adjustments: serde_json::Value,
     pub is_interactive: bool,
@@ -71,6 +143,7 @@ pub struct PreviewJob {
     pub compute_waveform: bool,
     pub active_waveform_channel: Option<String>,
     pub responder: tokio::sync::oneshot::Sender<Vec<u8>>,
+    pub generation: PreviewGeneration,
 }
 
 pub struct AnalyticsJob {
@@ -78,6 +151,7 @@ pub struct AnalyticsJob {
     pub image: Arc<DynamicImage>,
     pub compute_waveform: bool,
     pub active_waveform_channel: Option<String>,
+    pub generation: PreviewGeneration,
 }
 
 pub struct AnalyticsConfig {
@@ -85,6 +159,7 @@ pub struct AnalyticsConfig {
     pub compute_waveform: bool,
     pub active_waveform_channel: Option<String>,
     pub sender: Sender<AnalyticsJob>,
+    pub generation: PreviewGeneration,
 }
 
 pub struct ThumbnailProgressTracker {
@@ -159,6 +234,7 @@ pub struct AppState {
     pub thumbnail_cancellation_token: Arc<AtomicBool>,
     pub thumbnail_progress: Mutex<ThumbnailProgressTracker>,
     pub preview_worker_tx: Mutex<Option<Sender<PreviewJob>>>,
+    pub preview_generation: PreviewGenerationTracker,
     pub analytics_worker_tx: Mutex<Option<Sender<AnalyticsJob>>>,
     pub mask_cache: Mutex<HashMap<u64, GrayImage>>,
     pub patch_cache: Mutex<HashMap<String, serde_json::Value>>,
@@ -174,4 +250,57 @@ pub struct AppState {
     pub disks_cache: Mutex<Option<Disks>>,
     pub disks_cache_refreshing: AtomicBool,
     pub camera_session: Mutex<CameraSession>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn newer_preview_generation_supersedes_older_work() {
+        let tracker = PreviewGenerationTracker::new();
+        let first = tracker.next();
+        assert!(first.is_current());
+
+        let second = tracker.next();
+        assert!(!first.is_current());
+        assert!(second.is_current());
+        assert_eq!(first.ensure_current().unwrap_err(), PREVIEW_SUPERSEDED);
+    }
+
+    #[test]
+    fn snapshot_is_invalidated_when_preview_work_starts() {
+        let tracker = PreviewGenerationTracker::new();
+        let idle_snapshot = tracker.snapshot();
+        assert!(idle_snapshot.is_current());
+
+        let active = tracker.next();
+        assert!(!idle_snapshot.is_current());
+        assert!(active.is_current());
+    }
+
+    #[test]
+    fn generation_change_waits_for_frame_commit() {
+        let tracker = Arc::new(PreviewGenerationTracker::new());
+        let first = tracker.next();
+        let commit_guard = first.lock_commit();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let tracker_for_thread = Arc::clone(&tracker);
+
+        let handle = std::thread::spawn(move || {
+            let next = tracker_for_thread.next();
+            tx.send(next.number()).unwrap();
+        });
+
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(25))
+                .is_err()
+        );
+        drop(commit_guard);
+        assert_eq!(
+            rx.recv_timeout(std::time::Duration::from_secs(1)).unwrap(),
+            2
+        );
+        handle.join().unwrap();
+    }
 }

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -104,6 +104,12 @@ impl Default for PreviewGenerationTracker {
     }
 }
 
+#[derive(Clone)]
+pub struct PendingDisplayFrame {
+    pub path: String,
+    pub generation: PreviewGeneration,
+}
+
 impl PreviewGenerationTracker {
     pub fn new() -> Self {
         Self {
@@ -235,6 +241,7 @@ pub struct AppState {
     pub thumbnail_progress: Mutex<ThumbnailProgressTracker>,
     pub preview_worker_tx: Mutex<Option<Sender<PreviewJob>>>,
     pub preview_generation: PreviewGenerationTracker,
+    pub pending_display_frame: Mutex<Option<PendingDisplayFrame>>,
     pub analytics_worker_tx: Mutex<Option<Sender<AnalyticsJob>>>,
     pub mask_cache: Mutex<HashMap<u64, GrayImage>>,
     pub patch_cache: Mutex<HashMap<String, serde_json::Value>>,
@@ -277,6 +284,24 @@ mod tests {
         let active = tracker.next();
         assert!(!idle_snapshot.is_current());
         assert!(active.is_current());
+    }
+
+    #[test]
+    fn deferred_display_frame_is_invalidated_by_new_preview_work() {
+        let tracker = PreviewGenerationTracker::new();
+        let pending = PendingDisplayFrame {
+            path: "preview.jpg".to_string(),
+            generation: tracker.next(),
+        };
+        assert!(pending.generation.is_current());
+
+        let replacement = tracker.next();
+        assert!(!pending.generation.is_current());
+        assert_eq!(
+            pending.generation.ensure_current().unwrap_err(),
+            PREVIEW_SUPERSEDED
+        );
+        assert!(replacement.is_current());
     }
 
     #[test]

--- a/src-tauri/src/gpu_processing.rs
+++ b/src-tauri/src/gpu_processing.rs
@@ -30,7 +30,13 @@ pub struct RenderRequest<'a> {
 
 pub struct PreviewProcessResult {
     pub image: DynamicImage,
-    pub display_submission: Option<wgpu::SubmissionIndex>,
+    pub display_result: DisplayRenderResult,
+}
+
+pub enum DisplayRenderResult {
+    Empty,
+    Deferred,
+    Submitted(wgpu::SubmissionIndex),
 }
 
 #[repr(C)]
@@ -63,7 +69,7 @@ impl WgpuDisplay {
         &mut self,
         device: &wgpu::Device,
         queue: &wgpu::Queue,
-    ) -> Result<Option<wgpu::SubmissionIndex>, String> {
+    ) -> Result<DisplayRenderResult, String> {
         if let Some(bind_group) = &self.current_bind_group {
             let output = match self.surface.get_current_texture() {
                 wgpu::CurrentSurfaceTexture::Success(tex)
@@ -73,19 +79,24 @@ impl WgpuDisplay {
                     match self.surface.get_current_texture() {
                         wgpu::CurrentSurfaceTexture::Success(tex)
                         | wgpu::CurrentSurfaceTexture::Suboptimal(tex) => tex,
-                        _ => {
+                        wgpu::CurrentSurfaceTexture::Timeout
+                        | wgpu::CurrentSurfaceTexture::Occluded => {
+                            return Ok(DisplayRenderResult::Deferred);
+                        }
+                        wgpu::CurrentSurfaceTexture::Outdated
+                        | wgpu::CurrentSurfaceTexture::Lost => {
                             return Err(
                                 "Failed to acquire the display surface after reconfiguration"
                                     .to_string(),
                             );
                         }
+                        wgpu::CurrentSurfaceTexture::Validation => {
+                            return Err("Display surface validation failed".to_string());
+                        }
                     }
                 }
-                wgpu::CurrentSurfaceTexture::Timeout => {
-                    return Err("Timed out acquiring the display surface".to_string());
-                }
-                wgpu::CurrentSurfaceTexture::Occluded => {
-                    return Err("Display surface is occluded".to_string());
+                wgpu::CurrentSurfaceTexture::Timeout | wgpu::CurrentSurfaceTexture::Occluded => {
+                    return Ok(DisplayRenderResult::Deferred);
                 }
                 wgpu::CurrentSurfaceTexture::Validation => {
                     return Err("Display surface validation failed".to_string());
@@ -153,9 +164,9 @@ impl WgpuDisplay {
             }
             let submission = queue.submit(Some(encoder.finish()));
             output.present();
-            Ok(Some(submission))
+            Ok(DisplayRenderResult::Submitted(submission))
         } else {
-            Ok(None)
+            Ok(DisplayRenderResult::Empty)
         }
     }
 }
@@ -1764,7 +1775,7 @@ fn process_and_get_dynamic_image_inner(
         );
         return Ok(PreviewProcessResult {
             image: base_image.clone(),
-            display_submission: None,
+            display_result: DisplayRenderResult::Empty,
         });
     }
 
@@ -2070,7 +2081,7 @@ fn process_and_get_dynamic_image_inner(
         }
     }
 
-    let mut display_submission = None;
+    let mut display_result = DisplayRenderResult::Empty;
     if output_to_display {
         if let Some(generation) = preview_generation {
             generation.ensure_current()?;
@@ -2111,23 +2122,35 @@ fn process_and_get_dynamic_image_inner(
             label: None,
         });
         display.current_bind_group = Some(bind_group);
-        display_submission = display.render(device, queue)?;
+        display_result = display.render(device, queue)?;
     }
 
     if skip_readback {
         let duration = start_time.elapsed();
-        let fps = 1.0 / duration.as_secs_f64();
-        log::info!(
-            "[{}] {}x{} native WGPU display updated in {:?} ({:.2} FPS)",
-            caller_id,
-            width,
-            height,
-            duration,
-            fps
-        );
+        match &display_result {
+            DisplayRenderResult::Submitted(_) => {
+                let fps = 1.0 / duration.as_secs_f64();
+                log::info!(
+                    "[{}] {}x{} native WGPU display submitted in {:?} ({:.2} FPS)",
+                    caller_id,
+                    width,
+                    height,
+                    duration,
+                    fps
+                );
+            }
+            DisplayRenderResult::Deferred => log::debug!(
+                "[{}] {}x{} WGPU frame ready in {:?}; surface presentation deferred",
+                caller_id,
+                width,
+                height,
+                duration
+            ),
+            DisplayRenderResult::Empty => {}
+        }
         return Ok(PreviewProcessResult {
             image: DynamicImage::new_rgba8(0, 0),
-            display_submission,
+            display_result,
         });
     }
 
@@ -2148,7 +2171,7 @@ fn process_and_get_dynamic_image_inner(
         .ok_or("Failed to create image buffer from GPU data")?;
     Ok(PreviewProcessResult {
         image: DynamicImage::ImageRgba8(img_buf),
-        display_submission,
+        display_result,
     })
 }
 

--- a/src-tauri/src/gpu_processing.rs
+++ b/src-tauri/src/gpu_processing.rs
@@ -11,7 +11,7 @@ use wgpu::util::{DeviceExt, TextureDataOrder};
 
 use crate::image_processing::{AllAdjustments, GpuContext, MAX_MASKS};
 use crate::lut_processing::Lut;
-use crate::{AppState, GpuImageCache};
+use crate::{AppState, GpuImageCache, PreviewGeneration};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Roi {
@@ -26,6 +26,11 @@ pub struct RenderRequest<'a> {
     pub mask_bitmaps: &'a [ImageBuffer<Luma<u8>, Vec<u8>>],
     pub lut: Option<Arc<Lut>>,
     pub roi: Option<Roi>,
+}
+
+pub struct PreviewProcessResult {
+    pub image: DynamicImage,
+    pub display_submission: Option<wgpu::SubmissionIndex>,
 }
 
 #[repr(C)]
@@ -54,7 +59,11 @@ pub struct WgpuDisplay {
 }
 
 impl WgpuDisplay {
-    pub fn render(&mut self, device: &wgpu::Device, queue: &wgpu::Queue) {
+    pub fn render(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> Result<Option<wgpu::SubmissionIndex>, String> {
         if let Some(bind_group) = &self.current_bind_group {
             let output = match self.surface.get_current_texture() {
                 wgpu::CurrentSurfaceTexture::Success(tex)
@@ -64,10 +73,23 @@ impl WgpuDisplay {
                     match self.surface.get_current_texture() {
                         wgpu::CurrentSurfaceTexture::Success(tex)
                         | wgpu::CurrentSurfaceTexture::Suboptimal(tex) => tex,
-                        _ => panic!("Failed to acquire surface texture"),
+                        _ => {
+                            return Err(
+                                "Failed to acquire the display surface after reconfiguration"
+                                    .to_string(),
+                            );
+                        }
                     }
                 }
-                _ => return,
+                wgpu::CurrentSurfaceTexture::Timeout => {
+                    return Err("Timed out acquiring the display surface".to_string());
+                }
+                wgpu::CurrentSurfaceTexture::Occluded => {
+                    return Err("Display surface is occluded".to_string());
+                }
+                wgpu::CurrentSurfaceTexture::Validation => {
+                    return Err("Display surface validation failed".to_string());
+                }
             };
             let view = output
                 .texture
@@ -129,8 +151,11 @@ impl WgpuDisplay {
                     }
                 }
             }
-            queue.submit(Some(encoder.finish()));
+            let submission = queue.submit(Some(encoder.finish()));
             output.present();
+            Ok(Some(submission))
+        } else {
+            Ok(None)
         }
     }
 }
@@ -411,6 +436,52 @@ pub fn get_or_init_gpu_context(
     Ok(new_context)
 }
 
+#[cfg(target_os = "macos")]
+pub fn start_gpu_pipeline_prewarm(app_handle: tauri::AppHandle) {
+    let generation = app_handle.state::<AppState>().preview_generation.snapshot();
+
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(350));
+        if !generation.is_current() {
+            return;
+        }
+
+        let state = app_handle.state::<AppState>();
+        if state.original_image.lock().unwrap().is_some() {
+            return;
+        }
+
+        let context = match get_or_init_gpu_context(&state, &app_handle) {
+            Ok(context) => context,
+            Err(error) => {
+                log::warn!("GPU pipeline prewarm skipped: {}", error);
+                return;
+            }
+        };
+
+        let mut processor_lock = state.gpu_processor.lock().unwrap();
+        if processor_lock.is_some()
+            || !generation.is_current()
+            || state.original_image.lock().unwrap().is_some()
+        {
+            return;
+        }
+
+        let started = Instant::now();
+        match GpuProcessor::new(context, 1, 1) {
+            Ok(processor) => {
+                *processor_lock = Some(crate::GpuProcessorState {
+                    processor,
+                    width: 1,
+                    height: 1,
+                });
+                log::info!("GPU compute pipelines prewarmed in {:?}", started.elapsed());
+            }
+            Err(error) => log::warn!("GPU pipeline prewarm failed: {}", error),
+        }
+    });
+}
+
 fn read_texture_data_roi(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
@@ -535,6 +606,24 @@ pub struct GpuProcessor {
     dummy_blur_view: wgpu::TextureView,
     dummy_lut_view: wgpu::TextureView,
     dummy_lut_sampler: wgpu::Sampler,
+    textures: GpuProcessorTextures,
+}
+
+fn rounded_processor_capacity(dimension: u32) -> u32 {
+    dimension.saturating_add(255) & !255
+}
+
+fn expanded_processor_capacity(current: Option<(u32, u32)>, requested: (u32, u32)) -> (u32, u32) {
+    let requested = (
+        rounded_processor_capacity(requested.0),
+        rounded_processor_capacity(requested.1),
+    );
+    current.map_or(requested, |current| {
+        (current.0.max(requested.0), current.1.max(requested.1))
+    })
+}
+
+struct GpuProcessorTextures {
     ping_pong_view: wgpu::TextureView,
     sharpness_blur_view: wgpu::TextureView,
     tonal_blur_view: wgpu::TextureView,
@@ -544,12 +633,110 @@ pub struct GpuProcessor {
     pub tile_output_texture: wgpu::Texture,
     pub tile_output_texture_view: wgpu::TextureView,
     pub working_texture: wgpu::Texture,
-    pub working_texture_view: wgpu::TextureView,
     pub output_texture: wgpu::Texture,
     pub output_texture_view: wgpu::TextureView,
 }
 
 const FLARE_MAP_SIZE: u32 = 512;
+
+impl GpuProcessorTextures {
+    fn new(device: &wgpu::Device, max_width: u32, max_height: u32) -> Self {
+        const TILE_SIZE: u32 = 2048;
+        const TILE_OVERLAP: u32 = 128;
+
+        let clamped_tile_size = wgpu::Extent3d {
+            width: max_width.min(TILE_SIZE + TILE_OVERLAP * 2),
+            height: max_height.min(TILE_SIZE + TILE_OVERLAP * 2),
+            depth_or_array_layers: 1,
+        };
+        let full_image_size = wgpu::Extent3d {
+            width: max_width,
+            height: max_height,
+            depth_or_array_layers: 1,
+        };
+        let reusable_texture_desc = wgpu::TextureDescriptor {
+            label: None,
+            size: clamped_tile_size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba16Float,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
+            view_formats: &[],
+        };
+
+        let ping_pong_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Ping Pong Texture"),
+            ..reusable_texture_desc
+        });
+        let sharpness_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Sharpness Blur Texture"),
+            ..reusable_texture_desc
+        });
+        let tonal_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Tonal Blur Texture"),
+            ..reusable_texture_desc
+        });
+        let clarity_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Clarity Blur Texture"),
+            ..reusable_texture_desc
+        });
+        let structure_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Structure Blur Texture"),
+            ..reusable_texture_desc
+        });
+
+        let tile_output_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Tile Output Texture"),
+            size: clamped_tile_size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::STORAGE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let working_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Working Output Texture"),
+            size: full_image_size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let output_texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Full Output Texture"),
+            size: full_image_size,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_DST
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+
+        Self {
+            ping_pong_view: ping_pong_texture.create_view(&Default::default()),
+            sharpness_blur_view: sharpness_blur_texture.create_view(&Default::default()),
+            tonal_blur_view: tonal_blur_texture.create_view(&Default::default()),
+            clarity_blur_view: clarity_blur_texture.create_view(&Default::default()),
+            structure_blur_view: structure_blur_texture.create_view(&Default::default()),
+            tile_output_texture_view: tile_output_texture.create_view(&Default::default()),
+            tile_output_texture,
+            working_texture,
+            output_texture_view: output_texture.create_view(&Default::default()),
+            output_texture,
+        }
+    }
+}
 
 impl GpuProcessor {
     pub fn new(context: GpuContext, max_width: u32, max_height: u32) -> Result<Self, String> {
@@ -947,106 +1134,7 @@ impl GpuProcessor {
         let dummy_lut_view = dummy_lut_texture.create_view(&Default::default());
         let dummy_lut_sampler = device.create_sampler(&wgpu::SamplerDescriptor::default());
 
-        const TILE_SIZE: u32 = 2048;
-        const TILE_OVERLAP: u32 = 128;
-
-        let clamped_tile_width = max_width.min(TILE_SIZE + TILE_OVERLAP * 2);
-        let clamped_tile_height = max_height.min(TILE_SIZE + TILE_OVERLAP * 2);
-
-        let clamped_tile_size = wgpu::Extent3d {
-            width: clamped_tile_width,
-            height: clamped_tile_height,
-            depth_or_array_layers: 1,
-        };
-
-        let full_image_size = wgpu::Extent3d {
-            width: max_width,
-            height: max_height,
-            depth_or_array_layers: 1,
-        };
-
-        let reusable_texture_desc = wgpu::TextureDescriptor {
-            label: None,
-            size: clamped_tile_size,
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba16Float,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::STORAGE_BINDING,
-            view_formats: &[],
-        };
-
-        let ping_pong_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Ping Pong Texture"),
-            ..reusable_texture_desc
-        });
-        let ping_pong_view = ping_pong_texture.create_view(&Default::default());
-
-        let sharpness_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Sharpness Blur Texture"),
-            ..reusable_texture_desc
-        });
-        let sharpness_blur_view = sharpness_blur_texture.create_view(&Default::default());
-
-        let tonal_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Tonal Blur Texture"),
-            ..reusable_texture_desc
-        });
-        let tonal_blur_view = tonal_blur_texture.create_view(&Default::default());
-
-        let clarity_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Clarity Blur Texture"),
-            ..reusable_texture_desc
-        });
-        let clarity_blur_view = clarity_blur_texture.create_view(&Default::default());
-
-        let structure_blur_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Structure Blur Texture"),
-            ..reusable_texture_desc
-        });
-        let structure_blur_view = structure_blur_texture.create_view(&Default::default());
-
-        let tile_output_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Tile Output Texture"),
-            size: clamped_tile_size,
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::STORAGE_BINDING
-                | wgpu::TextureUsages::COPY_SRC,
-            view_formats: &[],
-        });
-        let tile_output_texture_view = tile_output_texture.create_view(&Default::default());
-
-        let working_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Working Output Texture"),
-            size: full_image_size,
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::COPY_DST
-                | wgpu::TextureUsages::COPY_SRC,
-            view_formats: &[],
-        });
-        let working_texture_view = working_texture.create_view(&Default::default());
-
-        let output_texture = device.create_texture(&wgpu::TextureDescriptor {
-            label: Some("Full Output Texture"),
-            size: full_image_size,
-            mip_level_count: 1,
-            sample_count: 1,
-            dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8Unorm,
-            usage: wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::COPY_DST
-                | wgpu::TextureUsages::COPY_SRC,
-            view_formats: &[],
-        });
-        let output_texture_view = output_texture.create_view(&Default::default());
+        let textures = GpuProcessorTextures::new(device, max_width, max_height);
 
         Ok(Self {
             context,
@@ -1069,20 +1157,15 @@ impl GpuProcessor {
             dummy_blur_view,
             dummy_lut_view,
             dummy_lut_sampler,
-            ping_pong_view,
-            sharpness_blur_view,
-            tonal_blur_view,
-            clarity_blur_view,
-            structure_blur_view,
-            tile_output_texture,
-            tile_output_texture_view,
-            working_texture,
-            working_texture_view,
-            output_texture,
-            output_texture_view,
+            textures,
         })
     }
 
+    pub fn resize(&mut self, max_width: u32, max_height: u32) {
+        self.textures = GpuProcessorTextures::new(&self.context.device, max_width, max_height);
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn run(
         &self,
         input_texture_view: &wgpu::TextureView,
@@ -1091,7 +1174,11 @@ impl GpuProcessor {
         request: RenderRequest,
         skip_cpu_readback: bool,
         output_to_display: bool,
+        preview_generation: Option<&PreviewGeneration>,
     ) -> Result<(Vec<u8>, u32, u32, u32, u32), String> {
+        if let Some(generation) = preview_generation {
+            generation.ensure_current()?;
+        }
         let device = &self.context.device;
         let queue = &self.context.queue;
         let scale = (width.min(height) as f32) / 1080.0;
@@ -1283,6 +1370,9 @@ impl GpuProcessor {
                 cpass.dispatch_workgroups(FLARE_MAP_SIZE / 16, FLARE_MAP_SIZE / 16, 1);
             }
 
+            if let Some(generation) = preview_generation {
+                generation.ensure_current()?;
+            }
             queue.submit(Some(encoder.finish()));
         }
 
@@ -1305,6 +1395,9 @@ impl GpuProcessor {
 
         for tile_y in start_tile_y..end_tile_y {
             for tile_x in start_tile_x..end_tile_x {
+                if let Some(generation) = preview_generation {
+                    generation.ensure_current()?;
+                }
                 let x_start_unclamped = tile_x * TILE_SIZE;
                 let y_start_unclamped = tile_y * TILE_SIZE;
 
@@ -1333,10 +1426,12 @@ impl GpuProcessor {
                     depth_or_array_layers: 1,
                 };
 
-                let run_blur = |base_radius: f32, output_view: &wgpu::TextureView| -> bool {
+                let run_blur = |base_radius: f32,
+                                output_view: &wgpu::TextureView|
+                 -> Result<bool, String> {
                     let radius = (base_radius * scale).ceil().max(1.0) as u32;
                     if radius == 0 {
-                        return false;
+                        return Ok(false);
                     }
 
                     let params = BlurParams {
@@ -1363,7 +1458,9 @@ impl GpuProcessor {
                             },
                             wgpu::BindGroupEntry {
                                 binding: 1,
-                                resource: wgpu::BindingResource::TextureView(&self.ping_pong_view),
+                                resource: wgpu::BindingResource::TextureView(
+                                    &self.textures.ping_pong_view,
+                                ),
                             },
                             wgpu::BindGroupEntry {
                                 binding: 2,
@@ -1385,7 +1482,9 @@ impl GpuProcessor {
                         entries: &[
                             wgpu::BindGroupEntry {
                                 binding: 0,
-                                resource: wgpu::BindingResource::TextureView(&self.ping_pong_view),
+                                resource: wgpu::BindingResource::TextureView(
+                                    &self.textures.ping_pong_view,
+                                ),
                             },
                             wgpu::BindGroupEntry {
                                 binding: 1,
@@ -1405,14 +1504,17 @@ impl GpuProcessor {
                         cpass.dispatch_workgroups(input_width, input_height.div_ceil(256), 1);
                     }
 
+                    if let Some(generation) = preview_generation {
+                        generation.ensure_current()?;
+                    }
                     queue.submit(Some(blur_encoder.finish()));
-                    true
+                    Ok(true)
                 };
 
-                let did_create_sharpness_blur = run_blur(1.0, &self.sharpness_blur_view);
-                let did_create_tonal_blur = run_blur(3.5, &self.tonal_blur_view);
-                let did_create_clarity_blur = run_blur(8.0, &self.clarity_blur_view);
-                let did_create_structure_blur = run_blur(40.0, &self.structure_blur_view);
+                let did_create_sharpness_blur = run_blur(1.0, &self.textures.sharpness_blur_view)?;
+                let did_create_tonal_blur = run_blur(3.5, &self.textures.tonal_blur_view)?;
+                let did_create_clarity_blur = run_blur(8.0, &self.textures.clarity_blur_view)?;
+                let did_create_structure_blur = run_blur(40.0, &self.textures.structure_blur_view)?;
 
                 let mut main_encoder = device.create_command_encoder(&Default::default());
 
@@ -1433,7 +1535,7 @@ impl GpuProcessor {
                     wgpu::BindGroupEntry {
                         binding: 1,
                         resource: wgpu::BindingResource::TextureView(
-                            &self.tile_output_texture_view,
+                            &self.textures.tile_output_texture_view,
                         ),
                     },
                     wgpu::BindGroupEntry {
@@ -1457,7 +1559,7 @@ impl GpuProcessor {
                 bind_group_entries.push(wgpu::BindGroupEntry {
                     binding: 5 + MAX_MASK_BINDINGS,
                     resource: wgpu::BindingResource::TextureView(if did_create_sharpness_blur {
-                        &self.sharpness_blur_view
+                        &self.textures.sharpness_blur_view
                     } else {
                         &self.dummy_blur_view
                     }),
@@ -1465,7 +1567,7 @@ impl GpuProcessor {
                 bind_group_entries.push(wgpu::BindGroupEntry {
                     binding: 6 + MAX_MASK_BINDINGS,
                     resource: wgpu::BindingResource::TextureView(if did_create_tonal_blur {
-                        &self.tonal_blur_view
+                        &self.textures.tonal_blur_view
                     } else {
                         &self.dummy_blur_view
                     }),
@@ -1473,7 +1575,7 @@ impl GpuProcessor {
                 bind_group_entries.push(wgpu::BindGroupEntry {
                     binding: 7 + MAX_MASK_BINDINGS,
                     resource: wgpu::BindingResource::TextureView(if did_create_clarity_blur {
-                        &self.clarity_blur_view
+                        &self.textures.clarity_blur_view
                     } else {
                         &self.dummy_blur_view
                     }),
@@ -1481,7 +1583,7 @@ impl GpuProcessor {
                 bind_group_entries.push(wgpu::BindGroupEntry {
                     binding: 8 + MAX_MASK_BINDINGS,
                     resource: wgpu::BindingResource::TextureView(if did_create_structure_blur {
-                        &self.structure_blur_view
+                        &self.textures.structure_blur_view
                     } else {
                         &self.dummy_blur_view
                     }),
@@ -1524,7 +1626,7 @@ impl GpuProcessor {
                 if output_to_display {
                     main_encoder.copy_texture_to_texture(
                         wgpu::TexelCopyTextureInfo {
-                            texture: &self.tile_output_texture,
+                            texture: &self.textures.tile_output_texture,
                             mip_level: 0,
                             origin: wgpu::Origin3d {
                                 x: crop_x_start,
@@ -1534,7 +1636,7 @@ impl GpuProcessor {
                             aspect: wgpu::TextureAspect::All,
                         },
                         wgpu::TexelCopyTextureInfo {
-                            texture: &self.working_texture,
+                            texture: &self.textures.working_texture,
                             mip_level: 0,
                             origin: wgpu::Origin3d {
                                 x: x_start,
@@ -1551,13 +1653,16 @@ impl GpuProcessor {
                     );
                 }
 
+                if let Some(generation) = preview_generation {
+                    generation.ensure_current()?;
+                }
                 queue.submit(Some(main_encoder.finish()));
 
                 if !skip_cpu_readback {
                     let processed_tile_data = read_texture_data_roi(
                         device,
                         queue,
-                        &self.tile_output_texture,
+                        &self.textures.tile_output_texture,
                         wgpu::Origin3d::ZERO,
                         input_texture_size,
                     )?;
@@ -1602,7 +1707,9 @@ pub fn process_and_get_dynamic_image(
         caller_id,
         false,
         None,
+        None,
     )
+    .map(|result| result.image)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1615,7 +1722,8 @@ pub fn process_and_get_dynamic_image_with_analytics(
     caller_id: &str,
     output_to_display: bool,
     analytics_config: Option<crate::AnalyticsConfig>,
-) -> Result<DynamicImage, String> {
+    preview_generation: Option<&PreviewGeneration>,
+) -> Result<PreviewProcessResult, String> {
     process_and_get_dynamic_image_inner(
         context,
         state,
@@ -1625,6 +1733,7 @@ pub fn process_and_get_dynamic_image_with_analytics(
         caller_id,
         output_to_display,
         analytics_config,
+        preview_generation,
     )
 }
 
@@ -1638,7 +1747,8 @@ fn process_and_get_dynamic_image_inner(
     caller_id: &str,
     output_to_display: bool,
     analytics_config: Option<crate::AnalyticsConfig>,
-) -> Result<DynamicImage, String> {
+    preview_generation: Option<&PreviewGeneration>,
+) -> Result<PreviewProcessResult, String> {
     let start_time = Instant::now();
     let (width, height) = base_image.dimensions();
     let device = &context.device;
@@ -1652,13 +1762,23 @@ fn process_and_get_dynamic_image_inner(
             height,
             max_dim
         );
-        return Ok(base_image.clone());
+        return Ok(PreviewProcessResult {
+            image: base_image.clone(),
+            display_submission: None,
+        });
+    }
+
+    if let Some(generation) = preview_generation {
+        generation.ensure_current()?;
     }
 
     let mut processor_lock = state.gpu_processor.lock().unwrap();
+    if let Some(generation) = preview_generation {
+        generation.ensure_current()?;
+    }
     let mut needs_new_processor = false;
-    let new_width = (width + 255) & !255;
-    let new_height = (height + 255) & !255;
+    let current_capacity = processor_lock.as_ref().map(|p| (p.width, p.height));
+    let (new_width, new_height) = expanded_processor_capacity(current_capacity, (width, height));
 
     if let Some(p) = processor_lock.as_ref() {
         if p.width < width || p.height < height {
@@ -1669,27 +1789,27 @@ fn process_and_get_dynamic_image_inner(
     }
 
     if needs_new_processor {
-        log::info!(
-            "Creating new GPU Processor for dimensions up to {}x{}",
-            new_width,
-            new_height
-        );
-
-        let old_processor = processor_lock.take();
-        drop(old_processor);
-
-        let _ = context.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: Some(std::time::Duration::from_millis(500)),
-        });
-
-        let new_processor = GpuProcessor::new(context.clone(), new_width, new_height)?;
-
-        *processor_lock = Some(crate::GpuProcessorState {
-            processor: new_processor,
-            width: new_width,
-            height: new_height,
-        });
+        if let Some(processor_state) = processor_lock.as_mut() {
+            log::info!(
+                "Resizing GPU Processor textures to {}x{}",
+                new_width,
+                new_height
+            );
+            processor_state.processor.resize(new_width, new_height);
+            processor_state.width = new_width;
+            processor_state.height = new_height;
+        } else {
+            log::info!(
+                "Creating GPU Processor for dimensions up to {}x{}",
+                new_width,
+                new_height
+            );
+            *processor_lock = Some(crate::GpuProcessorState {
+                processor: GpuProcessor::new(context.clone(), new_width, new_height)?,
+                width: new_width,
+                height: new_height,
+            });
+        }
     }
 
     let processor_state = processor_lock.as_ref().unwrap();
@@ -1711,10 +1831,9 @@ fn process_and_get_dynamic_image_inner(
         let old_cache = cache_lock.take();
         drop(old_cache);
 
-        let _ = context.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: Some(std::time::Duration::from_millis(500)),
-        });
+        if let Some(generation) = preview_generation {
+            generation.ensure_current()?;
+        }
 
         let img_rgba_f16 = to_rgba_f16(base_image);
         let texture_size = wgpu::Extent3d {
@@ -1759,7 +1878,26 @@ fn process_and_get_dynamic_image_inner(
         request,
         skip_readback,
         output_to_display,
+        preview_generation,
     )?;
+
+    if let Some(generation) = preview_generation {
+        generation.ensure_current()?;
+    }
+
+    // Keep the final persistent-texture copy and surface present atomic with respect to
+    // generation changes. A newer request waits only for this short commit section.
+    let _preview_commit = if output_to_display {
+        if let Some(generation) = preview_generation {
+            let guard = generation.lock_commit();
+            generation.ensure_current()?;
+            Some(guard)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
 
     let mut final_encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("Final Passes Encoder"),
@@ -1785,7 +1923,7 @@ fn process_and_get_dynamic_image_inner(
 
         final_encoder.copy_texture_to_buffer(
             wgpu::TexelCopyTextureInfo {
-                texture: &processor.working_texture,
+                texture: &processor.textures.working_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
                     x: out_x,
@@ -1818,7 +1956,7 @@ fn process_and_get_dynamic_image_inner(
     if output_to_display {
         final_encoder.copy_texture_to_texture(
             wgpu::TexelCopyTextureInfo {
-                texture: &processor.working_texture,
+                texture: &processor.textures.working_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
                     x: out_x,
@@ -1828,7 +1966,7 @@ fn process_and_get_dynamic_image_inner(
                 aspect: wgpu::TextureAspect::All,
             },
             wgpu::TexelCopyTextureInfo {
-                texture: &processor.output_texture,
+                texture: &processor.textures.output_texture,
                 mip_level: 0,
                 origin: wgpu::Origin3d {
                     x: out_x,
@@ -1847,6 +1985,9 @@ fn process_and_get_dynamic_image_inner(
     }
 
     if submit_final_encoder {
+        if let Some(generation) = preview_generation {
+            generation.ensure_current()?;
+        }
         queue.submit(Some(final_encoder.finish()));
     }
 
@@ -1856,6 +1997,7 @@ fn process_and_get_dynamic_image_inner(
             let padded_bytes_per_row: u32 = async_padded_bpr;
             let unpadded_bytes_per_row: u32 = async_unpadded_bpr;
             let device_clone = context.device.clone();
+            let analytics_generation = analytics.generation.clone();
 
             std::thread::spawn(move || {
                 let buffer_slice = output_buffer.slice(..);
@@ -1874,6 +2016,9 @@ fn process_and_get_dynamic_image_inner(
                 }
 
                 if let Ok(Ok(())) = rx.recv() {
+                    if !analytics_generation.is_current() {
+                        return;
+                    }
                     let padded_data = buffer_slice.get_mapped_range().to_vec();
                     output_buffer.unmap();
 
@@ -1897,13 +2042,18 @@ fn process_and_get_dynamic_image_inner(
                             image: std::sync::Arc::new(dynamic_img),
                             compute_waveform: analytics.compute_waveform,
                             active_waveform_channel: analytics.active_waveform_channel,
+                            generation: analytics_generation,
                         });
                     }
                 }
             });
         } else {
             let pixels_clone = processed_pixels.clone();
+            let analytics_generation = analytics.generation.clone();
             std::thread::spawn(move || {
+                if !analytics_generation.is_current() {
+                    return;
+                }
                 if let Some(img_buf) =
                     ImageBuffer::<Rgba<u8>, _>::from_raw(out_w, out_h, pixels_clone)
                 {
@@ -1913,16 +2063,23 @@ fn process_and_get_dynamic_image_inner(
                         image: std::sync::Arc::new(dynamic_img),
                         compute_waveform: analytics.compute_waveform,
                         active_waveform_channel: analytics.active_waveform_channel,
+                        generation: analytics_generation,
                     });
                 }
             });
         }
     }
 
-    if output_to_display
-        && let Ok(mut display_lock) = context.display.lock()
-        && let Some(display) = display_lock.as_mut()
-    {
+    let mut display_submission = None;
+    if output_to_display {
+        if let Some(generation) = preview_generation {
+            generation.ensure_current()?;
+        }
+        let mut display_lock = context.display.lock().unwrap();
+        let display = display_lock
+            .as_mut()
+            .ok_or_else(|| "WGPU display is not initialized".to_string())?;
+
         display.latest_transform.image_size = [width as f32, height as f32];
         display.latest_transform.texture_size =
             [processor_state.width as f32, processor_state.height as f32];
@@ -1942,7 +2099,9 @@ fn process_and_get_dynamic_image_inner(
                 },
                 wgpu::BindGroupEntry {
                     binding: 1,
-                    resource: wgpu::BindingResource::TextureView(&processor.output_texture_view),
+                    resource: wgpu::BindingResource::TextureView(
+                        &processor.textures.output_texture_view,
+                    ),
                 },
                 wgpu::BindGroupEntry {
                     binding: 2,
@@ -1952,7 +2111,7 @@ fn process_and_get_dynamic_image_inner(
             label: None,
         });
         display.current_bind_group = Some(bind_group);
-        display.render(device, queue);
+        display_submission = display.render(device, queue)?;
     }
 
     if skip_readback {
@@ -1966,7 +2125,10 @@ fn process_and_get_dynamic_image_inner(
             duration,
             fps
         );
-        return Ok(DynamicImage::new_rgba8(0, 0));
+        return Ok(PreviewProcessResult {
+            image: DynamicImage::new_rgba8(0, 0),
+            display_submission,
+        });
     }
 
     let duration = start_time.elapsed();
@@ -1984,5 +2146,29 @@ fn process_and_get_dynamic_image_inner(
 
     let img_buf = ImageBuffer::<Rgba<u8>, Vec<u8>>::from_raw(out_w, out_h, processed_pixels)
         .ok_or("Failed to create image buffer from GPU data")?;
-    Ok(DynamicImage::ImageRgba8(img_buf))
+    Ok(PreviewProcessResult {
+        image: DynamicImage::ImageRgba8(img_buf),
+        display_submission,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn processor_capacity_rounds_up_without_shrinking_either_axis() {
+        assert_eq!(
+            expanded_processor_capacity(None, (1921, 1081)),
+            (2048, 1280)
+        );
+        assert_eq!(
+            expanded_processor_capacity(Some((4096, 2048)), (1536, 3072)),
+            (4096, 3072)
+        );
+        assert_eq!(
+            expanded_processor_capacity(Some((4096, 3072)), (3840, 2160)),
+            (4096, 3072)
+        );
+    }
 }

--- a/src-tauri/src/image_loader.rs
+++ b/src-tauri/src/image_loader.rs
@@ -841,6 +841,8 @@ pub async fn load_image(
     let my_generation = state.load_image_generation.fetch_add(1, Ordering::SeqCst) + 1;
     let generation_tracker = state.load_image_generation.clone();
     let cancel_token = Some((generation_tracker.clone(), my_generation));
+    // Invalidate any in-flight preview before replacing the source image or its caches.
+    let _ = state.preview_generation.next();
 
     {
         *state.original_image.lock().unwrap() = None;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -311,7 +311,7 @@ async fn update_wgpu_transform(
                 0,
                 bytemuck::bytes_of(&display.latest_transform),
             );
-            display.render(&context.device, &context.queue);
+            let _ = display.render(&context.device, &context.queue);
         }
     })
     .await
@@ -324,6 +324,7 @@ async fn update_wgpu_transform(
 fn process_preview_job(
     app_handle: &tauri::AppHandle,
     state: tauri::State<AppState>,
+    generation: PreviewGeneration,
     mut adjustments_json: serde_json::Value,
     is_interactive: bool,
     target_resolution: Option<u32>,
@@ -333,8 +334,10 @@ fn process_preview_job(
     active_waveform_channel: Option<&str>,
 ) -> Result<Vec<u8>, String> {
     let fn_start = std::time::Instant::now();
+    generation.ensure_current()?;
     let context = get_or_init_gpu_context(&state, app_handle)?;
     hydrate_adjustments(&state, &mut adjustments_json);
+    generation.ensure_current()?;
     let adjustments_clone = adjustments_json;
 
     let loaded_image_guard = state.original_image.lock().unwrap();
@@ -343,6 +346,7 @@ fn process_preview_job(
         .ok_or("No original image loaded")?
         .clone();
     drop(loaded_image_guard);
+    generation.ensure_current()?;
 
     let new_transform_hash = calculate_transform_hash(&adjustments_clone);
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
@@ -384,6 +388,7 @@ fn process_preview_job(
 
         let (base, scale, offset) =
             generate_transformed_preview(&state, &loaded_image, &adjustments_clone, preview_dim)?;
+        generation.ensure_current()?;
         (Arc::new(base), scale, offset)
     };
 
@@ -416,6 +421,7 @@ fn process_preview_job(
         small
     };
 
+    generation.ensure_current()?;
     *cached_preview_lock = Some(CachedPreview {
         image: Arc::clone(&final_preview_base),
         small_image: Arc::clone(&small_preview_base),
@@ -475,6 +481,7 @@ fn process_preview_job(
             )
         })
         .collect();
+    generation.ensure_current()?;
 
     let is_raw = loaded_image.is_raw;
     let tm_override = resolve_tonemapper_override_from_handle(app_handle, is_raw);
@@ -500,6 +507,7 @@ fn process_preview_job(
                 compute_waveform,
                 active_waveform_channel: channel_filter,
                 sender: tx,
+                generation: generation.clone(),
             })
     } else {
         None
@@ -520,91 +528,118 @@ fn process_preview_job(
             "apply_adjustments",
             use_wgpu_renderer,
             analytics_config,
+            Some(&generation),
         );
 
-    if let Ok(final_processed_image) = final_processed_image_result {
-        if use_wgpu_renderer {
-            let _ = context.device.poll(wgpu::PollType::Wait {
-                submission_index: None,
+    let final_processed = match final_processed_image_result {
+        Ok(final_processed) => final_processed,
+        Err(error) => {
+            if error != PREVIEW_SUPERSEDED {
+                log::error!(
+                    "[process_preview_job] processing failed after {:.2?}: {}",
+                    fn_start.elapsed(),
+                    error
+                );
+            }
+            return Err(error);
+        }
+    };
+
+    generation.ensure_current()?;
+    if use_wgpu_renderer {
+        let submission = final_processed
+            .display_submission
+            .ok_or_else(|| "WGPU display did not submit a frame".to_string())?;
+        let device = context.device.clone();
+        let completion_app_handle = app_handle.clone();
+        let completion_generation = generation.clone();
+        let completion_path = loaded_image.path.clone();
+        std::thread::spawn(move || {
+            let completion = device.poll(wgpu::PollType::Wait {
+                submission_index: Some(submission),
                 timeout: Some(std::time::Duration::from_millis(500)),
             });
-            let _ = app_handle.emit(
-                "wgpu-frame-ready",
-                serde_json::json!({ "path": loaded_image.path }),
-            );
-            return Ok(b"WGPU_RENDER".to_vec());
-        }
-
-        let final_processed_image = Arc::new(final_processed_image);
-        let final_rgba_image = match &*final_processed_image {
-            DynamicImage::ImageRgba8(img) => img,
-            _ => return Err("Expected Rgba8 image from GPU for encoding".to_string()),
-        };
-
-        let raw_bytes: &[u8] = final_rgba_image.as_raw();
-        let rgba8_pixels: &[RGBA8] = raw_bytes.as_rgba();
-
-        let img_ref = ImgRef::new(
-            rgba8_pixels,
-            final_rgba_image.width() as usize,
-            final_rgba_image.height() as usize,
-        );
-
-        let step_start = std::time::Instant::now();
-
-        let encode_result = Encoder::new(Preset::BaselineFastest)
-            .quality(jpeg_quality)
-            .fast_color(true)
-            .encode_imgref(img_ref);
-
-        match encode_result {
-            Ok(jpeg_bytes) => {
-                if is_interactive {
-                    let (roi_w, roi_h) = final_rgba_image.dimensions();
-                    let (rx, ry) = if let Some(r) = pixel_roi {
-                        (r.x, r.y)
-                    } else {
-                        (0, 0)
-                    };
-
-                    let mut response = Vec::with_capacity(24 + jpeg_bytes.len());
-                    response.extend_from_slice(&rx.to_le_bytes());
-                    response.extend_from_slice(&ry.to_le_bytes());
-                    response.extend_from_slice(&roi_w.to_le_bytes());
-                    response.extend_from_slice(&roi_h.to_le_bytes());
-                    response.extend_from_slice(&preview_width.to_le_bytes());
-                    response.extend_from_slice(&preview_height.to_le_bytes());
-                    response.extend_from_slice(&jpeg_bytes);
-
-                    log::info!(
-                        "[process_preview_job] interactive ROI {}x{} encode in {:.2?}, total {:.2?}",
-                        roi_w,
-                        roi_h,
-                        step_start.elapsed(),
-                        fn_start.elapsed()
+            if completion.is_ok() {
+                let _commit_guard = completion_generation.lock_commit();
+                if completion_generation.is_current() {
+                    let _ = completion_app_handle.emit(
+                        "wgpu-frame-ready",
+                        serde_json::json!({
+                            "path": completion_path,
+                            "generation": completion_generation.number(),
+                        }),
                     );
-                    Ok(response)
-                } else {
-                    let (width, height) = final_rgba_image.dimensions();
-                    log::info!(
-                        "[process_preview_job] full {}x{} q={} encode in {:.2?}, total {:.2?}",
-                        width,
-                        height,
-                        jpeg_quality,
-                        step_start.elapsed(),
-                        fn_start.elapsed()
-                    );
-                    Ok(jpeg_bytes)
                 }
+            } else if let Err(error) = completion {
+                log::warn!("WGPU frame completion wait failed: {}", error);
             }
-            Err(e) => Err(format!("Failed to encode preview: {}", e)),
+        });
+        return Ok(b"WGPU_RENDER".to_vec());
+    }
+
+    let final_processed_image = Arc::new(final_processed.image);
+    let final_rgba_image = match &*final_processed_image {
+        DynamicImage::ImageRgba8(img) => img,
+        _ => return Err("Expected Rgba8 image from GPU for encoding".to_string()),
+    };
+
+    let raw_bytes: &[u8] = final_rgba_image.as_raw();
+    let rgba8_pixels: &[RGBA8] = raw_bytes.as_rgba();
+
+    let img_ref = ImgRef::new(
+        rgba8_pixels,
+        final_rgba_image.width() as usize,
+        final_rgba_image.height() as usize,
+    );
+
+    let step_start = std::time::Instant::now();
+
+    let encode_result = Encoder::new(Preset::BaselineFastest)
+        .quality(jpeg_quality)
+        .fast_color(true)
+        .encode_imgref(img_ref);
+
+    match encode_result {
+        Ok(jpeg_bytes) => {
+            if is_interactive {
+                let (roi_w, roi_h) = final_rgba_image.dimensions();
+                let (rx, ry) = if let Some(r) = pixel_roi {
+                    (r.x, r.y)
+                } else {
+                    (0, 0)
+                };
+
+                let mut response = Vec::with_capacity(24 + jpeg_bytes.len());
+                response.extend_from_slice(&rx.to_le_bytes());
+                response.extend_from_slice(&ry.to_le_bytes());
+                response.extend_from_slice(&roi_w.to_le_bytes());
+                response.extend_from_slice(&roi_h.to_le_bytes());
+                response.extend_from_slice(&preview_width.to_le_bytes());
+                response.extend_from_slice(&preview_height.to_le_bytes());
+                response.extend_from_slice(&jpeg_bytes);
+
+                log::info!(
+                    "[process_preview_job] interactive ROI {}x{} encode in {:.2?}, total {:.2?}",
+                    roi_w,
+                    roi_h,
+                    step_start.elapsed(),
+                    fn_start.elapsed()
+                );
+                Ok(response)
+            } else {
+                let (width, height) = final_rgba_image.dimensions();
+                log::info!(
+                    "[process_preview_job] full {}x{} q={} encode in {:.2?}, total {:.2?}",
+                    width,
+                    height,
+                    jpeg_quality,
+                    step_start.elapsed(),
+                    fn_start.elapsed()
+                );
+                Ok(jpeg_bytes)
+            }
         }
-    } else {
-        log::error!(
-            "[process_preview_job] processing failed after {:.2?}",
-            fn_start.elapsed()
-        );
-        Err("Processing failed".to_string())
+        Err(e) => Err(format!("Failed to encode preview: {}", e)),
     }
 }
 
@@ -615,8 +650,10 @@ fn start_analytics_worker(app_handle: tauri::AppHandle) {
 
     std::thread::spawn(move || {
         while let Ok(mut job) = rx.recv() {
-            while let Ok(latest) = rx.try_recv() {
-                job = latest;
+            while let Ok(queued_job) = rx.try_recv() {
+                if queued_job.generation.number() > job.generation.number() {
+                    job = queued_job;
+                }
             }
 
             let histogram_data = image_processing::calculate_histogram_from_image(&job.image).ok();
@@ -631,7 +668,9 @@ fn start_analytics_worker(app_handle: tauri::AppHandle) {
                 None
             };
 
-            if histogram_data.is_some() || waveform_data.is_some() {
+            let _commit_guard = job.generation.lock_commit();
+            if job.generation.is_current() && (histogram_data.is_some() || waveform_data.is_some())
+            {
                 let _ = app_handle.emit(
                     "analytics-update",
                     serde_json::json!({
@@ -653,15 +692,19 @@ fn start_preview_worker(app_handle: tauri::AppHandle) {
 
     std::thread::spawn(move || {
         while let Ok(mut job) = rx.recv() {
-            while let Ok(latest_job) = rx.try_recv() {
-                job = latest_job;
+            while let Ok(queued_job) = rx.try_recv() {
+                if queued_job.generation.number() > job.generation.number() {
+                    job = queued_job;
+                }
             }
 
             let state = app_handle.state::<AppState>();
+            let generation = job.generation.clone();
             let responder = job.responder;
             match process_preview_job(
                 &app_handle,
                 state,
+                generation,
                 job.adjustments,
                 job.is_interactive,
                 job.target_resolution,
@@ -674,7 +717,9 @@ fn start_preview_worker(app_handle: tauri::AppHandle) {
                     let _ = responder.send(bytes);
                 }
                 Err(e) => {
-                    log::error!("Preview worker error: {}", e);
+                    if e != PREVIEW_SUPERSEDED {
+                        log::error!("Preview worker error: {}", e);
+                    }
                 }
             }
         }
@@ -694,6 +739,7 @@ async fn apply_adjustments(
     state: tauri::State<'_, AppState>,
 ) -> Result<Response, String> {
     let (tx, rx) = tokio::sync::oneshot::channel();
+    let generation = state.preview_generation.next();
 
     {
         let tx_guard = state.preview_worker_tx.lock().unwrap();
@@ -707,6 +753,7 @@ async fn apply_adjustments(
                 compute_waveform,
                 active_waveform_channel,
                 responder: tx,
+                generation,
             };
             worker_tx
                 .send(job)
@@ -1828,6 +1875,11 @@ fn frontend_ready(
         }
     }
 
+    #[cfg(target_os = "macos")]
+    if is_first_run {
+        gpu_processing::start_gpu_pipeline_prewarm(app_handle.clone());
+    }
+
     let open_with_file = state.initial_file_path.lock().unwrap().take();
     let edit_session = state.pending_edit_session.lock().unwrap().take();
     if let Some(path) = &open_with_file {
@@ -1895,7 +1947,7 @@ pub fn run() {
                         display.config.width = size.width.max(1);
                         display.config.height = size.height.max(1);
                         display.surface.configure(&ctx.device, &display.config);
-                        display.render(&ctx.device, &ctx.queue);
+                        let _ = display.render(&ctx.device, &ctx.queue);
                     }
         })
         .setup(move |app| {
@@ -2239,6 +2291,7 @@ pub fn run() {
             thumbnail_cancellation_token: Arc::new(AtomicBool::new(false)),
             thumbnail_progress: Mutex::new(ThumbnailProgressTracker { total: 0, completed: 0 }),
             preview_worker_tx: Mutex::new(None),
+            preview_generation: PreviewGenerationTracker::new(),
             analytics_worker_tx: Mutex::new(None),
             mask_cache: Mutex::new(HashMap::new()),
             patch_cache: Mutex::new(HashMap::new()),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -281,9 +281,86 @@ pub fn get_cached_full_warped_image(
     Ok(warped_arc)
 }
 
+fn clear_pending_display_frame_if_generation(state: &AppState, generation: usize) {
+    let mut pending = state.pending_display_frame.lock().unwrap();
+    if pending
+        .as_ref()
+        .is_some_and(|frame| frame.generation.number() == generation)
+    {
+        *pending = None;
+    }
+}
+
+fn schedule_display_completion(
+    app_handle: tauri::AppHandle,
+    context: &crate::image_processing::GpuContext,
+    frame: PendingDisplayFrame,
+    submission: wgpu::SubmissionIndex,
+) {
+    let device = context.device.clone();
+    std::thread::spawn(move || {
+        let completion = device.poll(wgpu::PollType::Wait {
+            submission_index: Some(submission),
+            timeout: Some(std::time::Duration::from_millis(500)),
+        });
+        if completion.is_ok() {
+            let _commit_guard = frame.generation.lock_commit();
+            if frame.generation.is_current() {
+                let _ = app_handle.emit(
+                    "wgpu-frame-ready",
+                    serde_json::json!({
+                        "path": frame.path,
+                        "generation": frame.generation.number(),
+                    }),
+                );
+            }
+        } else if let Err(error) = completion {
+            log::warn!("WGPU frame completion wait failed: {}", error);
+        }
+    });
+}
+
+fn render_wgpu_display(
+    app_handle: &tauri::AppHandle,
+    context: &crate::image_processing::GpuContext,
+) -> Result<(), String> {
+    let state = app_handle.state::<AppState>();
+    let pending = state.pending_display_frame.lock().unwrap().clone();
+
+    if let Some(frame) = pending {
+        let commit_generation = frame.generation.clone();
+        let _commit_guard = commit_generation.lock_commit();
+        if !frame.generation.is_current() {
+            clear_pending_display_frame_if_generation(&state, frame.generation.number());
+            return Ok(());
+        }
+
+        let result = {
+            let mut display_lock = context.display.lock().unwrap();
+            let display = display_lock
+                .as_mut()
+                .ok_or_else(|| "WGPU display is not initialized".to_string())?;
+            display.render(&context.device, &context.queue)?
+        };
+
+        if let gpu_processing::DisplayRenderResult::Submitted(submission) = result {
+            clear_pending_display_frame_if_generation(&state, frame.generation.number());
+            schedule_display_completion(app_handle.clone(), context, frame, submission);
+        }
+        return Ok(());
+    }
+
+    let mut display_lock = context.display.lock().unwrap();
+    if let Some(display) = display_lock.as_mut() {
+        let _ = display.render(&context.device, &context.queue)?;
+    }
+    Ok(())
+}
+
 #[tauri::command]
 async fn update_wgpu_transform(
     payload: WgpuTransformPayload,
+    app_handle: tauri::AppHandle,
     state: tauri::State<'_, AppState>,
 ) -> Result<(), String> {
     let context = match state.gpu_context.lock().unwrap().as_ref() {
@@ -291,7 +368,7 @@ async fn update_wgpu_transform(
         None => return Ok(()),
     };
 
-    tokio::task::spawn_blocking(move || {
+    tokio::task::spawn_blocking(move || -> Result<(), String> {
         let mut display_lock = context.display.lock().unwrap();
         if let Some(display) = display_lock.as_mut() {
             display.latest_transform.rect = [payload.x, payload.y, payload.width, payload.height];
@@ -311,11 +388,12 @@ async fn update_wgpu_transform(
                 0,
                 bytemuck::bytes_of(&display.latest_transform),
             );
-            let _ = display.render(&context.device, &context.queue);
         }
+        drop(display_lock);
+        render_wgpu_display(&app_handle, &context)
     })
     .await
-    .map_err(|e| format!("Task panicked: {}", e))?;
+    .map_err(|e| format!("Task panicked: {}", e))??;
 
     Ok(())
 }
@@ -547,33 +625,24 @@ fn process_preview_job(
 
     generation.ensure_current()?;
     if use_wgpu_renderer {
-        let submission = final_processed
-            .display_submission
-            .ok_or_else(|| "WGPU display did not submit a frame".to_string())?;
-        let device = context.device.clone();
-        let completion_app_handle = app_handle.clone();
-        let completion_generation = generation.clone();
-        let completion_path = loaded_image.path.clone();
-        std::thread::spawn(move || {
-            let completion = device.poll(wgpu::PollType::Wait {
-                submission_index: Some(submission),
-                timeout: Some(std::time::Duration::from_millis(500)),
-            });
-            if completion.is_ok() {
-                let _commit_guard = completion_generation.lock_commit();
-                if completion_generation.is_current() {
-                    let _ = completion_app_handle.emit(
-                        "wgpu-frame-ready",
-                        serde_json::json!({
-                            "path": completion_path,
-                            "generation": completion_generation.number(),
-                        }),
-                    );
-                }
-            } else if let Err(error) = completion {
-                log::warn!("WGPU frame completion wait failed: {}", error);
+        let frame = PendingDisplayFrame {
+            path: loaded_image.path.clone(),
+            generation: generation.clone(),
+        };
+        match final_processed.display_result {
+            gpu_processing::DisplayRenderResult::Submitted(submission) => {
+                *state.pending_display_frame.lock().unwrap() = None;
+                schedule_display_completion(app_handle.clone(), &context, frame, submission);
             }
-        });
+            gpu_processing::DisplayRenderResult::Deferred => {
+                let _commit_guard = generation.lock_commit();
+                generation.ensure_current()?;
+                *state.pending_display_frame.lock().unwrap() = Some(frame);
+            }
+            gpu_processing::DisplayRenderResult::Empty => {
+                return Err("WGPU display did not have a frame to present".to_string());
+            }
+        }
         return Ok(b"WGPU_RENDER".to_vec());
     }
 
@@ -1939,16 +2008,33 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(PinchZoomDisablePlugin)
-        .on_window_event(|window, event| if let tauri::WindowEvent::Resized(size) = event {
+        .on_window_event(|window, event| {
             let state = window.state::<AppState>();
-            if let Some(ctx) = state.gpu_context.lock().unwrap().as_ref()
-                && let Ok(mut display_lock) = ctx.display.try_lock()
-                    && let Some(display) = display_lock.as_mut() {
+            let context = state.gpu_context.lock().unwrap().as_ref().cloned();
+            let Some(context) = context else {
+                return;
+            };
+
+            let should_render = match event {
+                tauri::WindowEvent::Resized(size) => {
+                    if let Ok(mut display_lock) = context.display.try_lock()
+                        && let Some(display) = display_lock.as_mut()
+                    {
                         display.config.width = size.width.max(1);
                         display.config.height = size.height.max(1);
-                        display.surface.configure(&ctx.device, &display.config);
-                        let _ = display.render(&ctx.device, &ctx.queue);
+                        display.surface.configure(&context.device, &display.config);
                     }
+                    true
+                }
+                tauri::WindowEvent::Focused(true) => true,
+                _ => false,
+            };
+
+            if should_render
+                && let Err(error) = render_wgpu_display(window.app_handle(), &context)
+            {
+                log::warn!("WGPU display retry failed: {}", error);
+            }
         })
         .setup(move |app| {
             #[cfg(feature = "tethering")]
@@ -2292,6 +2378,7 @@ pub fn run() {
             thumbnail_progress: Mutex::new(ThumbnailProgressTracker { total: 0, completed: 0 }),
             preview_worker_tx: Mutex::new(None),
             preview_generation: PreviewGenerationTracker::new(),
+            pending_display_frame: Mutex::new(None),
             analytics_worker_tx: Mutex::new(None),
             mask_cache: Mutex::new(HashMap::new()),
             patch_cache: Mutex::new(HashMap::new()),


### PR DESCRIPTION
## Description

Moves the expensive compute-pipeline build out of the first editor render on macOS and prevents obsolete interactive previews from committing or announcing stale frames.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Performance improvement
- [x] Code refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Build/CI or Dependency update

## Changes Made

- prewarms the compute processor 350 ms after the macOS frontend is ready, but only while no image or preview work has started
- separates reusable size-dependent textures from static compute pipelines, so larger images resize textures without recompiling shaders
- preserves the larger capacity on each axis to avoid portrait/landscape resize thrash
- assigns monotonic generations to preview work and cancels obsolete jobs before GPU submissions
- guards the final working-texture copy and surface present as one short generation-aware commit
- waits for the exact display submission on a background thread before emitting frame readiness
- suppresses stale analytics and replaces a surface-retry panic with a normal render error
- treats an occluded or temporarily unavailable surface as deferred presentation, retains the newest completed frame, and retries on focus, resize, or transform updates
- emits `wgpu-frame-ready` only after the exact submitted work completes and only while that generation is still current

## Profiling and slider benchmark

I compared optimized packaged apps built from the exact base (`d6d8daa9`) and this branch using the same local 7728×5152 JPEG (39.8 MP). A script drove an actual `.slider-input` through a 30-step drag at 16 ms cadence in the foreground Tauri/WKWebView app. Each build ran 12 iterations; the first two were discarded as warmups and the remaining 10 were measured.

| Measurement | Exact base | This branch | Change |
|---|---:|---:|---:|
| Last input to final `wgpu-frame-ready`, median | 470 ms | 64 ms | -86.4% |
| Last input to final `wgpu-frame-ready`, p95 | 808 ms | 65 ms | -92.0% |
| UI animation rate, median | 59.993 FPS | 60.010 FPS | Essentially unchanged |
| Worst UI frame across measured runs, p95 | 95 ms | 58 ms | -38.9% |

Each measured candidate drag emitted one readiness event for the newest generation. Generation numbers advanced by 33 for each scripted drag, showing that the request burst collapsed to its final result instead of presenting every intermediate generation.

Pipeline initialization remained cache-dependent: one cold or partially cold process took 910.9 ms, while three subsequent processes took 11.2–12.9 ms. The benchmark therefore supports the request-supersession improvement in settled slider latency; it does not claim faster steady-state GPU shader execution or the same result on every GPU and image.

Profiling also exposed an occluded-surface correctness issue. The base could claim readiness despite not presenting a drawable; the previous PR head avoided that false event but treated occlusion as a terminal preview failure. Commit `b82a66e6` retains the newest completed GPU frame and defers presentation until the surface becomes available.

## Screenshots/Videos

Not applicable; this changes scheduling and GPU resource lifetime without changing the UI.

## Testing

- [ ] These changes were tested locally by a human and confirmed to work.
- [ ] I haven't added any automated tests to the code because the codebase currently lacks a test suite.

Automated, static, and runtime checks:

- `cargo fmt --all -- --check`
- `cargo check --release --locked --features tauri/custom-protocol`
- `cargo clippy --locked --lib -- -D warnings`
- `cargo test --locked --lib` (5 focused tests passed)
- matched packaged-app slider benchmark described above

**Test Configuration:**

- **OS:** macOS 26.6.2
- **Hardware:** Apple M5 Pro MacBook Pro, 24 GB
- **Rust/Cargo:** 1.98.0

## Checklist

- [x] My code follows the project's code style
- [x] I haven't added unnecessary AI-generated code comments
- [x] My changes generate no new warnings or errors

## Additional Notes

The background frame-completion wait is tied to the exact surface submission. Queue ordering guarantees that the preceding compute and output-copy submissions are complete before readiness is emitted.

## AI Disclaimer

- [x] This PR is created by an AI agent
- [ ] This PR is mostly AI-generated but edited/merged together by a human
- [ ] This PR was handwritten with AI assistance (spell check, logic suggestions, error resolving)
- [ ] This PR contains only blood, sweat, and coffee (AI-free)
