### PR TITLE
fix(macOS): handle file open events while app is running

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2213,16 +2213,40 @@ pub fn run() {
         .run(#[allow(unused_variables)] |app_handle, event| {
             match event {
                 #[cfg(target_os = "macos")]
-                tauri::RunEvent::Opened { urls } => {
-                    if let Some(url) = urls.first()
-                        && let Ok(path) = url.to_file_path()
-                        && let Some(path_str) = path.to_str()
-                    {
-                        let state = app_handle.state::<AppState>();
-                        *state.initial_file_path.lock().unwrap() = Some(path_str.to_string());
-                        log::info!("macOS initial open: Stored path {} for later.", path_str);
-                    }
-                }
+				tauri::RunEvent::Opened { urls } => {
+				    if let Some(url) = urls.first()
+				        && let Ok(path) = url.to_file_path()
+				        && let Some(path_str) = path.to_str()
+				    {
+				        let state = app_handle.state::<AppState>();
+
+				        if state
+				            .window_setup_complete
+				            .load(std::sync::atomic::Ordering::Relaxed)
+				        {
+				            if let Some(window) = app_handle.get_webview_window("main") {
+				                let _ = window.unminimize();
+				                let _ = window.show();
+				                let _ = window.set_focus();
+				            }
+
+				            log::info!("macOS runtime open: Opening {}.", path_str);
+
+				            emit_launch_request(
+				                app_handle,
+				                LaunchRequest::OpenFile(path_str.to_string()),
+				            );
+				        } else {
+				            *state.initial_file_path.lock().unwrap() =
+				                Some(path_str.to_string());
+
+				            log::info!(
+				                "macOS initial open: Stored path {} for later.",
+				                path_str
+				            );
+				        }
+				    }
+				}
                 tauri::RunEvent::ExitRequested { api, .. } => {
                     api.prevent_exit();
 


### PR DESCRIPTION
## Summary

Fixes macOS file-open handling when RapidRAW is already running.

Previously, `RunEvent::Opened` always stored the path in `initial_file_path`.
That works for a cold start because `frontend_ready()` consumes the stored
path, but when the app is already running `frontend_ready()` is not called
again, so the new file never opens.

This change keeps the existing cold-start behavior, but when the frontend/window
setup is already complete it:
- brings the main window to the foreground,
- forwards the file through the existing
  `emit_launch_request(..., LaunchRequest::OpenFile(...))` path.

## Tested

Verified on macOS with both Finder `Open With` and Excire Foto while RapidRAW
was already running. The selected RAW file now opens in the existing RapidRAW
instance.