### PR TITLE
Add optional loopback external control API for hardware controllers

### DIFF
--- a/docs/EXTERNAL_CONTROL_API.md
+++ b/docs/EXTERNAL_CONTROL_API.md
@@ -1,0 +1,180 @@
+# RapidRAW External Control API
+
+Protocol version **1**. Lets a hardware controller (the MX Creative Console plugin, a MIDI
+bridge, a test script) drive RapidRAW's develop sliders live and fire editor actions.
+
+## Transport
+
+* TCP, **loopback only**: `127.0.0.1:47820` by default.
+* Newline-delimited JSON (one UTF-8 JSON object per `\n`-terminated line), both directions.
+* Any number of clients may connect. Every client receives every outbound message.
+* No authentication: the socket is bound to loopback, which is the trust boundary.
+
+Configuration, in RapidRAW's `settings.json` (both optional):
+
+```json
+{ "enableExternalControl": true, "externalControlPort": 47820 }
+```
+
+`RAPIDRAW_CONTROL_PORT=<n>` in the environment overrides the port. If the port cannot be
+bound, RapidRAW logs a warning and runs normally without the server.
+
+## Session start
+
+On connect the server sends a greeting and, if it has one, the most recent state snapshot:
+
+```json
+{"type":"hello","app":"RapidRAW","version":"1.6.3","protocol":1}
+{"type":"state", ...}
+```
+
+`ping` is answered by the Rust server even before the UI is up; everything else is handled
+by the editor UI, so expect no replies until the main window has loaded.
+
+## Requests (client → RapidRAW)
+
+Every request may carry a `ref` (any JSON value). Replies that answer a specific request
+echo it back, so a client can correlate. Messages without `ref` get anonymous replies.
+(`action` uses `id` for the action name; `ref` is separate.)
+
+| `type`        | fields                                 | effect                                                                                                                    |
+| ------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `set`         | `param`, `value`                       | Set a parameter to an absolute value. Snapped to the parameter's step and clamped to its range.                          |
+| `adjust`      | `param`, `delta`                       | Add `delta` (in parameter units) to the current value.                                                                    |
+| `step`        | `param`, `ticks` (default 1), `multiplier` (default 1) | Add `ticks × step × multiplier`. Meant for dials: one detent = one tick; use `multiplier` for a fine/coarse modifier. |
+| `reset`       | `param`                                | Return the parameter to its default.                                                                                       |
+| `tracking`    | `active` (bool)                        | Explicitly begin/end "dial is being turned" mode (see below). Optional.                                                    |
+| `action`      | `id`                                   | Fire a named editor action (see list below). Same code path as the keyboard shortcut.                                     |
+| `get_state`   | —                                      | Reply with a `state` snapshot.                                                                                             |
+| `get_params`  | —                                      | Reply with the parameter table: `{"type":"params","params":[{id,group,min,max,step,default},…]}`.                        |
+| `get_actions` | —                                      | Reply with `{"type":"actions","actions":["undo","redo",…]}`.                                                              |
+| `ping`        | —                                      | `{"type":"pong"}` (echoes `ref`).                                                                                          |
+
+Value changes are ignored (reply `{"type":"ignored","reason":…}`) when no image is open in
+the editor view. Unknown parameters, actions or message types produce `{"type":"error","message":…}`.
+
+### Tracking
+
+RapidRAW renders a fast low-resolution preview while a slider is being dragged and a full
+quality render once it is released; the release also triggers the auto-save. The same
+mechanism is used for controllers:
+
+* **Automatic** (default): every `set`/`adjust`/`step`/`reset` marks the editor as "dragging".
+  If no further value change arrives for ~180 ms the editor is released. A dial spun
+  continuously therefore gets live previews, and the full render + save happen as soon as
+  it stops. Nothing to do on the client side.
+* **Explicit**: send `{"type":"tracking","active":true}` before a burst and
+  `{"type":"tracking","active":false}` after it. While explicit tracking is active the
+  automatic release is suspended. Use this if the controller knows when a dial is touched
+  and released (e.g. a touch-sensitive encoder).
+
+Undo history is coalesced the same way as for slider drags (one history step per burst).
+
+## Notifications (RapidRAW → client)
+
+### `state`
+
+Sent on connect (replay), on request, and whenever anything in it changes — throttled to
+roughly 30 messages/s during a burst.
+
+```json
+{
+  "type": "state",
+  "view": "editor",
+  "image": { "path": "D:\\shoot\\DSC_0001.NEF", "name": "DSC_0001.NEF", "isReady": true, "rating": 3 },
+  "canUndo": true,
+  "canRedo": false,
+  "showOriginal": false,
+  "params": { "exposure": 0.35, "contrast": 12, "hsl.reds.hue": 0, … }
+}
+```
+
+`view` is `library` or `editor`; `image` is `null` when nothing is open. `params` lists every
+controllable parameter with its current value, so a controller can render dial positions
+without asking.
+
+### Others
+
+* `{"type":"action-result","action":"preview_next","result":"ok"|"ignored"}` — `ignored` means
+  the action's preconditions were not met (e.g. `preview_next` while in the library).
+* `{"type":"error","message":"…"}`
+* `{"type":"pong"}`
+
+## Parameters
+
+Identifiers are the field names of RapidRAW's `Adjustments` object; nested ones are joined
+with dots. Ranges mirror the sliders in the UI. `get_params` returns the authoritative table
+for the running build; the list below is the one shipped with protocol 1.
+
+| group         | id                                                                                                           | range            | step |
+| ------------- | ------------------------------------------------------------------------------------------------------------ | ---------------- | ---- |
+| basic         | `exposure`, `brightness`                                                                                     | −5 … 5           | 0.01 |
+| basic         | `contrast`, `highlights`, `shadows`, `whites`, `blacks`                                                      | −100 … 100       | 1    |
+| color         | `temperature`, `tint`, `vibrance`, `saturation`                                                              | −100 … 100       | 1    |
+| color         | `hue`                                                                                                        | −180 … 180       | 1    |
+| hsl           | `hsl.<color>.hue` / `.saturation` / `.luminance` — colors: reds, oranges, yellows, greens, aquas, blues, purples, magentas | −100 … 100 | 1 |
+| colorGrading  | `colorGrading.<range>.hue` — ranges: shadows, midtones, highlights, global                                    | 0 … 360          | 1    |
+| colorGrading  | `colorGrading.<range>.saturation`                                                                            | 0 … 100          | 1    |
+| colorGrading  | `colorGrading.<range>.luminance`                                                                             | −100 … 100       | 1    |
+| colorGrading  | `colorGrading.blending`                                                                                      | 0 … 100          | 1    |
+| colorGrading  | `colorGrading.balance`                                                                                       | −100 … 100       | 1    |
+| calibration   | `colorCalibration.shadowsTint`, `.redHue`, `.redSaturation`, `.greenHue`, `.greenSaturation`, `.blueHue`, `.blueSaturation` | −100 … 100 | 1 |
+| details       | `sharpness`, `clarity`, `dehaze`, `structure`, `centré`, `chromaticAberrationRedCyan`, `chromaticAberrationBlueYellow` | −100 … 100 | 1 |
+| details       | `sharpnessThreshold`                                                                                         | 0 … 80           | 1    |
+| details       | `lumaNoiseReduction`, `colorNoiseReduction`                                                                  | 0 … 100          | 1    |
+| effects       | `glowAmount`, `halationAmount`, `flareAmount`, `lensBlurAmount`, `lensBlurDiffusion`, `vignetteMidpoint`, `vignetteFeather`, `grainAmount`, `grainSize`, `grainRoughness`, `lutIntensity` | 0 … 100 | 1 |
+| effects       | `vignetteAmount`, `vignetteRoundness`                                                                        | −100 … 100       | 1    |
+| transform     | `rotation`, `transformRotate`                                                                                | −45 … 45         | 0.1  |
+| transform     | `transformVertical`, `transformHorizontal`, `transformDistortion`, `transformAspect`, `transformXOffset`, `transformYOffset` | −100 … 100 | 1 |
+| transform     | `transformScale`                                                                                             | 50 … 150         | 1    |
+
+Note the accent in `centré` — it is the real field name in RapidRAW.
+
+## Actions
+
+Exactly the named actions RapidRAW binds to keyboard shortcuts; `get_actions` returns the
+live list. Useful ones for a console:
+
+`undo`, `redo`, `show_original`, `preview_prev`, `preview_next`, `open_image`,
+`rate_0` … `rate_5`, `color_label_none|red|yellow|green|blue|purple`,
+`rotate_left`, `rotate_right`, `zoom_in`, `zoom_out`, `zoom_fit`, `zoom_100`, `cycle_zoom`,
+`copy_adjustments`, `paste_adjustments`, `toggle_crop`, `toggle_masks`, `toggle_presets`,
+`toggle_left_panel`, `toggle_right_panel`, `toggle_bottom_panel`, `toggle_fullscreen`,
+`brush_size_up`, `brush_size_down`, `delete_selected`, `select_all`.
+
+`rate_n` behaves like the keyboard shortcut: rating an image that already has `n` stars
+clears it to 0.
+
+Actions run through their own `shouldFire` guards, so a `preview_next` in the library or a
+`brush_size_up` outside the mask panel is reported as `ignored`, never misapplied.
+
+## Example session
+
+```
+→ {"type":"get_params","ref":1}
+← {"type":"params","protocol":1,"params":[…],"ref":1}
+→ {"type":"step","param":"exposure","ticks":3}
+→ {"type":"step","param":"exposure","ticks":2}
+← {"type":"state",…,"params":{"exposure":0.05,…}}
+→ {"type":"action","id":"rate_4"}
+← {"type":"action-result","action":"rate_4","result":"ok"}
+← {"type":"state",…,"image":{…,"rating":4},…}
+```
+
+Quick manual test from a shell:
+
+```
+# Windows (PowerShell)
+$c = New-Object Net.Sockets.TcpClient('127.0.0.1', 47820); $s = $c.GetStream()
+$w = New-Object IO.StreamWriter($s); $w.AutoFlush = $true
+$w.WriteLine('{"type":"adjust","param":"exposure","delta":0.5}')
+
+# macOS / Linux
+printf '{"type":"adjust","param":"exposure","delta":0.5}\n' | nc 127.0.0.1 47820
+```
+
+## Versioning
+
+`protocol` in `hello` increments only for incompatible changes. Adding parameters, actions
+or message fields is backwards compatible and does not bump it. A client should read the
+parameter table from `get_params` rather than hard-coding ranges.

