### PR TITLE
Add an opt-in color-managed white balance path for RAW files

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "mozjpeg-rs",
+ "naga",
  "nalgebra",
  "ndarray",
  "ndk-context",
@@ -46,6 +47,7 @@ dependencies = [
  "pollster",
  "quick-xml 0.41.0",
  "rand 0.10.2",
+ "rawcolor",
  "rawler",
  "rayon",
  "regex",
@@ -5225,6 +5227,12 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
 ]
+
+[[package]]
+name = "rawcolor"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1839c82df8c23135a69c027587efada55602a7311af4b5849313062f831630ca"
 
 [[package]]
 name = "rawler"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -29,6 +29,7 @@ bytemuck = { version = "1.25", features = ["derive"] }
 anyhow = "1.0.104"
 kamadak-exif = "0.6.1"
 rawler = { git = "https://github.com/CyberTimon/RapidRAW-DngLab.git" }
+rawcolor = "0.1.1"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1.25", features = ["v4", "serde"] }
 walkdir = "2.5.0"
@@ -114,3 +115,6 @@ strip = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
+[dev-dependencies]
+naga = { version = "29.0", features = ["wgsl-in"] }

--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -464,6 +464,10 @@ pub struct AppSettings {
     pub display_edit_icon: Option<bool>,
     #[serde(default = "default_linear_raw_mode")]
     pub linear_raw_mode: String,
+    /// Develop raws to camera-native RGB and do white balance colorimetrically
+    /// on the GPU, instead of letting rawler calibrate with a fixed matrix.
+    #[serde(default)]
+    pub color_managed_wb: Option<bool>,
     #[serde(default)]
     pub enable_xmp_sync: Option<bool>,
     #[serde(default)]
@@ -582,6 +586,7 @@ impl Default for AppSettings {
             enable_folder_image_counts: Some(false),
             display_edit_icon: Some(true),
             linear_raw_mode: default_linear_raw_mode(),
+            color_managed_wb: Some(false),
             enable_xmp_sync: Some(true),
             create_xmp_if_missing: Some(false),
             is_waveform_visible: Some(false),

--- a/src-tauri/src/app_state.rs
+++ b/src-tauri/src/app_state.rs
@@ -35,6 +35,9 @@ pub struct LoadedImage {
     pub path: String,
     pub image: Arc<DynamicImage>,
     pub is_raw: bool,
+    /// Camera calibration for raw files, used to resolve white balance without
+    /// decoding again. `None` for non-raws and for raws with no usable profile.
+    pub color_info: Option<crate::color_management::CameraColorInfo>,
 }
 
 #[derive(Clone)]

--- a/src-tauri/src/cache_utils.rs
+++ b/src-tauri/src/cache_utils.rs
@@ -229,9 +229,20 @@ pub fn calculate_full_job_hash(path: &str, adjustments: &serde_json::Value) -> u
     hasher.finish()
 }
 
+type DecodedEntry = (
+    String,
+    Arc<DynamicImage>,
+    HashMap<String, String>,
+    Option<crate::color_management::CameraColorInfo>,
+    // Whether these pixels were developed color-managed. Stored rather than
+    // inferred from the profile, because a file with no usable calibration
+    // yields no profile in either mode and would otherwise never cache-hit.
+    bool,
+);
+
 pub struct DecodedImageCache {
     capacity: usize,
-    items: Vec<(String, Arc<DynamicImage>, HashMap<String, String>)>,
+    items: Vec<DecodedEntry>,
 }
 
 impl DecodedImageCache {
@@ -249,10 +260,26 @@ impl DecodedImageCache {
         }
     }
 
-    pub fn get(&mut self, path: &str) -> Option<(Arc<DynamicImage>, HashMap<String, String>)> {
-        if let Some(pos) = self.items.iter().position(|(p, _, _)| p == path) {
+    /// Look up decoded pixels developed in the given mode.
+    ///
+    /// A mode mismatch is a miss: the buffers hold different data.
+    #[allow(clippy::type_complexity)]
+    pub fn get(
+        &mut self,
+        path: &str,
+        color_managed: bool,
+    ) -> Option<(
+        Arc<DynamicImage>,
+        HashMap<String, String>,
+        Option<crate::color_management::CameraColorInfo>,
+    )> {
+        if let Some(pos) = self
+            .items
+            .iter()
+            .position(|(p, _, _, _, m)| p == path && *m == color_managed)
+        {
             let item = self.items.remove(pos);
-            let result = (item.1.clone(), item.2.clone());
+            let result = (item.1.clone(), item.2.clone(), item.3.clone());
             self.items.push(item);
             Some(result)
         } else {
@@ -269,13 +296,20 @@ impl DecodedImageCache {
         path: String,
         image: Arc<DynamicImage>,
         exif: HashMap<String, String>,
+        color_info: Option<crate::color_management::CameraColorInfo>,
+        color_managed: bool,
     ) {
-        if let Some(pos) = self.items.iter().position(|(p, _, _)| *p == path) {
+        if let Some(pos) = self
+            .items
+            .iter()
+            .position(|(p, _, _, _, m)| *p == path && *m == color_managed)
+        {
             self.items.remove(pos);
         } else if self.items.len() >= self.capacity {
             self.items.remove(0);
         }
-        self.items.push((path, image, exif));
+        self.items
+            .push((path, image, exif, color_info, color_managed));
     }
 }
 

--- a/src-tauri/src/color_management.rs
+++ b/src-tauri/src/color_management.rs
@@ -1,0 +1,677 @@
+//! Bridge from rawler's decoded metadata to rawcolor's camera profiles.
+//!
+//! rawler carries every calibration matrix the file declares, keyed by
+//! illuminant, but its develop path picks the D65 one and ignores the rest.
+//! That means a tungsten-lit frame gets developed through the daylight matrix.
+//! This module hands the full set to rawcolor so the matrix can be interpolated
+//! for the actual scene illuminant instead.
+//!
+//! The profile is extracted at decode time and carried alongside the image so
+//! the renderer can resolve white balance per adjustment without re-decoding.
+//! The develop path itself still runs rawler's own calibration — switching it
+//! to camera-native output has to land together with the shader change.
+#![allow(dead_code)]
+
+use rawcolor::{
+    camera::{Calibration, CalibrationIlluminant, CameraProfile},
+    cct::{TempTint, chromaticity_to_temp_tint},
+    math::{Mat3, Vec3},
+};
+use rawcolor::{cat::Cat, rgb::RgbSpace, wb::WhiteBalance};
+use rawler::{imgop::xyz::Illuminant, rawimage::RawImage};
+
+/// Working space for the editing pipeline.
+///
+/// This has to match whatever the rest of the pipeline thinks its numbers
+/// are in, which is sRGB primaries at D65 - see `PRIMARIES_SRGB` in
+/// `image_processing.rs`, where AgX takes the pipe as sRGB and converts to
+/// Rec.2020 for its own rendering transform. Handing the pipe Rec.2020
+/// instead reads as desaturation, because every later stage misinterprets it.
+///
+/// Widening the pipe is worth doing - sRGB primaries clip saturated reds a
+/// raw file can capture - but it is a pipeline-wide change, not this one.
+pub const WORKING_SPACE: RgbSpace = RgbSpace::SRGB;
+
+/// Adaptation used when moving between white points. Bradford is what ICC and
+/// DNG both assume, so this keeps results comparable with other tools.
+pub const ADAPTATION: Cat = Cat::Bradford;
+
+/// White balance resolved for the renderer.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResolvedWhiteBalance {
+    /// Camera-space gains, green normalized to 1.
+    pub coefficients: [f32; 3],
+    /// Camera RGB to the working space, column-major.
+    pub camera_to_working: [[f32; 3]; 3],
+    /// Where the sliders ended up, for display.
+    pub cct: f64,
+    /// Tint as Duv.
+    pub duv: f64,
+    /// Highlight roll-off limit, carried through from the decode that produced
+    /// these pixels so the shader rolls off exactly what develop assumed.
+    pub highlight_compression: f32,
+}
+
+/// Everything needed to resolve white balance for one image.
+///
+/// Built once when the file is decoded and kept with the loaded image, since
+/// re-deriving it means decoding the raw again.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CameraColorInfo {
+    /// The camera's calibration, for interpolating the color matrix.
+    pub profile: CameraProfile,
+    /// As-shot white balance gains from the file, normalized to green.
+    pub as_shot_coefficients: Option<Vec3>,
+    /// The as-shot balance expressed as temperature and tint. This is what the
+    /// UI sliders should be seeded with, and what "As Shot" resets to.
+    pub as_shot_temp_tint: Option<TempTint>,
+    /// The highlight compression this image was developed under. Held here
+    /// rather than read at render time so it cannot drift from the decode.
+    pub highlight_compression: f32,
+}
+
+impl CameraColorInfo {
+    /// Extract color information from a decoded raw image.
+    ///
+    /// Returns `None` when the file carries no usable calibration, in which
+    /// case the caller keeps the existing develop path.
+    /// Resolve white balance for a chosen temperature and tint.
+    ///
+    /// Falling back to the as-shot values when the target is unusable keeps a
+    /// nonsense slider position from blanking the image.
+    pub fn resolve(&self, cct: f64, duv: f64) -> Option<ResolvedWhiteBalance> {
+        let requested = TempTint::new(
+            cct.clamp(rawcolor::cct::MIN_CCT, rawcolor::cct::MAX_CCT),
+            duv,
+        );
+        let wb = match WhiteBalance::from_temp_tint(
+            &self.profile,
+            requested,
+            &WORKING_SPACE,
+            ADAPTATION,
+        ) {
+            Ok(wb) => wb,
+            Err(_) => {
+                let fallback = self.as_shot_temp_tint?;
+                WhiteBalance::from_temp_tint(&self.profile, fallback, &WORKING_SPACE, ADAPTATION)
+                    .ok()?
+            }
+        };
+
+        Some(ResolvedWhiteBalance {
+            coefficients: wb.coefficients_f32(),
+            camera_to_working: wb.matrix_f32(),
+            highlight_compression: self.highlight_compression,
+            cct: wb.temp_tint.cct,
+            duv: wb.temp_tint.duv,
+        })
+    }
+
+    /// Resolve at the camera's as-shot white balance.
+    pub fn resolve_as_shot(&self) -> Option<ResolvedWhiteBalance> {
+        let tt = self.as_shot_temp_tint?;
+        self.resolve(tt.cct, tt.duv)
+    }
+
+    pub fn from_raw(raw: &RawImage, highlight_compression: f32) -> Option<Self> {
+        let Some(profile) = profile_from_raw(raw) else {
+            log::warn!(
+                "Color management: no usable calibration for '{} {}' ({} matrices in file), keeping the default develop path",
+                raw.clean_make,
+                raw.clean_model,
+                raw.color_matrix.len(),
+            );
+            return None;
+        };
+        let as_shot_coefficients = as_shot_coefficients(raw);
+
+        // Gains are the reciprocal of the neutral the camera recorded, so
+        // invert before asking the profile what illuminant produced it.
+        let as_shot_temp_tint = as_shot_coefficients
+            .and_then(|c| c.recip_safe(1e-12).normalized_to(1, 1e-12))
+            .and_then(|neutral| profile.neutral_to_xy(neutral).ok())
+            .and_then(chromaticity_to_temp_tint);
+
+        match as_shot_temp_tint {
+            Some(tt) => log::info!(
+                "Color management: '{} {}' calibrated for {:?}{}, as shot {:.0}K duv {:+.4}",
+                raw.clean_make,
+                raw.clean_model,
+                profile.primary.illuminant,
+                profile
+                    .secondary
+                    .map(|c| format!(" and {:?}", c.illuminant))
+                    .unwrap_or_default(),
+                tt.cct,
+                tt.duv,
+            ),
+            None => log::warn!(
+                "Color management: '{} {}' has a profile but no usable as-shot white balance",
+                raw.clean_make,
+                raw.clean_model,
+            ),
+        }
+
+        Some(CameraColorInfo {
+            profile,
+            as_shot_coefficients,
+            as_shot_temp_tint,
+            highlight_compression,
+        })
+    }
+}
+
+/// Map a rawler illuminant onto rawcolor's.
+///
+/// Both enums use the EXIF LightSource codes as discriminants, so this is a
+/// numeric hand-off rather than a translation table. `Unknown` has no defined
+/// chromaticity and is dropped.
+fn convert_illuminant(illuminant: Illuminant) -> Option<CalibrationIlluminant> {
+    if illuminant == Illuminant::Unknown {
+        return None;
+    }
+    CalibrationIlluminant::from_exif_code(illuminant as u16)
+}
+
+/// Reshape rawler's flat row-major matrix into a 3x3.
+///
+/// Returns `None` for four-color sensors (RGBE, CMYG), whose matrices are 4x3.
+/// Those keep the existing develop path — handling them needs a 4xN transform
+/// that rawcolor does not model.
+fn to_mat3(flat: &[f32]) -> Option<Mat3> {
+    if flat.len() != 9 {
+        return None;
+    }
+    let mut rows = [[0.0f64; 3]; 3];
+    for r in 0..3 {
+        for c in 0..3 {
+            rows[r][c] = flat[r * 3 + c] as f64;
+        }
+    }
+    let m = Mat3::new(rows);
+    // A matrix that cannot be inverted is unusable downstream, so reject it
+    // here rather than letting it fail later inside the solver.
+    m.inverse().map(|_| m)
+}
+
+/// Build a camera profile from a decoded raw image.
+///
+/// Returns `None` when the file carries no usable 3x3 calibration, in which
+/// case callers should fall back to rawler's own develop path.
+pub fn profile_from_raw(raw: &RawImage) -> Option<CameraProfile> {
+    let mut calibrations: Vec<(f64, Calibration)> = raw
+        .color_matrix
+        .iter()
+        .filter_map(|(illuminant, flat)| {
+            let illuminant = convert_illuminant(*illuminant)?;
+            let matrix = to_mat3(flat)?;
+            Some((illuminant.cct(), Calibration::new(illuminant, matrix)))
+        })
+        .collect();
+
+    if calibrations.is_empty() {
+        return None;
+    }
+
+    // Sort by temperature so the selection below is deterministic. The source
+    // is a HashMap, whose iteration order is not.
+    calibrations.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+    if calibrations.len() == 1 {
+        return Some(CameraProfile::single(calibrations.remove(0).1));
+    }
+
+    // Use the widest available pair. Interpolating between the extremes covers
+    // the whole range; intermediate calibrations would need a piecewise blend
+    // that DNG itself does not define.
+    let cool = calibrations.pop()?.1;
+    let warm = calibrations.remove(0).1;
+    Some(CameraProfile::dual(warm, cool))
+}
+
+/// The camera's as-shot white balance coefficients, normalized to green.
+///
+/// rawler reports `wb_coeffs` in RGBE order and signals "absent" with NaN in
+/// the first slot.
+pub fn as_shot_coefficients(raw: &RawImage) -> Option<Vec3> {
+    let coeffs = raw.wb_coeffs;
+    if coeffs[..3].iter().any(|c| !c.is_finite() || *c <= 0.0) {
+        return None;
+    }
+    Vec3::new(coeffs[0] as f64, coeffs[1] as f64, coeffs[2] as f64).normalized_to(1, 1e-12)
+}
+
+/// Full-scale travel of the temperature slider, in mired.
+///
+/// Matches the constant the Lightroom preset importer already uses, so a
+/// slider position keeps meaning the same shift it did before.
+const MAX_MIRED_SHIFT: f64 = 150.0;
+
+/// Full-scale travel of the tint slider, in Duv.
+///
+/// Approximate: the slider was never calibrated against a colorimetric unit,
+/// so this is chosen to cover the useful range rather than derived.
+const MAX_DUV_SHIFT: f64 = 0.03;
+
+/// Turn the UI's relative temperature and tint into an absolute white point.
+///
+/// The sliders are offsets from the as-shot value rather than absolutes, which
+/// is what existing presets and sidecars encode. Reading them that way keeps
+/// saved edits meaning what they meant before.
+pub fn target_temp_tint(info: &CameraColorInfo, js_adjustments: &serde_json::Value) -> (f64, f64) {
+    let as_shot = info
+        .as_shot_temp_tint
+        .unwrap_or_else(|| TempTint::new(5500.0, 0.0));
+
+    let temperature = js_adjustments
+        .get("temperature")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0)
+        .clamp(-100.0, 100.0);
+    let tint = js_adjustments
+        .get("tint")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0)
+        .clamp(-100.0, 100.0);
+
+    // Warming the image means telling the renderer the light was bluer than
+    // assumed, so a positive slider raises the target temperature.
+    let as_shot_mired = 1.0e6 / as_shot.cct;
+    let target_mired = (as_shot_mired - (temperature / 100.0) * MAX_MIRED_SHIFT)
+        .max(1.0e6 / rawcolor::cct::MAX_CCT);
+
+    // Same inversion as temperature. A magenta image comes from telling the
+    // renderer the light was greener than assumed, so a positive slider raises
+    // Duv even though positive Duv is itself the green direction.
+    let duv = as_shot.duv + (tint / 100.0) * MAX_DUV_SHIFT;
+
+    (1.0e6 / target_mired, duv)
+}
+
+/// Point a render at the color-managed white balance path.
+///
+/// Does nothing without a profile, which is also the signal that the pixels
+/// are camera-native, so the two stay in step.
+pub fn apply_to_render(
+    adjustments: &mut crate::image_processing::AllAdjustments,
+    color_info: Option<&CameraColorInfo>,
+    js_adjustments: &serde_json::Value,
+) {
+    let Some(info) = color_info else {
+        return;
+    };
+    let (cct, duv) = target_temp_tint(info, js_adjustments);
+    if let Some(resolved) = info.resolve(cct, duv) {
+        adjustments.set_camera_color(&resolved);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rawcolor::{cat::Cat, cct::TempTint, rgb::RgbSpace, wb::WhiteBalance};
+    use std::collections::HashMap;
+
+    fn tungsten_flat() -> Vec<f32> {
+        vec![
+            0.7137, -0.1793, -0.0442, -0.4894, 1.2521, 0.2647, -0.0774, 0.1258, 0.7773,
+        ]
+    }
+
+    fn daylight_flat() -> Vec<f32> {
+        vec![
+            0.7866, -0.2108, -0.0555, -0.4869, 1.2483, 0.2681, -0.0856, 0.1287, 0.7473,
+        ]
+    }
+
+    fn profile_from_map(entries: Vec<(Illuminant, Vec<f32>)>) -> Option<CameraProfile> {
+        // profile_from_raw only reads color_matrix, so exercising the same
+        // logic over a bare map avoids constructing a whole RawImage.
+        let map: HashMap<Illuminant, Vec<f32>> = entries.into_iter().collect();
+        let mut calibrations: Vec<(f64, Calibration)> = map
+            .iter()
+            .filter_map(|(illuminant, flat)| {
+                let illuminant = convert_illuminant(*illuminant)?;
+                let matrix = to_mat3(flat)?;
+                Some((illuminant.cct(), Calibration::new(illuminant, matrix)))
+            })
+            .collect();
+        if calibrations.is_empty() {
+            return None;
+        }
+        calibrations.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        if calibrations.len() == 1 {
+            return Some(CameraProfile::single(calibrations.remove(0).1));
+        }
+        let cool = calibrations.pop()?.1;
+        let warm = calibrations.remove(0).1;
+        Some(CameraProfile::dual(warm, cool))
+    }
+
+    #[test]
+    fn illuminant_codes_hand_off_numerically() {
+        assert_eq!(
+            convert_illuminant(Illuminant::A),
+            Some(CalibrationIlluminant::StandardA)
+        );
+        assert_eq!(
+            convert_illuminant(Illuminant::D65),
+            Some(CalibrationIlluminant::D65)
+        );
+        assert_eq!(
+            convert_illuminant(Illuminant::Tungsten),
+            Some(CalibrationIlluminant::Tungsten)
+        );
+        assert_eq!(convert_illuminant(Illuminant::Unknown), None);
+    }
+
+    #[test]
+    fn four_color_matrices_are_declined() {
+        assert!(to_mat3(&vec![0.5; 12]).is_none());
+        assert!(to_mat3(&vec![0.5; 3]).is_none());
+    }
+
+    #[test]
+    fn singular_matrices_are_declined() {
+        // Third row is the sum of the first two.
+        let flat = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 5.0, 7.0, 9.0];
+        assert!(to_mat3(&flat).is_none());
+    }
+
+    #[test]
+    fn dual_illuminant_file_yields_an_interpolating_profile() {
+        let profile = profile_from_map(vec![
+            (Illuminant::A, tungsten_flat()),
+            (Illuminant::D65, daylight_flat()),
+        ])
+        .expect("two valid matrices must produce a profile");
+
+        assert_eq!(profile.primary.illuminant, CalibrationIlluminant::StandardA);
+        assert!(profile.secondary.is_some());
+
+        // The whole point: the matrix must actually change with temperature.
+        let warm = profile.xyz_to_camera_at_cct(3000.0);
+        let cool = profile.xyz_to_camera_at_cct(6500.0);
+        assert!(
+            (warm.rows[0][0] - cool.rows[0][0]).abs() > 1e-4,
+            "matrix did not vary with illuminant"
+        );
+    }
+
+    #[test]
+    fn single_illuminant_file_still_works() {
+        let profile = profile_from_map(vec![(Illuminant::D65, daylight_flat())])
+            .expect("one matrix is enough");
+        assert!(profile.secondary.is_none());
+        assert_eq!(
+            profile.xyz_to_camera_at_cct(3000.0),
+            profile.xyz_to_camera_at_cct(6500.0)
+        );
+    }
+
+    #[test]
+    fn unusable_matrices_leave_no_profile() {
+        assert!(profile_from_map(vec![(Illuminant::Unknown, daylight_flat())]).is_none());
+        assert!(profile_from_map(vec![(Illuminant::D65, vec![0.5; 12])]).is_none());
+        assert!(profile_from_map(vec![]).is_none());
+    }
+
+    #[test]
+    fn selection_is_stable_regardless_of_map_order() {
+        // The source is a HashMap, so this guards the ordering fix.
+        let a = profile_from_map(vec![
+            (Illuminant::A, tungsten_flat()),
+            (Illuminant::D65, daylight_flat()),
+            (Illuminant::D50, daylight_flat()),
+        ]);
+        let b = profile_from_map(vec![
+            (Illuminant::D50, daylight_flat()),
+            (Illuminant::D65, daylight_flat()),
+            (Illuminant::A, tungsten_flat()),
+        ]);
+        assert_eq!(a, b);
+        let profile = a.unwrap();
+        assert_eq!(profile.primary.illuminant, CalibrationIlluminant::StandardA);
+        assert_eq!(
+            profile.secondary.unwrap().illuminant,
+            CalibrationIlluminant::D65
+        );
+    }
+
+    #[test]
+    fn resolve_produces_gains_that_neutralize_the_scene() {
+        let info = CameraColorInfo {
+            profile: profile_from_map(vec![
+                (Illuminant::A, tungsten_flat()),
+                (Illuminant::D65, daylight_flat()),
+            ])
+            .unwrap(),
+            as_shot_coefficients: None,
+            as_shot_temp_tint: None,
+            highlight_compression: 2.5,
+        };
+
+        for cct in [2800.0, 4000.0, 5500.0, 6504.0, 9000.0] {
+            let resolved = info.resolve(cct, 0.0).expect("resolve must succeed");
+            assert!((resolved.cct - cct).abs() < 5.0, "got {}K", resolved.cct);
+            // Green stays at unity so the transform never darkens the image.
+            assert!((resolved.coefficients[1] - 1.0).abs() < 1e-6);
+            assert!(
+                resolved
+                    .coefficients
+                    .iter()
+                    .all(|c| c.is_finite() && *c > 0.0)
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_clamps_absurd_temperatures_instead_of_failing() {
+        let info = CameraColorInfo {
+            profile: profile_from_map(vec![(Illuminant::D65, daylight_flat())]).unwrap(),
+            as_shot_coefficients: None,
+            as_shot_temp_tint: None,
+            highlight_compression: 2.5,
+        };
+        let cold = info.resolve(-1000.0, 0.0).expect("clamped, not rejected");
+        let hot = info.resolve(1.0e9, 0.0).expect("clamped, not rejected");
+        assert!(cold.cct >= rawcolor::cct::MIN_CCT - 1.0);
+        assert!(hot.cct <= rawcolor::cct::MAX_CCT + 1.0);
+    }
+
+    #[test]
+    fn warmer_target_lifts_blue_relative_to_red() {
+        let info = CameraColorInfo {
+            profile: profile_from_map(vec![
+                (Illuminant::A, tungsten_flat()),
+                (Illuminant::D65, daylight_flat()),
+            ])
+            .unwrap(),
+            as_shot_coefficients: None,
+            as_shot_temp_tint: None,
+            highlight_compression: 2.5,
+        };
+        let tungsten = info.resolve(2856.0, 0.0).unwrap();
+        let daylight = info.resolve(6504.0, 0.0).unwrap();
+        assert!(tungsten.coefficients[2] > daylight.coefficients[2]);
+        assert!(tungsten.coefficients[0] < daylight.coefficients[0]);
+    }
+
+    fn info_at(cct: f64) -> CameraColorInfo {
+        CameraColorInfo {
+            profile: profile_from_map(vec![
+                (Illuminant::A, tungsten_flat()),
+                (Illuminant::D65, daylight_flat()),
+            ])
+            .unwrap(),
+            as_shot_coefficients: None,
+            as_shot_temp_tint: Some(TempTint::new(cct, 0.0)),
+            highlight_compression: 2.5,
+        }
+    }
+
+    #[test]
+    fn neutral_sliders_reproduce_the_as_shot_white_point() {
+        let info = info_at(5200.0);
+        let (cct, duv) = target_temp_tint(&info, &serde_json::json!({}));
+        assert!((cct - 5200.0).abs() < 1e-6, "got {cct}");
+        assert!(duv.abs() < 1e-12);
+    }
+
+    #[test]
+    fn positive_temperature_warms_the_image() {
+        // Warmer output means a higher assumed scene temperature.
+        let info = info_at(5000.0);
+        let (warm, _) = target_temp_tint(&info, &serde_json::json!({"temperature": 100.0}));
+        let (cool, _) = target_temp_tint(&info, &serde_json::json!({"temperature": -100.0}));
+        assert!(warm > 5000.0, "warm slider gave {warm}");
+        assert!(cool < 5000.0, "cool slider gave {cool}");
+
+        // Full scale is the same 150 mired the preset importer assumes.
+        let expected = 1.0e6 / (1.0e6 / 5000.0 - 150.0);
+        assert!((warm - expected).abs() < 1e-6, "{warm} vs {expected}");
+    }
+
+    /// How magenta a camera-neutral pixel renders under a given slider setting.
+    ///
+    /// Asserting on the Duv that comes out of `target_temp_tint` is what let
+    /// the sign error through the first time: that is the illuminant's tint,
+    /// and the render divides by it, so it reads backwards from the image.
+    /// This goes all the way to a pixel instead.
+    fn rendered_magenta(info: &CameraColorInfo, tint: f64) -> f64 {
+        let (cct, duv) = target_temp_tint(info, &serde_json::json!({ "tint": tint }));
+        let resolved = info.resolve(cct, duv).expect("must resolve");
+        let [gr, gg, gb] = resolved.coefficients;
+        let m = resolved.camera_to_working;
+
+        // A neutral sensor reading, balanced and taken into the working space.
+        let balanced = [gr, gg, gb];
+        let out: Vec<f64> = (0..3)
+            .map(|row| {
+                (0..3)
+                    .map(|col| m[col][row] as f64 * balanced[col] as f64)
+                    .sum()
+            })
+            .collect();
+
+        (out[0] + out[2]) / 2.0 - out[1]
+    }
+
+    #[test]
+    fn resolve_carries_the_highlight_limit_to_the_renderer() {
+        // The shader reads this out of wb_coefficients.w and rolls highlights
+        // off with it, because develop no longer can - its own branch only
+        // fires above 1.0, and camera-native data never gets there. A zero
+        // here would silently disable the roll-off all over again.
+        let mut info = info_at(5000.0);
+        info.highlight_compression = 3.25;
+        let resolved = info.resolve(5000.0, 0.0).expect("must resolve");
+        assert!((resolved.highlight_compression - 3.25).abs() < 1e-6);
+
+        let mut adj = crate::image_processing::AllAdjustments::default();
+        adj.set_camera_color(&resolved);
+        assert!((adj.global.wb_coefficients[3] - 3.25).abs() < 1e-6);
+
+        // And the path reads as live, which is the same field.
+        assert!(adj.global.wb_coefficients[3] > 0.0);
+    }
+
+    #[test]
+    fn working_space_matches_the_rest_of_the_pipeline() {
+        // image_processing.rs feeds AgX PRIMARIES_SRGB at WP_D65 as the pipe
+        // profile. camera_to_working writes into that same pipe, so the two
+        // have to name the same space. If someone widens the pipeline, this
+        // fails and points at the constant that also needs changing.
+        let expect = [
+            (WORKING_SPACE.red, [0.64, 0.33]),
+            (WORKING_SPACE.green, [0.30, 0.60]),
+            (WORKING_SPACE.blue, [0.15, 0.06]),
+            (WORKING_SPACE.white, [0.3127, 0.3290]),
+        ];
+        for (got, [x, y]) in expect {
+            assert!(
+                (got.x - x).abs() < 1e-4 && (got.y - y).abs() < 1e-4,
+                "working space drifted from the pipeline: got ({}, {}), pipeline has ({x}, {y})",
+                got.x,
+                got.y
+            );
+        }
+    }
+
+    #[test]
+    fn positive_tint_renders_more_magenta() {
+        let info = info_at(5000.0);
+        let magenta = rendered_magenta(&info, 100.0);
+        let neutral = rendered_magenta(&info, 0.0);
+        let green = rendered_magenta(&info, -100.0);
+
+        assert!(
+            magenta > neutral,
+            "positive tint must render magenta: {magenta} vs {neutral}"
+        );
+        assert!(
+            green < neutral,
+            "negative tint must render green: {green} vs {neutral}"
+        );
+    }
+
+    #[test]
+    fn tint_slider_matches_the_legacy_shader_direction() {
+        // apply_white_balance in shader.wgsl scales (r, g, b) by
+        // (1 + t*0.25, 1 - t*0.25, 1 + t*0.25), so a positive slider lifts red
+        // and blue over green. The color-managed path has to agree, or saved
+        // edits flip sign the moment the setting is switched on.
+        let info = info_at(5000.0);
+        assert!(rendered_magenta(&info, 50.0) > rendered_magenta(&info, -50.0));
+    }
+
+    #[test]
+    fn sliders_stay_inside_the_supported_range() {
+        let info = info_at(2000.0);
+        let (cct, _) = target_temp_tint(&info, &serde_json::json!({"temperature": -100.0}));
+        assert!(cct >= rawcolor::cct::MIN_CCT * 0.5, "got {cct}");
+        assert!(
+            info.resolve(cct, 0.0).is_some(),
+            "must still resolve at {cct}"
+        );
+    }
+
+    #[test]
+    fn out_of_range_slider_values_are_clamped() {
+        let info = info_at(5000.0);
+        let (huge, _) = target_temp_tint(&info, &serde_json::json!({"temperature": 100000.0}));
+        let (at_max, _) = target_temp_tint(&info, &serde_json::json!({"temperature": 100.0}));
+        assert!((huge - at_max).abs() < 1e-9);
+    }
+
+    #[test]
+    fn round_trips_into_a_usable_white_balance() {
+        // End to end: a file's matrices resolve to gains and a matrix that
+        // render the as-shot neutral neutral.
+        let profile = profile_from_map(vec![
+            (Illuminant::A, tungsten_flat()),
+            (Illuminant::D65, daylight_flat()),
+        ])
+        .unwrap();
+
+        let wb = WhiteBalance::from_temp_tint(
+            &profile,
+            TempTint::new(3200.0, 0.0),
+            &RgbSpace::REC2020,
+            Cat::Bradford,
+        )
+        .unwrap();
+
+        let scene = rawcolor::cct::temp_tint_to_chromaticity(TempTint::new(3200.0, 0.0)).unwrap();
+        let camera_pixel = profile.xy_to_neutral(scene).unwrap();
+        let balanced = Vec3::new(
+            camera_pixel.x() * wb.coefficients.x(),
+            camera_pixel.y() * wb.coefficients.y(),
+            camera_pixel.z() * wb.coefficients.z(),
+        );
+        let working = wb.camera_to_working * balanced;
+        let max = working.max_component();
+        assert!((working.x() / max - working.y() / max).abs() < 1e-6);
+        assert!((working.y() / max - working.z() / max).abs() < 1e-6);
+    }
+}

--- a/src-tauri/src/color_management.rs
+++ b/src-tauri/src/color_management.rs
@@ -8,8 +8,9 @@
 //!
 //! The profile is extracted at decode time and carried alongside the image so
 //! the renderer can resolve white balance per adjustment without re-decoding.
-//! The develop path itself still runs rawler's own calibration — switching it
-//! to camera-native output has to land together with the shader change.
+//! With a profile present the buffer is camera-native, and every consumer of
+//! it has to apply the transform: the GPU path through `apply_to_render`, the
+//! CPU path through `develop_to_working`.
 #![allow(dead_code)]
 
 use rawcolor::{
@@ -306,6 +307,58 @@ pub fn apply_to_render(
     }
 }
 
+/// Apply the color-managed white balance on the CPU.
+///
+/// The same arithmetic as `apply_camera_color` in the shader, for consumers
+/// that read the camera-native buffer without rendering it on the GPU:
+/// thumbnails and the auto-adjustment analysis. Keep the two in step.
+pub fn develop_to_working(
+    image: &image::DynamicImage,
+    info: &CameraColorInfo,
+    js_adjustments: &serde_json::Value,
+) -> image::DynamicImage {
+    use rayon::prelude::*;
+
+    let (cct, duv) = target_temp_tint(info, js_adjustments);
+    let Some(resolved) = info.resolve(cct, duv) else {
+        return image.clone();
+    };
+    let [gain_r, gain_g, gain_b] = resolved.coefficients;
+    let limit = resolved.highlight_compression.max(1.01);
+    let cols = resolved.camera_to_working;
+
+    let mut buffer = image.to_rgba32f();
+    let samples: &mut [f32] = &mut buffer;
+    samples.par_chunks_mut(4).for_each(|px| {
+        let balanced = roll_off_highlights([px[0] * gain_r, px[1] * gain_g, px[2] * gain_b], limit);
+        for (channel, out) in px.iter_mut().take(3).enumerate() {
+            *out = cols[0][channel] * balanced[0]
+                + cols[1][channel] * balanced[1]
+                + cols[2][channel] * balanced[2];
+        }
+    });
+    image::DynamicImage::ImageRgba32F(buffer)
+}
+
+/// Highlight roll-off, mirroring the shader: above 1.0, compress toward the
+/// darkest channel so a blown pixel lands on neutral, then put the original
+/// brightness back.
+fn roll_off_highlights(balanced: [f32; 3], limit: f32) -> [f32; 3] {
+    let max_c = balanced[0].max(balanced[1]).max(balanced[2]);
+    if max_c <= 1.0 {
+        return balanced;
+    }
+    let min_c = balanced[0].min(balanced[1]).min(balanced[2]);
+    let factor = (1.0 - (max_c - 1.0) / (limit - 1.0)).clamp(0.0, 1.0);
+    let compressed = balanced.map(|c| min_c + (c - min_c) * factor);
+    let compressed_max = compressed[0].max(compressed[1]).max(compressed[2]);
+    if compressed_max > 1e-6 {
+        compressed.map(|c| c * (max_c / compressed_max))
+    } else {
+        [max_c; 3]
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -367,8 +420,8 @@ mod tests {
 
     #[test]
     fn four_color_matrices_are_declined() {
-        assert!(to_mat3(&vec![0.5; 12]).is_none());
-        assert!(to_mat3(&vec![0.5; 3]).is_none());
+        assert!(to_mat3(&[0.5; 12]).is_none());
+        assert!(to_mat3(&[0.5; 3]).is_none());
     }
 
     #[test]
@@ -673,5 +726,55 @@ mod tests {
         let max = working.max_component();
         assert!((working.x() / max - working.y() / max).abs() < 1e-6);
         assert!((working.y() / max - working.z() / max).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cpu_develop_honours_the_shader_contract() {
+        let info = CameraColorInfo {
+            profile: profile_from_map(vec![
+                (Illuminant::A, tungsten_flat()),
+                (Illuminant::D65, daylight_flat()),
+            ])
+            .unwrap(),
+            as_shot_coefficients: None,
+            as_shot_temp_tint: Some(TempTint::new(3200.0, 0.0)),
+            highlight_compression: 2.5,
+        };
+        let [r, g, b] = info.resolve_as_shot().unwrap().coefficients;
+
+        // Camera white, camera grey, and a pixel blown past the roll-off limit.
+        let mut buffer = image::Rgba32FImage::new(3, 1);
+        buffer.put_pixel(0, 0, image::Rgba([1.0 / r, 1.0 / g, 1.0 / b, 1.0]));
+        buffer.put_pixel(1, 0, image::Rgba([0.5 / r, 0.5 / g, 0.5 / b, 1.0]));
+        buffer.put_pixel(2, 0, image::Rgba([2.0 / r, 3.0 / g, 2.0 / b, 1.0]));
+
+        let developed = develop_to_working(
+            &image::DynamicImage::ImageRgba32F(buffer),
+            &info,
+            &serde_json::json!({}),
+        )
+        .to_rgba32f();
+
+        let white = developed.get_pixel(0, 0).0;
+        let grey = developed.get_pixel(1, 0).0;
+        let blown = developed.get_pixel(2, 0).0;
+        for c in &white[..3] {
+            assert!((c - 1.0).abs() < 1e-4, "camera white became {white:?}");
+        }
+        for c in &grey[..3] {
+            assert!((c - 0.5).abs() < 1e-4, "camera grey became {grey:?}");
+        }
+        // Past the limit everything collapses to neutral at the brightness of
+        // the hottest channel, which is what keeps blown highlights from going
+        // magenta.
+        assert!(
+            (blown[0] - blown[1]).abs() < 1e-4 && (blown[1] - blown[2]).abs() < 1e-4,
+            "blown pixel became {blown:?}"
+        );
+        assert!(
+            (blown[0] - 3.0).abs() < 1e-3,
+            "blown pixel became {blown:?}"
+        );
+        assert!((developed.get_pixel(0, 0).0[3] - 1.0).abs() < 1e-6);
     }
 }

--- a/src-tauri/src/export_processing.rs
+++ b/src-tauri/src/export_processing.rs
@@ -24,7 +24,7 @@ use crate::file_management::{
 };
 use crate::formats::is_raw_file;
 use crate::image_loader::{
-    composite_patches_on_image, load_and_composite, load_base_image_from_bytes,
+    composite_patches_on_image, load_base_image_from_bytes, load_base_image_with_color_info,
 };
 use crate::image_processing::{
     AllAdjustments, Crop, GpuContext, RenderRequest, downscale_f32_image,
@@ -412,6 +412,7 @@ fn process_image_for_export_pipeline(
     context: &GpuContext,
     state: &tauri::State<AppState>,
     is_raw: bool,
+    color_info: Option<&crate::color_management::CameraColorInfo>,
     debug_tag: &str,
     app_handle: &tauri::AppHandle,
 ) -> Result<DynamicImage, String> {
@@ -442,6 +443,7 @@ fn process_image_for_export_pipeline(
     let tm_override = resolve_tonemapper_override_from_handle(app_handle, is_raw);
     let mut all_adjustments = get_all_adjustments_from_json(js_adjustments, is_raw, tm_override);
     all_adjustments.global.show_clipping = 0;
+    crate::color_management::apply_to_render(&mut all_adjustments, color_info, js_adjustments);
 
     let lut_path = js_adjustments["lutPath"].as_str();
     let lut = lut_path.and_then(|p| get_or_load_lut(state, p).ok());
@@ -547,6 +549,7 @@ fn process_image_for_export(
     context: &GpuContext,
     state: &tauri::State<AppState>,
     is_raw: bool,
+    color_info: Option<&crate::color_management::CameraColorInfo>,
     app_handle: &tauri::AppHandle,
 ) -> Result<DynamicImage, String> {
     let processed_image = process_image_for_export_pipeline(
@@ -556,6 +559,7 @@ fn process_image_for_export(
         context,
         state,
         is_raw,
+        color_info,
         "process_image_for_export",
         app_handle,
     )?;
@@ -1081,51 +1085,40 @@ pub(crate) async fn export_images_impl(
                         return Ok(());
                     }
 
-                    let base_image = if is_current_edit {
-                        match crate::get_original_image(&state) {
-                            Ok((orig_data_arc, _)) => {
-                                composite_patches_on_image(&orig_data_arc, &js_adjustments)
-                                    .map_err(|e| format!("Failed to composite AI patches: {}", e))?
-                            }
-                            Err(_) => {
-                                let bytes =
-                                    fs::read(&source_path_str).map_err(|e| e.to_string())?;
-                                load_and_composite(
-                                    &bytes,
-                                    &source_path_str,
-                                    &js_adjustments,
-                                    false,
-                                    &settings,
-                                    None,
-                                )
-                                .map_err(|e| format!("Failed to load fallback image: {}", e))?
-                            }
-                        }
+                    // The profile travels with the pixels: with the
+                    // color-managed path on, both the in-memory buffer and a
+                    // fresh decode are camera-native, and the export has to
+                    // apply the same transform the preview did.
+                    let (base_image, color_info) = if is_current_edit
+                        && let Ok(loaded) = crate::get_loaded_image(&state)
+                    {
+                        let composited = composite_patches_on_image(&loaded.image, &js_adjustments)
+                            .map_err(|e| format!("Failed to composite AI patches: {}", e))?;
+                        (composited, loaded.color_info)
                     } else {
-                        match read_file_mapped(Path::new(&source_path_str)) {
-                            Ok(mmap) => load_and_composite(
-                                &mmap,
+                        let decode = |bytes: &[u8]| {
+                            load_base_image_with_color_info(
+                                bytes,
                                 &source_path_str,
-                                &js_adjustments,
                                 false,
                                 &settings,
                                 None,
                             )
-                            .map_err(|e| format!("Failed to load from mmap: {}", e))?,
-                            Err(_) => {
-                                let bytes =
-                                    fs::read(&source_path_str).map_err(|e| e.to_string())?;
-                                load_and_composite(
-                                    &bytes,
-                                    &source_path_str,
-                                    &js_adjustments,
-                                    false,
-                                    &settings,
-                                    None,
-                                )
-                                .map_err(|e| format!("Failed to load from bytes: {}", e))?
-                            }
-                        }
+                        };
+                        let (decoded, color_info) =
+                            match read_file_mapped(Path::new(&source_path_str)) {
+                                Ok(mmap) => decode(&mmap)
+                                    .map_err(|e| format!("Failed to load from mmap: {}", e))?,
+                                Err(_) => {
+                                    let bytes =
+                                        fs::read(&source_path_str).map_err(|e| e.to_string())?;
+                                    decode(&bytes)
+                                        .map_err(|e| format!("Failed to load from bytes: {}", e))?
+                                }
+                            };
+                        let composited = composite_patches_on_image(&decoded, &js_adjustments)
+                            .map_err(|e| format!("Failed to composite AI patches: {}", e))?;
+                        (composited, color_info)
                     };
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
 
@@ -1144,6 +1137,7 @@ pub(crate) async fn export_images_impl(
                         &context_clone,
                         &state,
                         is_raw,
+                        color_info.as_ref(),
                         &app_handle_clone,
                     )?;
                     ensure_export_not_cancelled(&cancellation_token_clone)?;
@@ -1511,6 +1505,11 @@ pub async fn estimate_export_sizes(
         let mut all_adjustments =
             get_all_adjustments_from_json(&adjustments_clone, is_raw, tm_override);
         all_adjustments.global.show_clipping = 0;
+        crate::color_management::apply_to_render(
+            &mut all_adjustments,
+            loaded_image.color_info.as_ref(),
+            &adjustments_clone,
+        );
 
         let lut = adjustments_clone["lutPath"]
             .as_str()

--- a/src-tauri/src/file_management.rs
+++ b/src-tauri/src/file_management.rs
@@ -1553,14 +1553,20 @@ pub fn generate_thumbnail_data(
                     }
                 };
 
-                let img = image_loader::load_and_composite(
+                let (decoded, color_info) = image_loader::load_base_image_with_color_info(
                     file_slice,
                     &source_path_str,
-                    &adjustments,
                     true,
                     &settings,
                     None,
                 )?;
+                let decoded = match color_info.as_ref() {
+                    Some(info) => {
+                        crate::color_management::develop_to_working(&decoded, info, &adjustments)
+                    }
+                    None => decoded,
+                };
+                let img = image_loader::composite_patches_on_image(&decoded, &adjustments)?;
 
                 if is_raw {
                     raw_scale_factor = crate::raw_processing::get_fast_demosaic_scale_factor(
@@ -2548,7 +2554,7 @@ pub fn save_metadata_and_update_thumbnail(
     let loaded_image_lock = state.original_image.lock().unwrap();
     let preloaded_image_option = if let Some(loaded_image) = loaded_image_lock.as_ref() {
         if loaded_image.path == path {
-            Some(loaded_image.image.clone())
+            Some(loaded_image.clone())
         } else {
             None
         }
@@ -2556,6 +2562,7 @@ pub fn save_metadata_and_update_thumbnail(
         None
     };
     drop(loaded_image_lock);
+    let thumbnail_adjustments = metadata.adjustments.clone();
 
     let gpu_context = gpu_processing::get_or_init_gpu_context(&state, &app_handle).ok();
     let app_handle_clone = app_handle.clone();
@@ -2580,6 +2587,18 @@ pub fn save_metadata_and_update_thumbnail(
                 return;
             }
         };
+
+        // With a profile the buffer is camera-native, so develop it here and
+        // hand the thumbnail the same pixels the preview shows.
+        let preloaded_image_option =
+            preloaded_image_option.map(|loaded| match loaded.color_info.as_ref() {
+                Some(info) => Arc::new(crate::color_management::develop_to_working(
+                    &loaded.image,
+                    info,
+                    &thumbnail_adjustments,
+                )),
+                None => loaded.image,
+            });
 
         let result = generate_single_thumbnail_and_cache(
             &path_clone,

--- a/src-tauri/src/image_loader.rs
+++ b/src-tauri/src/image_loader.rs
@@ -84,6 +84,57 @@ pub fn load_base_image_from_bytes(
     settings: &AppSettings,
     cancel_token: Option<(Arc<AtomicUsize>, usize)>,
 ) -> Result<DynamicImage> {
+    // Deliberately never color managed. Callers of this entry point drop the
+    // profile, so handing them camera-native pixels would leave the data with
+    // no way to reach a display space.
+    load_base_image_inner(
+        bytes,
+        path_for_ext_check,
+        use_fast_raw_dev,
+        settings,
+        false,
+        cancel_token,
+    )
+    .map(|(image, _)| image)
+}
+
+/// Load an image, also returning the camera color profile for raw files.
+///
+/// Honours the color management setting, so a returned profile means the
+/// pixels are camera-native and the renderer must apply the transform.
+/// Non-raw files and raws without a usable calibration yield `None`.
+pub fn load_base_image_with_color_info(
+    bytes: &[u8],
+    path_for_ext_check: &str,
+    use_fast_raw_dev: bool,
+    settings: &AppSettings,
+    cancel_token: Option<(Arc<AtomicUsize>, usize)>,
+) -> Result<(
+    DynamicImage,
+    Option<crate::color_management::CameraColorInfo>,
+)> {
+    let color_managed = settings.color_managed_wb.unwrap_or(false);
+    load_base_image_inner(
+        bytes,
+        path_for_ext_check,
+        use_fast_raw_dev,
+        settings,
+        color_managed,
+        cancel_token,
+    )
+}
+
+fn load_base_image_inner(
+    bytes: &[u8],
+    path_for_ext_check: &str,
+    use_fast_raw_dev: bool,
+    settings: &AppSettings,
+    color_managed: bool,
+    cancel_token: Option<(Arc<AtomicUsize>, usize)>,
+) -> Result<(
+    DynamicImage,
+    Option<crate::color_management::CameraColorInfo>,
+)> {
     let highlight_compression = settings.raw_highlight_compression.unwrap_or(2.5);
     let linear_mode = settings.linear_raw_mode.clone();
     let color_nr_setting = settings.raw_preprocessing_color_nr.unwrap_or(0.5);
@@ -104,15 +155,16 @@ pub fn load_base_image_from_bytes(
 
     if is_raw_file(path_for_ext_check) {
         match panic::catch_unwind(move || {
-            crate::raw_processing::develop_raw_image(
+            crate::raw_processing::develop_raw_image_with_color_info(
                 bytes,
                 use_fast_raw_dev,
                 highlight_compression,
                 linear_mode,
+                color_managed,
                 cancel_token,
             )
         }) {
-            Ok(Ok(mut image)) => {
+            Ok(Ok((mut image, color_info))) => {
                 if !use_fast_raw_dev && (color_nr_amount > 0.0 || sharpening_amount > 0.0) {
                     let start = Instant::now();
                     remove_raw_artifacts_and_enhance(
@@ -127,7 +179,7 @@ pub fn load_base_image_from_bytes(
                         duration
                     );
                 }
-                Ok(image)
+                Ok((image, color_info))
             }
             Ok(Err(e)) => {
                 let classified = classify_raw_develop_error(path_for_ext_check, e);
@@ -149,7 +201,7 @@ pub fn load_base_image_from_bytes(
                         preview.height()
                     );
 
-                    return Ok(linearize_embedded_preview(preview));
+                    return Ok((linearize_embedded_preview(preview), None));
                 }
                 Err(classified)
             }
@@ -163,7 +215,7 @@ pub fn load_base_image_from_bytes(
                         preview.height()
                     );
 
-                    return Ok(linearize_embedded_preview(preview));
+                    return Ok((linearize_embedded_preview(preview), None));
                 }
                 Err(anyhow!(
                     "Failed to process RAW file: {}",
@@ -188,7 +240,7 @@ pub fn load_base_image_from_bytes(
             );
         }
 
-        Ok(image)
+        Ok((image, None))
     }
 }
 
@@ -821,14 +873,22 @@ pub fn composite_patches_on_image(
 }
 
 #[tauri::command]
-pub fn is_image_cached(path: String, state: tauri::State<'_, AppState>) -> bool {
+pub fn is_image_cached(
+    path: String,
+    state: tauri::State<'_, AppState>,
+    app_handle: tauri::AppHandle,
+) -> bool {
     let (source_path, _) = parse_virtual_path(&path);
     let source_path_str = source_path.to_string_lossy().to_string();
+    let color_managed = load_settings(app_handle)
+        .unwrap_or_default()
+        .color_managed_wb
+        .unwrap_or(false);
     state
         .decoded_image_cache
         .lock()
         .unwrap()
-        .get(&source_path_str)
+        .get(&source_path_str, color_managed)
         .is_some()
 }
 
@@ -897,6 +957,7 @@ pub async fn load_image(
     let metadata: ImageMetadata = crate::exif_processing::load_sidecar(&sidecar_path);
 
     let settings = load_settings(app_handle.clone()).unwrap_or_default();
+    let color_managed = settings.color_managed_wb.unwrap_or(false);
 
     let path_clone = source_path_str.clone();
 
@@ -904,10 +965,15 @@ pub async fn load_image(
         .decoded_image_cache
         .lock()
         .unwrap()
-        .get(&source_path_str);
+        .get(&source_path_str, color_managed);
 
-    let (pristine_arc, exif_data) = if let Some((cached_img, cached_exif)) = cached_data {
-        (cached_img, cached_exif)
+    let (pristine_arc, exif_data, color_info) = if let Some((
+        cached_img,
+        cached_exif,
+        cached_color,
+    )) = cached_data
+    {
+        (cached_img, cached_exif, cached_color)
     } else {
         if crate::file_management::is_cloud_placeholder(&source_path) {
             return Err(format!(
@@ -916,19 +982,27 @@ pub async fn load_image(
             ));
         }
 
-        let (pristine_img, exif_data_loaded) = tokio::task::spawn_blocking(move || {
-            if generation_tracker.load(Ordering::SeqCst) != my_generation {
-                return Err("Load cancelled".to_string());
-            }
+        let (pristine_img, exif_data_loaded, color_info_loaded) =
+            tokio::task::spawn_blocking(move || {
+                if generation_tracker.load(Ordering::SeqCst) != my_generation {
+                    return Err("Load cancelled".to_string());
+                }
 
-            let result: Result<(DynamicImage, HashMap<String, String>), String> =
-                (|| match read_file_mapped(Path::new(&path_clone)) {
+                #[allow(clippy::type_complexity)]
+                let result: Result<
+                    (
+                        DynamicImage,
+                        HashMap<String, String>,
+                        Option<crate::color_management::CameraColorInfo>,
+                    ),
+                    String,
+                > = (|| match read_file_mapped(Path::new(&path_clone)) {
                     Ok(mmap) => {
                         if generation_tracker.load(Ordering::SeqCst) != my_generation {
                             return Err("Load cancelled".to_string());
                         }
 
-                        let img = load_base_image_from_bytes(
+                        let (img, color) = load_base_image_with_color_info(
                             &mmap,
                             &path_clone,
                             false,
@@ -937,7 +1011,7 @@ pub async fn load_image(
                         )
                         .map_err(|e| e.to_string())?;
                         let exif = exif_processing::read_exif_data(&path_clone, &mmap);
-                        Ok((img, exif))
+                        Ok((img, exif, color))
                     }
                     Err(e) => {
                         log::warn!(
@@ -953,7 +1027,7 @@ pub async fn load_image(
                             return Err("Load cancelled".to_string());
                         }
 
-                        let img = load_base_image_from_bytes(
+                        let (img, color) = load_base_image_with_color_info(
                             &bytes,
                             &path_clone,
                             false,
@@ -962,13 +1036,13 @@ pub async fn load_image(
                         )
                         .map_err(|e| e.to_string())?;
                         let exif = exif_processing::read_exif_data(&path_clone, &bytes);
-                        Ok((img, exif))
+                        Ok((img, exif, color))
                     }
                 })();
-            result
-        })
-        .await
-        .map_err(|e| e.to_string())??;
+                result
+            })
+            .await
+            .map_err(|e| e.to_string())??;
 
         let arc_img = Arc::new(pristine_img);
 
@@ -976,9 +1050,11 @@ pub async fn load_image(
             source_path_str.clone(),
             arc_img.clone(),
             exif_data_loaded.clone(),
+            color_info_loaded.clone(),
+            color_managed,
         );
 
-        (arc_img, exif_data_loaded)
+        (arc_img, exif_data_loaded, color_info_loaded)
     };
 
     if state.load_image_generation.load(Ordering::SeqCst) != my_generation {
@@ -997,6 +1073,7 @@ pub async fn load_image(
         path,
         image: pristine_arc,
         is_raw,
+        color_info,
     });
 
     Ok(LoadImageResult {

--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -1457,6 +1457,18 @@ pub struct GpuMat3 {
     col2: [f32; 4],
 }
 
+impl GpuMat3 {
+    /// Build from a column-major 3x3, padding each column out to the 16-byte
+    /// stride a WGSL `mat3x3<f32>` expects.
+    pub fn from_cols_f32(cols: [[f32; 3]; 3]) -> Self {
+        Self {
+            col0: [cols[0][0], cols[0][1], cols[0][2], 0.0],
+            col1: [cols[1][0], cols[1][1], cols[1][2], 0.0],
+            col2: [cols[2][0], cols[2][1], cols[2][2], 0.0],
+        }
+    }
+}
+
 impl Default for GpuMat3 {
     fn default() -> Self {
         Self {
@@ -1554,6 +1566,12 @@ pub struct GlobalAdjustments {
     pub halation_amount: f32,
     pub flare_amount: f32,
     pub sharpness_threshold: f32,
+
+    /// xyz: white balance gains for camera-native data. w: 1.0 when the CPU
+    /// side resolved a camera profile, 0.0 to keep the legacy develop path.
+    pub wb_coefficients: [f32; 4],
+    /// Camera RGB to working space, interpolated for the chosen illuminant.
+    pub camera_to_working: GpuMat3,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, Pod, Zeroable, Default)]
@@ -1621,6 +1639,20 @@ pub struct AllAdjustments {
     pub tile_offset_x: u32,
     pub tile_offset_y: u32,
     pub mask_atlas_cols: u32,
+}
+
+impl AllAdjustments {
+    /// Switch the render onto the color-managed path.
+    ///
+    /// Only callers holding a camera profile can do this; everything else
+    /// leaves the flag clear and keeps rawler's developed output.
+    pub fn set_camera_color(&mut self, resolved: &crate::color_management::ResolvedWhiteBalance) {
+        let [r, g, b] = resolved.coefficients;
+        // w doubles as the highlight roll-off limit; see apply_camera_color.
+        // Anything above zero also means the path is live.
+        self.global.wb_coefficients = [r, g, b, resolved.highlight_compression.max(1.01)];
+        self.global.camera_to_working = GpuMat3::from_cols_f32(resolved.camera_to_working);
+    }
 }
 
 struct AdjustmentScales {
@@ -2212,6 +2244,11 @@ fn get_global_adjustments_from_json(
     };
 
     GlobalAdjustments {
+        // Off unless a caller with a camera profile fills these in; the
+        // legacy develop path stays exactly as it was.
+        wb_coefficients: [1.0, 1.0, 1.0, 0.0],
+        camera_to_working: GpuMat3::default(),
+
         exposure: get_val("basic", "exposure", SCALES.exposure, None),
         brightness: get_val("basic", "brightness", SCALES.brightness, None),
         contrast: get_val("basic", "contrast", SCALES.contrast, None),

--- a/src-tauri/src/image_processing.rs
+++ b/src-tauri/src/image_processing.rs
@@ -3509,16 +3509,25 @@ pub fn auto_results_to_json(results: &AutoAdjustmentResults) -> serde_json::Valu
 pub fn calculate_auto_adjustments(
     state: tauri::State<AppState>,
 ) -> Result<serde_json::Value, String> {
-    let original_image = state
+    let loaded = state
         .original_image
         .lock()
         .unwrap()
-        .as_ref()
-        .ok_or("No image loaded for auto adjustments")?
-        .image
-        .clone();
+        .clone()
+        .ok_or("No image loaded for auto adjustments")?;
 
-    let results = perform_auto_analysis(&original_image);
+    // The analysis wants developed pixels. With a profile the buffer is
+    // camera-native, so develop it at the as-shot balance first.
+    let analysed: Cow<DynamicImage> = match loaded.color_info.as_ref() {
+        Some(info) => Cow::Owned(crate::color_management::develop_to_working(
+            &loaded.image,
+            info,
+            &json!({}),
+        )),
+        None => Cow::Borrowed(loaded.image.as_ref()),
+    };
+
+    let results = perform_auto_analysis(&analysed);
 
     Ok(auto_results_to_json(&results))
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -848,6 +848,11 @@ async fn generate_uncropped_preview(
         let mut uncropped_adjustments =
             get_all_adjustments_from_json(&adjustments_clone, is_raw, tm_override);
         uncropped_adjustments.global.show_clipping = 0;
+        crate::color_management::apply_to_render(
+            &mut uncropped_adjustments,
+            loaded_image.color_info.as_ref(),
+            &adjustments_clone,
+        );
         let lut_path = adjustments_clone["lutPath"].as_str();
         let lut = lut_path.and_then(|p| lut_processing::get_or_load_lut(&state, p).ok());
 
@@ -896,6 +901,20 @@ pub fn get_original_image(
         std::sync::Arc::clone(&loaded_image.image),
         loaded_image.is_raw,
     ))
+}
+
+/// The loaded image together with its color profile.
+///
+/// Anything that renders these pixels needs the profile as well, since with
+/// the color-managed path on the buffer is camera-native and the render has
+/// to apply the transform to match the preview.
+pub fn get_loaded_image(state: &tauri::State<AppState>) -> Result<LoadedImage, String> {
+    state
+        .original_image
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or_else(|| "No original image loaded".to_string())
 }
 
 #[tauri::command]
@@ -950,6 +969,11 @@ fn generate_preset_preview(
     let tm_override = resolve_tonemapper_override_from_handle(&app_handle, is_raw);
     let mut all_adjustments = get_all_adjustments_from_json(&js_adjustments, is_raw, tm_override);
     all_adjustments.global.show_clipping = 0;
+    crate::color_management::apply_to_render(
+        &mut all_adjustments,
+        loaded_image.color_info.as_ref(),
+        &js_adjustments,
+    );
     let lut_path = js_adjustments["lutPath"].as_str();
     let lut = lut_path.and_then(|p| lut_processing::get_or_load_lut(&state, p).ok());
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod app_settings;
 mod app_state;
 mod cache_utils;
 mod camera_tethering;
+mod color_management;
 mod culling;
 mod denoising;
 mod exif_processing;
@@ -493,7 +494,13 @@ fn process_preview_job(
 
     let is_raw = loaded_image.is_raw;
     let tm_override = resolve_tonemapper_override_from_handle(app_handle, is_raw);
-    let final_adjustments = get_all_adjustments_from_json(&adjustments_clone, is_raw, tm_override);
+    let mut final_adjustments =
+        get_all_adjustments_from_json(&adjustments_clone, is_raw, tm_override);
+    crate::color_management::apply_to_render(
+        &mut final_adjustments,
+        loaded_image.color_info.as_ref(),
+        &adjustments_clone,
+    );
     let lut_path = adjustments_clone["lutPath"].as_str();
     let lut = lut_path.and_then(|p| lut_processing::get_or_load_lut(&state, p).ok());
 

--- a/src-tauri/src/lut_processing.rs
+++ b/src-tauri/src/lut_processing.rs
@@ -690,8 +690,13 @@ pub fn generate_lut_previews(
                 "lutIsSceneReferred": request.is_built_in,
                 "sectionVisibility": { "effects": true }
             });
-            let swatch_adjustments =
+            let mut swatch_adjustments =
                 get_all_adjustments_from_json(&swatch_lut_json, is_raw, tm_override);
+            crate::color_management::apply_to_render(
+                &mut swatch_adjustments,
+                loaded_image.color_info.as_ref(),
+                &base_json,
+            );
 
             let thumb = render_lut_swatch(
                 &context,

--- a/src-tauri/src/raw_processing.rs
+++ b/src-tauri/src/raw_processing.rs
@@ -1,3 +1,4 @@
+use crate::color_management::CameraColorInfo;
 use crate::image_processing::apply_orientation;
 use anyhow::{Result, anyhow};
 use image::{DynamicImage, ImageBuffer, Rgba};
@@ -12,21 +13,27 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 
-pub fn develop_raw_image(
+/// Develop a raw file, also returning its camera color profile.
+///
+/// Callers that only want pixels ignore the second element; extracting the
+/// profile costs nothing beyond reading metadata already in hand.
+pub fn develop_raw_image_with_color_info(
     file_bytes: &[u8],
     fast_demosaic: bool,
     highlight_compression: f32,
     linear_mode: String,
+    color_managed: bool,
     cancel_token: Option<(Arc<AtomicUsize>, usize)>,
-) -> Result<DynamicImage> {
-    let (developed_image, orientation) = develop_internal(
+) -> Result<(DynamicImage, Option<CameraColorInfo>)> {
+    let (developed_image, orientation, color_info) = develop_internal(
         file_bytes,
         fast_demosaic,
         highlight_compression,
         linear_mode,
+        color_managed,
         cancel_token,
     )?;
-    Ok(apply_orientation(developed_image, orientation))
+    Ok((apply_orientation(developed_image, orientation), color_info))
 }
 
 fn is_linear_raw_format(raw_image: &RawImage) -> bool {
@@ -50,8 +57,9 @@ fn develop_internal(
     fast_demosaic: bool,
     highlight_compression: f32,
     linear_mode: String,
+    color_managed: bool,
     cancel_token: Option<(Arc<AtomicUsize>, usize)>,
-) -> Result<(DynamicImage, Orientation)> {
+) -> Result<(DynamicImage, Orientation, Option<CameraColorInfo>)> {
     let check_cancel = || -> Result<()> {
         if let Some((tracker, generation)) = &cancel_token
             && tracker.load(Ordering::SeqCst) != *generation
@@ -77,6 +85,23 @@ fn develop_internal(
         .unwrap_or(Orientation::Normal);
 
     let is_linear_format = is_linear_raw_format(&raw_image);
+
+    // Shared with the color-managed path, which rolls highlights off in the
+    // shader instead because the gains no longer run during develop.
+    let safe_highlight_compression = highlight_compression.max(1.01);
+
+    // Invariant: a returned profile means the pixels are camera-native. The
+    // renderer keys its color-managed path off exactly that, so the two can
+    // never disagree about what the buffer holds.
+    //
+    // Linear formats are excluded for now: they arrive already demosaiced and
+    // partly processed, so they need their own handling.
+    let color_info = if color_managed && !is_linear_format {
+        CameraColorInfo::from_raw(&raw_image, safe_highlight_compression)
+    } else {
+        None
+    };
+    let use_color_management = color_info.is_some();
 
     let (apply_ungamma, apply_calibration) = match linear_mode.as_str() {
         "gamma" => (true, true),
@@ -110,11 +135,17 @@ fn develop_internal(
                 && step != ProcessingStep::Demosaic
                 && (apply_calibration || step != ProcessingStep::Calibrate)
         });
-    } else if fast_demosaic {
-        developer.demosaic_algorithm = DemosaicAlgorithm::Speed;
-        developer.steps.retain(|&step| step != ProcessingStep::SRgb);
     } else {
-        developer.steps.retain(|&step| step != ProcessingStep::SRgb);
+        if fast_demosaic {
+            developer.demosaic_algorithm = DemosaicAlgorithm::Speed;
+        }
+        developer.steps.retain(|&step| {
+            // Dropping Calibrate leaves the data camera-native, which is what
+            // the color-managed path wants. It also takes white balance with
+            // it, since rawler only applies wb inside that step.
+            step != ProcessingStep::SRgb
+                && (!use_color_management || step != ProcessingStep::Calibrate)
+        });
     }
 
     raw_image.wb_coeffs =
@@ -127,8 +158,6 @@ fn develop_internal(
 
     let denominator = (original_white_level - original_black_level).max(1.0);
     let rescale_factor = (u32::MAX as f32 - original_black_level) / denominator;
-
-    let safe_highlight_compression = highlight_compression.max(1.01);
 
     let clamp_limit = if fast_demosaic {
         1.0
@@ -230,7 +259,7 @@ fn develop_internal(
         }
     };
 
-    Ok((dynamic_image, orientation))
+    Ok((dynamic_image, orientation, color_info))
 }
 
 pub fn get_fast_demosaic_scale_factor(

--- a/src-tauri/src/shaders/shader.wgsl
+++ b/src-tauri/src/shaders/shader.wgsl
@@ -115,6 +115,9 @@ struct GlobalAdjustments {
     halation_amount: f32,
     flare_amount: f32,
     sharpness_threshold: f32,
+
+    wb_coefficients: vec4<f32>,
+    camera_to_working: mat3x3<f32>,
 }
 
 struct MaskAdjustments {
@@ -592,6 +595,51 @@ fn apply_color_calibration(color: vec3<f32>, cal: ColorCalibrationSettings) -> v
     }
 
     return c;
+}
+
+// Camera-native RGB into the working space, white balanced on the way.
+//
+// The gains have to be applied here, before the matrix: a camera matrix is only
+// valid for the illuminant it was interpolated for, so balancing afterwards
+// leaves the matrix evaluated for light the data no longer has.
+//
+// w carries the highlight compression limit rather than a plain flag: zero
+// means no camera profile was resolved, so the texture already holds developed
+// data and this is a pass-through. Anything above zero is the limit from
+// settings, which the develop step can no longer apply itself.
+fn apply_camera_color(color: vec3<f32>, wb: vec4<f32>, camera_to_working: mat3x3<f32>) -> vec3<f32> {
+    if (wb.w <= 0.0) {
+        return color;
+    }
+    var balanced = color * wb.xyz;
+
+    // The develop step rolls off anything above 1.0, but with the gains moved
+    // here nothing reaches it any more: camera-native data tops out at the
+    // white level, so that branch is dead and the setting stopped doing
+    // anything. Same curve, run where the headroom now appears.
+    //
+    // Doing it before the color matrix rather than after, as develop did, is
+    // deliberate. This is where the sensor actually clipped, so a channel that
+    // ran out of range is still identifiable as itself.
+    let limit = max(wb.w, 1.01);
+    let max_c = max(balanced.r, max(balanced.g, balanced.b));
+    if (max_c > 1.0) {
+        let min_c = min(balanced.r, min(balanced.g, balanced.b));
+        let factor = clamp(1.0 - (max_c - 1.0) / (limit - 1.0), 0.0, 1.0);
+        let compressed = vec3<f32>(min_c) + (balanced - vec3<f32>(min_c)) * factor;
+        let compressed_max = max(compressed.r, max(compressed.g, compressed.b));
+        if (compressed_max > 1e-6) {
+            // Desaturate toward the darkest channel, then put the original
+            // brightness back. A fully blown pixel lands on neutral, which is
+            // what stops clipped highlights going magenta once the gains have
+            // pulled the channels apart.
+            balanced = compressed * (max_c / compressed_max);
+        } else {
+            balanced = vec3<f32>(max_c);
+        }
+    }
+
+    return camera_to_working * balanced;
 }
 
 fn apply_white_balance(color: vec3<f32>, temp: f32, tnt: f32) -> vec3<f32> {
@@ -1642,6 +1690,12 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
         initial_linear_rgb = color_from_texture;
     }
 
+    initial_linear_rgb = apply_camera_color(
+        initial_linear_rgb,
+        adjustments.global.wb_coefficients,
+        adjustments.global.camera_to_working
+    );
+
     var t_exposure = adjustments.global.exposure;
     var t_brightness = adjustments.global.brightness;
     var t_contrast = adjustments.global.contrast;
@@ -1775,7 +1829,9 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     }
 
     var composite_rgb_linear = apply_dehaze(processed_rgb, structure_blurred, is_raw, t_dehaze);
-    composite_rgb_linear = apply_white_balance(composite_rgb_linear, t_temperature, t_tint);
+    if (adjustments.global.wb_coefficients.w < 0.5) {
+        composite_rgb_linear = apply_white_balance(composite_rgb_linear, t_temperature, t_tint);
+    }
     composite_rgb_linear = apply_centre_tonal_and_color(composite_rgb_linear, adjustments.global.centre, absolute_coord_i);
     composite_rgb_linear = apply_filmic_exposure(composite_rgb_linear, t_brightness);
     composite_rgb_linear = apply_tonal_adjustments(composite_rgb_linear, tonal_blurred, is_raw, t_contrast, t_shadows, t_whites, t_blacks);

--- a/src-tauri/tests/shader_validation.rs
+++ b/src-tauri/tests/shader_validation.rs
@@ -1,0 +1,31 @@
+//! Compile the WGSL shaders at test time.
+//!
+//! Shader errors otherwise only surface when a GPU pipeline is built at
+//! runtime, which means a typo or a uniform layout mistake ships as a blank
+//! canvas rather than a failing build.
+
+use naga::valid::{Capabilities, ValidationFlags, Validator};
+
+fn validate(name: &str, source: &str) {
+    let module = match naga::front::wgsl::parse_str(source) {
+        Ok(module) => module,
+        Err(e) => panic!("{name} failed to parse:\n{}", e.emit_to_string(source)),
+    };
+
+    let mut validator = Validator::new(ValidationFlags::all(), Capabilities::all());
+    if let Err(e) = validator.validate(&module) {
+        panic!("{name} failed validation:\n{e:?}");
+    }
+}
+
+#[test]
+fn shaders_compile() {
+    for (name, source) in [
+        ("shader.wgsl", include_str!("../src/shaders/shader.wgsl")),
+        ("display.wgsl", include_str!("../src/shaders/display.wgsl")),
+        ("blur.wgsl", include_str!("../src/shaders/blur.wgsl")),
+        ("flare.wgsl", include_str!("../src/shaders/flare.wgsl")),
+    ] {
+        validate(name, source);
+    }
+}

--- a/src/components/panel/SettingsPanel.tsx
+++ b/src/components/panel/SettingsPanel.tsx
@@ -559,6 +559,7 @@ export default function SettingsPanel({
     rawPreprocessingColorNr: appSettings?.rawPreprocessingColorNr ?? 0.5,
     rawPreprocessingSharpening: appSettings?.rawPreprocessingSharpening ?? 0.35,
     applyPreprocessingToNonRaws: appSettings?.applyPreprocessingToNonRaws ?? false,
+    colorManagedWb: appSettings?.colorManagedWb ?? false,
   });
   const [restartRequired, setRestartRequired] = useState(false);
   const [activeCategory, setActiveCategory] = useState('general');
@@ -667,6 +668,7 @@ export default function SettingsPanel({
       rawPreprocessingColorNr: appSettings?.rawPreprocessingColorNr ?? 0.5,
       rawPreprocessingSharpening: appSettings?.rawPreprocessingSharpening ?? 0.35,
       applyPreprocessingToNonRaws: appSettings?.applyPreprocessingToNonRaws ?? false,
+      colorManagedWb: appSettings?.colorManagedWb ?? false,
     });
     setRestartRequired(false);
   }, [appSettings]);
@@ -706,7 +708,8 @@ export default function SettingsPanel({
         key === 'rawHighlightCompression' ||
         key === 'rawPreprocessingColorNr' ||
         key === 'rawPreprocessingSharpening' ||
-        key === 'applyPreprocessingToNonRaws'
+        key === 'applyPreprocessingToNonRaws' ||
+        key === 'colorManagedWb'
       ) {
         await invoke('clear_image_caches');
       }
@@ -2116,6 +2119,18 @@ export default function SettingsPanel({
                           id="preprocessing-non-raws-toggle"
                           label={t('settings.processing.preprocessing.enablePreprocessingNonRaws')}
                           onChange={(checked) => handleProcessingSettingChange('applyPreprocessingToNonRaws', checked)}
+                        />
+                      </SettingItem>
+
+                      <SettingItem
+                        label={t('settings.processing.preprocessing.colorManagedWb')}
+                        description={t('settings.processing.preprocessing.colorManagedWbDesc')}
+                      >
+                        <Switch
+                          checked={processingSettings.colorManagedWb}
+                          id="color-managed-wb-toggle"
+                          label={t('settings.processing.preprocessing.colorManagedWb')}
+                          onChange={(checked) => handleProcessingSettingChange('colorManagedWb', checked)}
                         />
                       </SettingItem>
 

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -219,6 +219,7 @@ export interface AppSettings {
   enableFolderImageCounts?: boolean;
   displayEditIcon?: boolean;
   linearRawMode?: string;
+  colorManagedWb?: boolean;
   enableXmpSync?: boolean;
   createXmpIfMissing?: boolean;
   isWaveformVisible?: boolean;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1751,7 +1751,7 @@
         "tonemapperOverride": "Global Tonemapper Override",
         "tonemapperOverrideDesc": "Force a specific tonemapper globally for all images, hiding the tonemapper switch from the adjustments panel.",
         "colorManagedWb": "Color-Managed White Balance",
-        "colorManagedWbDesc": "Develop RAW files to camera-native color and resolve white balance from the camera's own calibration, interpolated for the scene illuminant, instead of always calibrating with the daylight matrix. Experimental, and currently applied to the editor preview only — export, inpainting and LUT previews still use the old path, so leave this off when exporting."
+        "colorManagedWbDesc": "Develop RAW files to camera-native color and resolve white balance from the camera's own calibration, interpolated for the scene illuminant, instead of always calibrating with the daylight matrix. Experimental. Applies to the preview, export, thumbnails, preset and LUT previews and auto adjustments; AI patches are generated in whichever color the buffer holds at the time, so patches made with this on won't match with it off."
       },
       "previewRes": "Preview Resolution",
       "previewResDesc": "Determines the maximum resolution of the preview. Lower values significantly improve performance.",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1749,7 +1749,9 @@
           "basic": "Basic"
         },
         "tonemapperOverride": "Global Tonemapper Override",
-        "tonemapperOverrideDesc": "Force a specific tonemapper globally for all images, hiding the tonemapper switch from the adjustments panel."
+        "tonemapperOverrideDesc": "Force a specific tonemapper globally for all images, hiding the tonemapper switch from the adjustments panel.",
+        "colorManagedWb": "Color-Managed White Balance",
+        "colorManagedWbDesc": "Develop RAW files to camera-native color and resolve white balance from the camera's own calibration, interpolated for the scene illuminant, instead of always calibrating with the daylight matrix. Experimental, and currently applied to the editor preview only — export, inpainting and LUT previews still use the old path, so leave this off when exporting."
       },
       "previewRes": "Preview Resolution",
       "previewResDesc": "Determines the maximum resolution of the preview. Lower values significantly improve performance.",


### PR DESCRIPTION
## What this does

Adds an opt-in **Color-Managed White Balance** setting (Settings → Processing → Preprocessing). Off by default; nothing changes unless it's switched on.

Today rawler applies white balance during develop using a camera-to-XYZ matrix that is always the daylight one, whatever the scene illuminant was. Under tungsten or mixed light the matrix is evaluated for light the data doesn't have, and the residual cast can't be removed with the sliders afterwards because the error is already baked in.

With the setting on:

- RAW files develop to camera-native color instead of being calibrated in develop.
- White balance gains and an illuminant-interpolated camera matrix are resolved from the camera's own dual-illuminant calibration (the DNG model: ColorMatrix1/2 interpolated in mired), and applied in the shader before the color matrix.
- Temperature and tint are Kelvin and Duv relative to the as-shot illuminant, so they mean the same thing on every camera.
- Highlight roll-off (`rawHighlightCompression`) runs in the shader too, since the gains no longer run in develop and that block had nothing to act on.

Files with no usable calibration, linear RAW formats and the legacy loader fall through to the existing path unchanged, and a log line says which path a file took and what the profile resolved to.

## Before / after

Canon EOS R6 Mark II, lantern-lit street, as shot 2986 K. Same file, default settings, the only difference is the toggle.

![Stock rendering next to the color-managed rendering](https://raw.githubusercontent.com/john-baxter-dev/RapidRAW/pr-assets/color-managed-wb/before_after.png)

The frame is dark, so here is the door and wall pushed +2 EV on all three panels. The third panel is the camera's own JPEG for reference.

![Door crop at +2 EV: stock, setting on, camera JPEG](https://raw.githubusercontent.com/john-baxter-dev/RapidRAW/pr-assets/color-managed-wb/door_crop.png)

Sampled on seven patches of the door and rendered wall, the stock path sits olive (R/G around 1.5) where the camera JPEG has R/G around 1.9. The new path lands closer to the camera on every patch and within a few percent on most. Matching Canon's look isn't the goal, but that residual green is the daylight-matrix error described above, and it goes away.

## Scope, deliberately small

- The colorimetry lives in [`rawcolor`](https://crates.io/crates/rawcolor), a zero-dependency, `#![forbid(unsafe_code)]` crate (MIT/Apache-2.0) so the math is testable on its own and reusable. This PR only holds the glue.
- Every render of a RAW goes through it once the setting is on: editor preview, export (including batch), thumbnails, preset and LUT previews, export size estimates and the auto-adjust analysis. GPU renders apply the transform in the shader; thumbnails and auto-adjust use a CPU port of the same arithmetic, with a test pinning the two to one contract. AI patches are generated from whatever the buffer holds when they're made, so a patch made with the setting on won't match with it off, and vice versa.
- The working space stays sRGB primaries, matching the rest of the pipeline. Widening it is worth doing but is a pipeline-wide change, not this one.
- Four-color sensors are excluded for now (3×3 matrices only).

## Testing

- 19 unit tests in `color_management.rs`. The important ones assert against the host pipeline's own constants and end-to-end pixel results, not the crate's intermediates, since every bug found during development was a mismatch at that boundary (working primaries, tint sign, highlight roll-off).
- A naga validation test for the shader.
- Profile resolution and as-shot CCT/Duv checked across ~110 Canon CR3 and DNG files spanning 3200–7000 K; rendering checked visually on a handful of tungsten and daylight shots.
- `cargo clippy` and `cargo fmt` clean. The pre-existing `tsc` and eslint errors are untouched.