--- a/src-tauri/src/app_settings.rs
+++ b/src-tauri/src/app_settings.rs
@@ -477,6 +477,10 @@ pub struct AppSettings {
     #[serde(default)]
     pub create_xmp_if_missing: Option<bool>,
     #[serde(default)]
+    pub enable_external_control: Option<bool>,
+    #[serde(default)]
+    pub external_control_port: Option<u16>,
+    #[serde(default)]
     pub is_waveform_visible: Option<bool>,
     #[serde(default)]
     pub waveform_height: Option<u32>,
@@ -592,6 +596,8 @@ impl Default for AppSettings {
             linear_raw_mode: default_linear_raw_mode(),
             enable_xmp_sync: Some(true),
             create_xmp_if_missing: Some(false),
+            enable_external_control: Some(true),
+            external_control_port: Some(crate::external_control::DEFAULT_PORT),
             is_waveform_visible: Some(false),
             waveform_height: Some(220),
             active_waveform_channel: Some("luma".to_string()),

--- a/src-tauri/src/external_control.rs
+++ b/src-tauri/src/external_control.rs
@@ -1,0 +1,273 @@
+//! External control server.
+//!
+//! Lets a hardware controller (e.g. a Logitech MX Creative Console plugin) drive the
+//! editor live. The server listens on the loopback interface only and speaks
+//! newline-delimited JSON in both directions:
+//!
+//! * client → RapidRAW: every line is forwarded verbatim to the frontend as the
+//!   `external-control-command` Tauri event. The frontend owns the adjustment state,
+//!   so it is the frontend that interprets `set` / `adjust` / `action` / ... messages.
+//! * RapidRAW → client: the frontend publishes state snapshots through the
+//!   `external_control_publish` command; they are broadcast to every connected
+//!   client. A fresh client immediately receives a `hello` line and the most recent
+//!   `state` snapshot (if any).
+//!
+//! The message vocabulary is documented in `docs/EXTERNAL_CONTROL_API.md`.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use serde_json::{Value, json};
+use tauri::{AppHandle, Emitter, EventTarget, Manager};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::broadcast;
+
+pub const PROTOCOL_VERSION: u32 = 1;
+pub const DEFAULT_PORT: u16 = 47820;
+pub const COMMAND_EVENT: &str = "external-control-command";
+pub const CLIENTS_EVENT: &str = "external-control-clients";
+/// Label of the editor window, as created in `lib.rs`.
+const MAIN_WINDOW_LABEL: &str = "main";
+
+/// Upper bound on a single incoming line. Anything larger is dropped and the
+/// connection closed; a controller never needs more than a few hundred bytes.
+const MAX_LINE_BYTES: usize = 64 * 1024;
+
+pub struct ExternalControlState {
+    /// Lines to be written to every connected client.
+    tx: broadcast::Sender<String>,
+    /// Most recent `state` snapshot published by the frontend, replayed to new clients.
+    last_state: Mutex<Option<String>>,
+    clients: AtomicUsize,
+    port: Mutex<Option<u16>>,
+    /// Monotonic id stamped on every forwarded command so the webview can drop
+    /// a duplicate delivery (Tauri fans `emit` out per event target).
+    seq: AtomicU64,
+}
+
+impl ExternalControlState {
+    pub fn new() -> Self {
+        let (tx, _rx) = broadcast::channel(256);
+        Self {
+            tx,
+            last_state: Mutex::new(None),
+            clients: AtomicUsize::new(0),
+            port: Mutex::new(None),
+            seq: AtomicU64::new(0),
+        }
+    }
+
+    fn broadcast(&self, line: String) {
+        // Errors only mean "no receivers", which is fine.
+        let _ = self.tx.send(line);
+    }
+}
+
+impl Default for ExternalControlState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn hello_line(app_handle: &AppHandle) -> String {
+    let version = app_handle.package_info().version.to_string();
+    json!({
+        "type": "hello",
+        "app": "RapidRAW",
+        "version": version,
+        "protocol": PROTOCOL_VERSION,
+    })
+    .to_string()
+}
+
+/// Binds the loopback listener and starts accepting clients. Never panics; a port
+/// clash is logged and the app keeps running without external control.
+pub fn start(app_handle: AppHandle, port: u16) {
+    tauri::async_runtime::spawn(async move {
+        let addr = format!("127.0.0.1:{}", port);
+        let listener = match TcpListener::bind(&addr).await {
+            Ok(l) => l,
+            Err(e) => {
+                log::warn!("External control: could not bind {}: {}", addr, e);
+                return;
+            }
+        };
+        {
+            let state = app_handle.state::<ExternalControlState>();
+            *state.port.lock().unwrap() = Some(port);
+        }
+        log::info!("External control: listening on {}", addr);
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer)) => {
+                    // Belt and braces: the bind is loopback-only, but never serve a
+                    // non-loopback peer even if that changes.
+                    if !peer.ip().is_loopback() {
+                        log::warn!("External control: rejected non-loopback peer {}", peer);
+                        continue;
+                    }
+                    let app = app_handle.clone();
+                    tauri::async_runtime::spawn(async move {
+                        handle_client(app, stream).await;
+                    });
+                }
+                Err(e) => {
+                    log::warn!("External control: accept failed: {}", e);
+                    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+                }
+            }
+        }
+    });
+}
+
+fn emit_client_count(app_handle: &AppHandle, count: usize) {
+    let _ = app_handle.emit(CLIENTS_EVENT, count);
+}
+
+async fn handle_client(app_handle: AppHandle, stream: TcpStream) {
+    let _ = stream.set_nodelay(true);
+    let (read_half, mut write_half) = stream.into_split();
+
+    let state = app_handle.state::<ExternalControlState>();
+    let mut rx = state.tx.subscribe();
+    let count = state.clients.fetch_add(1, Ordering::SeqCst) + 1;
+    log::info!("External control: client connected ({} total)", count);
+    emit_client_count(&app_handle, count);
+
+    // Greeting + replay of the latest snapshot.
+    let mut greeting = hello_line(&app_handle);
+    greeting.push('\n');
+    if let Some(snapshot) = state.last_state.lock().unwrap().clone() {
+        greeting.push_str(&snapshot);
+        greeting.push('\n');
+    }
+    if write_half.write_all(greeting.as_bytes()).await.is_err() {
+        finish_client(&app_handle);
+        return;
+    }
+
+    // Writer task: forwards broadcast lines to this socket.
+    let writer = tauri::async_runtime::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(mut line) => {
+                    line.push('\n');
+                    if write_half.write_all(line.as_bytes()).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    log::debug!("External control: client lagged, dropped {} messages", n);
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    // Reader loop: each line becomes a frontend event.
+    let mut reader = BufReader::new(read_half);
+    let mut line = String::new();
+    loop {
+        line.clear();
+        let read = reader.read_line(&mut line).await;
+        match read {
+            Ok(0) => break,
+            Ok(n) if n > MAX_LINE_BYTES => {
+                log::warn!("External control: oversized message, closing client");
+                break;
+            }
+            Ok(_) => {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                match serde_json::from_str::<Value>(trimmed) {
+                    Ok(msg) => {
+                        // `ping` is answered here so a client can probe liveness
+                        // even before the webview is up.
+                        if msg.get("type").and_then(Value::as_str) == Some("ping") {
+                            let mut pong = json!({ "type": "pong" });
+                            if let Some(r) = msg.get("ref") {
+                                pong["ref"] = r.clone();
+                            }
+                            state.broadcast(pong.to_string());
+                            continue;
+                        }
+                        let mut msg = msg;
+                        if let Some(obj) = msg.as_object_mut() {
+                            let seq = state.seq.fetch_add(1, Ordering::SeqCst) + 1;
+                            obj.insert("_seq".to_string(), json!(seq));
+                        }
+                        // Target the main webview window explicitly: a plain `emit`
+                        // goes to every event target and a global JS `listen` can
+                        // then see the same command twice.
+                        let target = EventTarget::webview_window(MAIN_WINDOW_LABEL);
+                        if let Err(e) = app_handle.emit_to(target, COMMAND_EVENT, msg) {
+                            log::warn!("External control: failed to emit command: {}", e);
+                        }
+                    }
+                    Err(e) => {
+                        state.broadcast(
+                            json!({
+                                "type": "error",
+                                "message": format!("invalid JSON: {}", e),
+                            })
+                            .to_string(),
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                log::debug!("External control: read error: {}", e);
+                break;
+            }
+        }
+    }
+
+    writer.abort();
+    finish_client(&app_handle);
+}
+
+fn finish_client(app_handle: &AppHandle) {
+    let state = app_handle.state::<ExternalControlState>();
+    let count = state.clients.fetch_sub(1, Ordering::SeqCst).saturating_sub(1);
+    log::info!("External control: client disconnected ({} total)", count);
+    emit_client_count(app_handle, count);
+}
+
+/// Called by the frontend to push a message to every connected controller.
+/// `state` messages are also cached for replay to late-joining clients.
+#[tauri::command]
+pub fn external_control_publish(
+    message: Value,
+    state: tauri::State<ExternalControlState>,
+) -> Result<(), String> {
+    let line = message.to_string();
+    if message.get("type").and_then(Value::as_str) == Some("state") {
+        *state.last_state.lock().unwrap() = Some(line.clone());
+    }
+    state.broadcast(line);
+    Ok(())
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExternalControlStatus {
+    pub listening: bool,
+    pub port: Option<u16>,
+    pub clients: usize,
+    pub protocol: u32,
+}
+
+#[tauri::command]
+pub fn external_control_status(state: tauri::State<ExternalControlState>) -> ExternalControlStatus {
+    let port = *state.port.lock().unwrap();
+    ExternalControlStatus {
+        listening: port.is_some(),
+        port,
+        clients: state.clients.load(Ordering::SeqCst),
+        protocol: PROTOCOL_VERSION,
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -18,6 +18,7 @@ mod culling;
 mod denoising;
 mod exif_processing;
 mod export_processing;
+mod external_control;
 mod file_management;
 mod focus_stacking;
 mod formats;
@@ -1888,6 +1889,19 @@ pub fn run() {
 
             start_preview_worker(app_handle.clone());
             start_analytics_worker(app_handle.clone());
+            {
+                let enabled = settings.enable_external_control.unwrap_or(true);
+                let port = std::env::var("RAPIDRAW_CONTROL_PORT")
+                    .ok()
+                    .and_then(|v| v.parse::<u16>().ok())
+                    .or(settings.external_control_port)
+                    .unwrap_or(external_control::DEFAULT_PORT);
+                if enabled {
+                    external_control::start(app_handle.clone(), port);
+                } else {
+                    log::info!("External control: disabled in settings");
+                }
+            }
             file_management::start_thumbnail_workers(app_handle.clone());
             file_management::start_metadata_workers(app_handle.clone());
             jxl_oxide::integration::register_image_decoding_hook();
@@ -2052,6 +2066,7 @@ pub fn run() {
             crate::register_exit_handler();
             Ok(())
         })
+        .manage(external_control::ExternalControlState::new())
         .manage(AppState {
             window_setup_complete: AtomicBool::new(false),
             gpu_crash_flag_path: Mutex::new(None),
@@ -2092,6 +2107,8 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             apply_adjustments,
+            external_control::external_control_publish,
+            external_control::external_control_status,
             generate_preview_for_path,
             generate_preset_preview,
             generate_uncropped_preview,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,6 +47,7 @@ import { useShallow } from 'zustand/react/shallow';
 import { useThumbnails } from './hooks/useThumbnails';
 import { ImageDimensions } from './hooks/useImageRenderSize';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
+import { useExternalControl } from './hooks/useExternalControl';
 import { useTauriListeners } from './hooks/useTauriListeners';
 import { useFileOperations } from './hooks/useFileOperations';
 import { useAppContextMenus } from './hooks/useAppContextMenus';
@@ -456,6 +457,8 @@ function App() {
   });
 
   useAndroidBackHandler();
+
+  useExternalControl();
 
   useKeyboardShortcuts({
     sortedImageList,

--- a/src/components/ui/AppProperties.tsx
+++ b/src/components/ui/AppProperties.tsx
@@ -222,6 +222,8 @@ export interface AppSettings {
   linearRawMode?: string;
   enableXmpSync?: boolean;
   createXmpIfMissing?: boolean;
+  enableExternalControl?: boolean;
+  externalControlPort?: number;
   isWaveformVisible?: boolean;
   waveformHeight?: number;
   activeWaveformChannel?: string;

--- a/src/hooks/useExternalControl.ts
+++ b/src/hooks/useExternalControl.ts
@@ -1,0 +1,253 @@
+/**
+ * Bridges the external control server (src-tauri/src/external_control.rs) to the editor.
+ *
+ * Inbound: `external-control-command` events carry one JSON message each from a connected
+ * controller. They are interpreted here, on top of the same `setAdjustments` path the UI
+ * sliders use, so undo history, auto-save, multi-select sync and live previews all behave
+ * exactly as if the user had dragged a slider.
+ *
+ * Outbound: a throttled `state` snapshot is published whenever the adjustments, selected
+ * image, view or history change, so a controller can show current values on its dials.
+ *
+ * Message vocabulary: docs/EXTERNAL_CONTROL_API.md
+ */
+
+import { useEffect, useRef } from 'react';
+import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
+import throttle from 'lodash.throttle';
+import { useEditorStore } from '../store/useEditorStore';
+import { useUIStore } from '../store/useUIStore';
+import { useLibraryStore } from '../store/useLibraryStore';
+import { useEditorActions } from './useEditorActions';
+import {
+  CONTROL_PARAMS,
+  EXTERNAL_CONTROL_COMMAND_EVENT,
+  EXTERNAL_CONTROL_PROTOCOL,
+  getControlParam,
+  listControlActions,
+  normalizeParamValue,
+  readParamValue,
+  runControlAction,
+  snapshotParams,
+  writePath,
+} from '../utils/externalControl';
+
+const PUBLISH_INTERVAL_MS = 33;
+/** A dial that stops sending ticks for this long is considered released. */
+const AUTO_TRACKING_RELEASE_MS = 180;
+
+type ControlMessage = { type?: unknown; ref?: unknown; _seq?: unknown; [key: string]: unknown };
+
+const publish = (message: Record<string, unknown>) => {
+  invoke('external_control_publish', { message }).catch((err) => {
+    console.warn('External control publish failed:', err);
+  });
+};
+
+const buildState = () => {
+  const editor = useEditorStore.getState();
+  const ui = useUIStore.getState();
+  const library = useLibraryStore.getState();
+  const path = editor.selectedImage?.path ?? null;
+  return {
+    type: 'state',
+    view: ui.activeView,
+    image: path
+      ? {
+          path,
+          name: path.split(/[\\/]/).pop() ?? path,
+          isReady: !!editor.selectedImage?.isReady,
+          rating: library.imageRatings[path] ?? 0,
+        }
+      : null,
+    canUndo: editor.historyIndex > 0,
+    canRedo: editor.historyIndex < editor.history.length - 1,
+    showOriginal: editor.showOriginal,
+    params: snapshotParams(editor.adjustments),
+  };
+};
+
+export function useExternalControl() {
+  const { setAdjustments } = useEditorActions();
+  const setAdjustmentsRef = useRef(setAdjustments);
+  setAdjustmentsRef.current = setAdjustments;
+
+  useEffect(() => {
+    let active = true;
+    let unlisten: (() => void) | null = null;
+    // Last command sequence number handled; the server stamps `_seq` so a
+    // duplicate event delivery is dropped rather than applied twice.
+    let lastSeq = 0;
+    let autoReleaseTimer: ReturnType<typeof setTimeout> | null = null;
+    // Set while a client holds explicit tracking; auto-release is suspended then.
+    let explicitTracking = false;
+
+    const setDragging = (dragging: boolean) => {
+      if (useEditorStore.getState().isSliderDragging !== dragging) {
+        useEditorStore.getState().setEditor({ isSliderDragging: dragging });
+      }
+    };
+
+    const touchAutoTracking = () => {
+      if (explicitTracking) return;
+      setDragging(true);
+      if (autoReleaseTimer) clearTimeout(autoReleaseTimer);
+      autoReleaseTimer = setTimeout(() => {
+        autoReleaseTimer = null;
+        if (!explicitTracking) setDragging(false);
+      }, AUTO_TRACKING_RELEASE_MS);
+    };
+
+    const reply = (request: ControlMessage, body: Record<string, unknown>) => {
+      publish(request.ref !== undefined ? { ...body, ref: request.ref } : body);
+    };
+
+    const fail = (request: ControlMessage, message: string) => reply(request, { type: 'error', message });
+
+    const canEdit = () => {
+      const editor = useEditorStore.getState();
+      return !!editor.selectedImage?.isReady && useUIStore.getState().activeView === 'editor';
+    };
+
+    const applyParam = (request: ControlMessage, compute: (current: number) => number) => {
+      const param = getControlParam(request.param);
+      if (!param) return fail(request, `unknown param: ${String(request.param)}`);
+      if (!canEdit()) return reply(request, { type: 'ignored', reason: 'no image open in editor' });
+      touchAutoTracking();
+      setAdjustmentsRef.current((prev) => {
+        const next = normalizeParamValue(param, compute(readParamValue(prev, param)));
+        return writePath(prev, param.path, next);
+      });
+    };
+
+    const handle = (msg: ControlMessage) => {
+      switch (msg.type) {
+        case 'set': {
+          const value = Number(msg.value);
+          if (!Number.isFinite(value)) return fail(msg, 'set requires a numeric value');
+          return applyParam(msg, () => value);
+        }
+        case 'adjust': {
+          const delta = Number(msg.delta);
+          if (!Number.isFinite(delta)) return fail(msg, 'adjust requires a numeric delta');
+          return applyParam(msg, (current) => current + delta);
+        }
+        case 'step': {
+          // Dial tick: signed number of native steps (1 == one slider step).
+          const ticks = Number(msg.ticks ?? 1);
+          if (!Number.isFinite(ticks)) return fail(msg, 'step requires numeric ticks');
+          const param = getControlParam(msg.param);
+          if (!param) return fail(msg, `unknown param: ${String(msg.param)}`);
+          const multiplier = Number(msg.multiplier ?? 1);
+          return applyParam(
+            msg,
+            (current) => current + ticks * param.step * (Number.isFinite(multiplier) ? multiplier : 1),
+          );
+        }
+        case 'reset': {
+          const param = getControlParam(msg.param);
+          if (!param) return fail(msg, `unknown param: ${String(msg.param)}`);
+          return applyParam(msg, () => param.default);
+        }
+        case 'tracking': {
+          explicitTracking = msg.active === true;
+          if (autoReleaseTimer) {
+            clearTimeout(autoReleaseTimer);
+            autoReleaseTimer = null;
+          }
+          setDragging(explicitTracking);
+          return;
+        }
+        case 'action': {
+          const result = runControlAction(msg.id);
+          if (result === 'unknown') return fail(msg, `unknown action: ${String(msg.id)}`);
+          if (result === 'unavailable') return fail(msg, 'actions are not available yet');
+          return reply(msg, { type: 'action-result', action: msg.id, result });
+        }
+        case 'get_state':
+          return reply(msg, buildState());
+        case 'get_params':
+          return reply(msg, {
+            type: 'params',
+            protocol: EXTERNAL_CONTROL_PROTOCOL,
+            params: CONTROL_PARAMS.map(({ id, group, min, max, step, default: def }) => ({
+              id,
+              group,
+              min,
+              max,
+              step,
+              default: def,
+            })),
+          });
+        case 'get_actions':
+          return reply(msg, { type: 'actions', actions: listControlActions() });
+        default:
+          return fail(msg, `unknown message type: ${String(msg.type)}`);
+      }
+    };
+
+    listen<ControlMessage>(EXTERNAL_CONTROL_COMMAND_EVENT, (event) => {
+      if (!active) return;
+      const msg = event.payload;
+      if (!msg || typeof msg !== 'object') return;
+      if (typeof msg._seq === 'number') {
+        if (msg._seq <= lastSeq) return;
+        lastSeq = msg._seq;
+      }
+      try {
+        handle(msg);
+      } catch (err) {
+        console.error('External control command failed:', err);
+        fail(msg, `command failed: ${err}`);
+      }
+    }).then((fn) => {
+      if (active) unlisten = fn;
+      else fn();
+    });
+
+    // State publishing.
+    const publishState = throttle(() => publish(buildState()), PUBLISH_INTERVAL_MS, { leading: true, trailing: true });
+
+    let lastEditorSig: unknown[] = [];
+    const unsubEditor = useEditorStore.subscribe((s) => {
+      const sig = [
+        s.adjustments,
+        s.selectedImage?.path,
+        s.selectedImage?.isReady,
+        s.historyIndex,
+        s.history.length,
+        s.showOriginal,
+      ];
+      if (sig.some((v, i) => v !== lastEditorSig[i])) {
+        lastEditorSig = sig;
+        publishState();
+      }
+    });
+    let lastView = useUIStore.getState().activeView;
+    const unsubUI = useUIStore.subscribe((s) => {
+      if (s.activeView !== lastView) {
+        lastView = s.activeView;
+        publishState();
+      }
+    });
+    let lastRatings = useLibraryStore.getState().imageRatings;
+    const unsubLibrary = useLibraryStore.subscribe((s) => {
+      if (s.imageRatings !== lastRatings) {
+        lastRatings = s.imageRatings;
+        publishState();
+      }
+    });
+    publishState();
+
+    return () => {
+      active = false;
+      if (unlisten) unlisten();
+      if (autoReleaseTimer) clearTimeout(autoReleaseTimer);
+      publishState.cancel();
+      unsubEditor();
+      unsubUI();
+      unsubLibrary();
+    };
+  }, []);
+}

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ import { useUIStore } from '../store/useUIStore';
 import { useProcessStore } from '../store/useProcessStore';
 import { useEditorActions } from './useEditorActions';
 import { useLibraryActions } from './useLibraryActions';
+import { registerControlActions } from '../utils/externalControl';
 
 interface KeyboardShortcutsProps {
   sortedImageList: Array<ImageFile>;
@@ -557,6 +558,9 @@ export const useKeyboardShortcuts = ({
       },
     };
 
+    // Expose the named actions to hardware controllers (see useExternalControl).
+    const unregisterControlActions = registerControlActions(actions, getStoreState);
+
     const builtinShortcuts = [
       {
         match: (e: KeyboardEvent) => e.code === 'Escape',
@@ -676,6 +680,7 @@ export const useKeyboardShortcuts = ({
     window.addEventListener('keydown', handleKeyDown);
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
+      unregisterControlActions();
     };
   }, [
     handleBackToLibrary,

--- a/src/utils/externalControl.ts
+++ b/src/utils/externalControl.ts
@@ -1,0 +1,222 @@
+/**
+ * External control: parameter table and action registry.
+ *
+ * A hardware controller talks to the Rust-side TCP server (src-tauri/src/external_control.rs),
+ * which forwards each message to the webview as the `external-control-command` event.
+ * `useExternalControl` interprets those messages; this module holds the data it needs:
+ *
+ *  - CONTROL_PARAMS: every adjustment a controller may address, with its range and default.
+ *    Ranges mirror the sliders in src/components/adjustments so a dial can never push a value
+ *    the UI could not.
+ *  - the action registry: the named actions (undo, preview_next, rate_3, ...) that
+ *    useKeyboardShortcuts builds are registered here so a controller button can fire them
+ *    without a synthetic keyboard event.
+ *
+ * Message vocabulary: docs/EXTERNAL_CONTROL_API.md
+ */
+
+import { Adjustments, INITIAL_ADJUSTMENTS } from './adjustments';
+
+export const EXTERNAL_CONTROL_COMMAND_EVENT = 'external-control-command';
+export const EXTERNAL_CONTROL_CLIENTS_EVENT = 'external-control-clients';
+export const EXTERNAL_CONTROL_PROTOCOL = 1;
+
+export interface ControlParam {
+  /** Stable identifier used on the wire, e.g. `exposure`, `hsl.reds.hue`. */
+  id: string;
+  /** Path into the Adjustments object. */
+  path: string[];
+  /** Panel the slider lives in; informational, for controller UIs. */
+  group: string;
+  min: number;
+  max: number;
+  step: number;
+  default: number;
+}
+
+const p = (
+  id: string,
+  group: string,
+  min: number,
+  max: number,
+  step: number,
+  path: string[] = id.split('.'),
+  def?: number,
+): ControlParam => ({
+  id,
+  path,
+  group,
+  min,
+  max,
+  step,
+  default: def ?? numberOr(readPath(INITIAL_ADJUSTMENTS, path), 0),
+});
+
+const numberOr = (value: unknown, fallback: number): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+
+const HSL_COLORS = ['reds', 'oranges', 'yellows', 'greens', 'aquas', 'blues', 'purples', 'magentas'];
+const GRADING_RANGES = ['shadows', 'midtones', 'highlights', 'global'];
+
+const FLAT_PARAMS: ControlParam[] = [
+  // Basic (Basic.tsx)
+  p('exposure', 'basic', -5, 5, 0.01),
+  p('brightness', 'basic', -5, 5, 0.01),
+  p('contrast', 'basic', -100, 100, 1),
+  p('highlights', 'basic', -100, 100, 1),
+  p('shadows', 'basic', -100, 100, 1),
+  p('whites', 'basic', -100, 100, 1),
+  p('blacks', 'basic', -100, 100, 1),
+  // Color (Color.tsx)
+  p('temperature', 'color', -100, 100, 1),
+  p('tint', 'color', -100, 100, 1),
+  p('vibrance', 'color', -100, 100, 1),
+  p('saturation', 'color', -100, 100, 1),
+  p('hue', 'color', -180, 180, 1),
+  p('colorGrading.blending', 'colorGrading', 0, 100, 1),
+  p('colorGrading.balance', 'colorGrading', -100, 100, 1),
+  p('colorCalibration.shadowsTint', 'calibration', -100, 100, 1),
+  p('colorCalibration.redHue', 'calibration', -100, 100, 1),
+  p('colorCalibration.redSaturation', 'calibration', -100, 100, 1),
+  p('colorCalibration.greenHue', 'calibration', -100, 100, 1),
+  p('colorCalibration.greenSaturation', 'calibration', -100, 100, 1),
+  p('colorCalibration.blueHue', 'calibration', -100, 100, 1),
+  p('colorCalibration.blueSaturation', 'calibration', -100, 100, 1),
+  // Details (Details.tsx)
+  p('sharpness', 'details', -100, 100, 1),
+  p('sharpnessThreshold', 'details', 0, 80, 1),
+  p('clarity', 'details', -100, 100, 1),
+  p('dehaze', 'details', -100, 100, 1),
+  p('structure', 'details', -100, 100, 1),
+  p('centré', 'details', -100, 100, 1),
+  p('lumaNoiseReduction', 'details', 0, 100, 1),
+  p('colorNoiseReduction', 'details', 0, 100, 1),
+  p('chromaticAberrationRedCyan', 'details', -100, 100, 1),
+  p('chromaticAberrationBlueYellow', 'details', -100, 100, 1),
+  // Effects (Effects.tsx)
+  p('glowAmount', 'effects', 0, 100, 1),
+  p('halationAmount', 'effects', 0, 100, 1),
+  p('flareAmount', 'effects', 0, 100, 1),
+  p('lensBlurAmount', 'effects', 0, 100, 1),
+  p('lensBlurDiffusion', 'effects', 0, 100, 1),
+  p('vignetteAmount', 'effects', -100, 100, 1),
+  p('vignetteMidpoint', 'effects', 0, 100, 1),
+  p('vignetteRoundness', 'effects', -100, 100, 1),
+  p('vignetteFeather', 'effects', 0, 100, 1),
+  p('grainAmount', 'effects', 0, 100, 1),
+  p('grainSize', 'effects', 0, 100, 1),
+  p('grainRoughness', 'effects', 0, 100, 1),
+  p('lutIntensity', 'effects', 0, 100, 1),
+  // Transform / crop
+  p('rotation', 'transform', -45, 45, 0.1),
+  p('transformRotate', 'transform', -45, 45, 0.1),
+  p('transformVertical', 'transform', -100, 100, 1),
+  p('transformHorizontal', 'transform', -100, 100, 1),
+  p('transformDistortion', 'transform', -100, 100, 1),
+  p('transformAspect', 'transform', -100, 100, 1),
+  p('transformScale', 'transform', 50, 150, 1),
+  p('transformXOffset', 'transform', -100, 100, 1),
+  p('transformYOffset', 'transform', -100, 100, 1),
+];
+
+const HSL_PARAMS: ControlParam[] = HSL_COLORS.flatMap((color) => [
+  p(`hsl.${color}.hue`, 'hsl', -100, 100, 1),
+  p(`hsl.${color}.saturation`, 'hsl', -100, 100, 1),
+  p(`hsl.${color}.luminance`, 'hsl', -100, 100, 1),
+]);
+
+const GRADING_PARAMS: ControlParam[] = GRADING_RANGES.flatMap((range) => [
+  p(`colorGrading.${range}.hue`, 'colorGrading', 0, 360, 1),
+  p(`colorGrading.${range}.saturation`, 'colorGrading', 0, 100, 1),
+  p(`colorGrading.${range}.luminance`, 'colorGrading', -100, 100, 1),
+]);
+
+export const CONTROL_PARAMS: ControlParam[] = [...FLAT_PARAMS, ...HSL_PARAMS, ...GRADING_PARAMS];
+
+const PARAM_INDEX = new Map(CONTROL_PARAMS.map((param) => [param.id, param]));
+
+export function getControlParam(id: unknown): ControlParam | undefined {
+  return typeof id === 'string' ? PARAM_INDEX.get(id) : undefined;
+}
+
+export function readPath(obj: unknown, path: string[]): unknown {
+  let cur: unknown = obj;
+  for (const key of path) {
+    if (cur === null || typeof cur !== 'object') return undefined;
+    cur = (cur as Record<string, unknown>)[key];
+  }
+  return cur;
+}
+
+/** Immutable set along `path`, shallow-copying every object on the way. */
+export function writePath<T extends object>(obj: T, path: string[], value: unknown): T {
+  if (path.length === 0) return obj;
+  const [head, ...rest] = path;
+  const current = (obj as Record<string, unknown>)[head];
+  const next =
+    rest.length === 0 ? value : writePath(current && typeof current === 'object' ? current : {}, rest, value);
+  return { ...obj, [head]: next };
+}
+
+/** Snap to the parameter's step grid and clamp to its range. */
+export function normalizeParamValue(param: ControlParam, raw: number): number {
+  if (!Number.isFinite(raw)) return param.default;
+  const decimals = Math.max(0, Math.ceil(-Math.log10(param.step)));
+  const snapped = Math.round(raw / param.step) * param.step;
+  const clamped = Math.min(param.max, Math.max(param.min, snapped));
+  return Number(clamped.toFixed(decimals));
+}
+
+export function readParamValue(adjustments: Adjustments, param: ControlParam): number {
+  const value = readPath(adjustments, param.path);
+  return typeof value === 'number' && Number.isFinite(value) ? value : param.default;
+}
+
+/** Flat `{ id: value }` map of every parameter, for the `state` message. */
+export function snapshotParams(adjustments: Adjustments): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const param of CONTROL_PARAMS) {
+    out[param.id] = readParamValue(adjustments, param);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Action registry
+// ---------------------------------------------------------------------------
+
+export interface RegisteredAction {
+  shouldFire?: (storeState: unknown) => boolean;
+  execute: (event: { preventDefault(): void; stopPropagation(): void }, storeState: unknown) => void;
+}
+
+interface ActionRegistry {
+  actions: Record<string, RegisteredAction>;
+  getStoreState: () => unknown;
+}
+
+let registry: ActionRegistry | null = null;
+
+export function registerControlActions(actions: Record<string, RegisteredAction>, getStoreState: () => unknown) {
+  registry = { actions, getStoreState };
+  return () => {
+    if (registry && registry.actions === actions) registry = null;
+  };
+}
+
+export function listControlActions(): string[] {
+  return registry ? Object.keys(registry.actions) : [];
+}
+
+export type ActionResult = 'ok' | 'ignored' | 'unknown' | 'unavailable';
+
+export function runControlAction(id: unknown): ActionResult {
+  if (!registry) return 'unavailable';
+  if (typeof id !== 'string') return 'unknown';
+  const handler = registry.actions[id];
+  if (!handler) return 'unknown';
+  const storeState = registry.getStoreState();
+  if (handler.shouldFire && !handler.shouldFire(storeState)) return 'ignored';
+  handler.execute({ preventDefault() {}, stopPropagation() {} }, storeState);
+  return 'ok';
+}


### PR DESCRIPTION
## Summary

Adds an optional **external control API** so hardware controllers (MX Creative Console,
Loupedeck, MIDI bridges, …) can drive the develop sliders and editor actions live.

* A tiny TCP server on `127.0.0.1:47820`, loopback only, newline-delimited JSON, no new
  dependencies (tokio is already in the tree).
* Clients can `set` / `adjust` / `step` / `reset` any develop slider, fire the named
  editor actions that already exist for keyboard shortcuts (undo/redo, next/previous
  image, rating, colour labels, zoom, panel toggles, …), and subscribe to a throttled
  `state` feed (current values, image, undo/redo availability) for dial displays.
* Controller edits go through the same path as a slider drag: low-res preview while the
  dial turns (`isSliderDragging`), full render and auto-save when it stops, coalesced undo
  steps, multi-select auto-sync honoured.
* Settings `enableExternalControl` (default `true`) and `externalControlPort` (default
  `47820`), plus a `RAPIDRAW_CONTROL_PORT` environment override. A port clash is logged
  and otherwise ignored, so startup is unaffected. No settings UI yet — happy to add one
  if you'd like it exposed.

Protocol reference: `docs/EXTERNAL_CONTROL_API.md`.

## Why

I wanted to edit with the dials on a Logitech MX Creative Console, the way the stock
Lightroom plugin works. RapidRAW had no way in, so this adds one that any controller
software can use. The plugin that uses it is here:
https://github.com/jiyang1018/rapidraw-logi-plugin — a short video/GIF of the dial
driving Exposure is in its README.

## Files

* `src-tauri/src/external_control.rs` — server, client bookkeeping, state cache
* `src-tauri/src/lib.rs`, `src-tauri/src/app_settings.rs` — wiring + two settings
* `src/hooks/useExternalControl.ts`, `src/utils/externalControl.ts` — command handling,
  parameter table (ids are the `Adjustments` field names), state publisher
* `src/hooks/useKeyboardShortcuts.ts`, `src/App.tsx`,
  `src/components/ui/AppProperties.tsx` — small hooks into existing code

Rendering, export, file management and defaults are untouched.

## Testing

Windows 11, v1.6.3 base: several days of daily use from the MX Creative Console
(≈110 sliders, undo/redo, ratings, labels, navigation), plus a scripted smoke test that
connects, nudges Exposure and rates the image. `cargo check`, `eslint` and `prettier` clean
on the touched files. Not yet run on macOS/Linux, though nothing in it is
platform-specific.
